### PR TITLE
Fix API route collision causing /debuglog 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ This project collects road roughness data from mobile devices and stores it in a
    uvicorn main:app --reload
    ```
 
-The built-in frontend is served from the `static/` directory when the
-server is running. Visit `/welcome.html` for a simple welcome page.
+The built-in frontend is served from the `static/` directory under the
+`/static` path when the server is running. The main interface is
+available at `/`, and you can still visit `/welcome.html` for a simple
+welcome page.
 
 ## Database Schema
 

--- a/main.py
+++ b/main.py
@@ -2,12 +2,25 @@ import os
 from typing import List
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 import numpy as np
 import pyodbc
 
 app = FastAPI(title="Road Condition Indexer")
-app.mount("/", StaticFiles(directory="static", html=True), name="static")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/")
+def read_index():
+    """Serve the main application page."""
+    return FileResponse("static/index.html")
+
+
+@app.get("/welcome.html")
+def read_welcome():
+    """Serve the welcome page."""
+    return FileResponse("static/welcome.html")
 
 # In-memory debug log
 DEBUG_LOG: List[str] = []


### PR DESCRIPTION
## Summary
- mount static files under `/static` instead of root to avoid route collisions
- serve `index.html` and `welcome.html` via dedicated routes
- document the new static path and main page location in README

## Testing
- `python -m py_compile main.py`
- `python -m venv venv && source venv/bin/activate && pip install -r requirements.txt`
- `uvicorn main:app --port 5000 &`
- `curl -s http://127.0.0.1:5000/ | head`
- `curl -s http://127.0.0.1:5000/debuglog`

------
https://chatgpt.com/codex/tasks/task_e_68502a4678d483209925283d714f2ab8