### PR TITLE
Enhance frontend with map and debug log

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3,17 +3,31 @@
 <head>
     <meta charset="UTF-8">
     <title>Road Condition Indexer</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <style>
         body { font-family: Arial, sans-serif; }
-        #log, #debug { width: 100%; height: 200px; overflow: auto; border: 1px solid #ccc; margin-bottom: 1rem; }
+        #log, #records { width: 100%; height: 150px; overflow: auto; border: 1px solid #ccc; margin-bottom: 1rem; white-space: pre; }
+        #debug { width: 100%; height: 150px; margin-top: 1rem; }
+        #map { width: 100%; height: 400px; margin-bottom: 1rem; }
     </style>
 </head>
 <body>
 <h1>Road Condition Indexer</h1>
 <div id="log"></div>
-<div id="debug"></div>
+<pre id="records"></pre>
+<div id="map"></div>
+<textarea id="debug" readonly></textarea>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let zValues = [];
+let map;
+
+function initMap() {
+    map = L.map('map').setView([0, 0], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+}
 
 function addLog(msg) {
     const div = document.getElementById('log');
@@ -21,10 +35,43 @@ function addLog(msg) {
     div.scrollTop = div.scrollHeight;
 }
 
+function colorForRoughness(r) {
+    const ratio = Math.min(Math.max(r / 10, 0), 1);
+    const red = Math.floor(255 * ratio);
+    const green = Math.floor(255 * (1 - ratio));
+    return `rgb(${red},${green},0)`;
+}
+
+function loadLogs() {
+    fetch('/logs').then(r => r.json()).then(data => {
+        const recordEl = document.getElementById('records');
+        recordEl.textContent = '';
+        if (map) {
+            map.eachLayer(layer => {
+                if (layer instanceof L.CircleMarker) {
+                    map.removeLayer(layer);
+                }
+            });
+        }
+        data.reverse().forEach(row => {
+            const { latitude, longitude, roughness } = row;
+            recordEl.textContent += `${latitude}, ${longitude} - roughness ${roughness.toFixed(2)}\n`;
+            if (map) {
+                L.circleMarker([latitude, longitude], {
+                    radius: 6,
+                    color: colorForRoughness(roughness),
+                    fillColor: colorForRoughness(roughness),
+                    fillOpacity: 0.8
+                }).addTo(map);
+            }
+        });
+    }).catch(err => console.error(err)).finally(() => setTimeout(loadLogs, 10000));
+}
+
 function addDebug(msg) {
-    const div = document.getElementById('debug');
-    div.textContent += msg + '\n';
-    div.scrollTop = div.scrollHeight;
+    const el = document.getElementById('debug');
+    el.value += msg + '\n';
+    el.scrollTop = el.scrollHeight;
 }
 
 if (window.DeviceMotionEvent) {
@@ -62,10 +109,12 @@ if (navigator.geolocation) {
 
 function pollDebug() {
     fetch('/debuglog').then(r => r.json()).then(data => {
-        document.getElementById('debug').textContent = data.log.join('\n');
+        document.getElementById('debug').value = data.log.join('\n');
     }).catch(console.error).finally(() => setTimeout(pollDebug, 2000));
 }
 
+initMap();
+loadLogs();
 pollDebug();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- show debug logs in a textarea
- draw a map via Leaflet and plot saved locations
- color markers from green to red based on roughness
- display server records on new lines

## Testing
- `python -m py_compile main.py`
- `pip install -q -r requirements.txt`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_68502bcecbec832087184b354d469673