### PR TITLE
Add timestamp display and verify DB inserts

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,6 +113,9 @@ def post_log(entry: LogEntry):
             entry.direction,
             roughness,
         )
+        if cursor.rowcount != 1:
+            log_debug(f"Insert affected {cursor.rowcount} rows")
+            raise HTTPException(status_code=500, detail="Insert failed")
         conn.commit()
         log_debug("Data inserted into database")
     except Exception as exc:

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,8 @@ let zValues = [];
 let map;
 
 function initMap() {
-    map = L.map('map').setView([0, 0], 13);
+    // Start slightly zoomed out so a larger area is visible
+    map = L.map('map').setView([0, 0], 5);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
@@ -54,8 +55,9 @@ function loadLogs() {
             });
         }
         data.reverse().forEach(row => {
-            const { latitude, longitude, roughness } = row;
-            recordEl.textContent += `${latitude}, ${longitude} - roughness ${roughness.toFixed(2)}\n`;
+            const { latitude, longitude, roughness, timestamp } = row;
+            const timeStr = new Date(timestamp).toLocaleString();
+            recordEl.textContent += `${timeStr} - ${latitude}, ${longitude} - roughness ${roughness.toFixed(2)}\n`;
             if (map) {
                 L.circleMarker([latitude, longitude], {
                     radius: 6,


### PR DESCRIPTION
## Summary
- show timestamp alongside each displayed record
- zoom out the initial map view
- validate that database inserts succeed before committing

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68503fda9b388320bcdd5e478c486731