### PR TITLE
Add elevation and timestamp to debug log

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pyodbc
 numpy
 python-dotenv
+requests


### PR DESCRIPTION
## Summary
- log debug messages with timestamps
- fetch elevation from OpenTopodata and include in debug logs for `/log`
- add `requests` dependency for elevation calls

## Testing
- `python -m py_compile main.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68515e2640308320a5556ff6be5f2112