### PR TITLE
Improve log loading and speed filter

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -43,6 +43,7 @@ let map;
 const GEO_OPTIONS = { enableHighAccuracy: true, maximumAge: 0, timeout: 10000 };
 const POLL_INTERVAL_MS = 1000; // attempt ~1m updates when moving
 let geoPollId = null;
+let lastLoaded = 0;
 
 function initMap() {
     // Show roughly a 10km area around Houten, NL
@@ -77,8 +78,12 @@ function colorForRoughness(r) {
     return `rgb(${red},${green},0)`;
 }
 
-function loadLogs(limit = 100) {
-    fetch(`/logs?limit=${limit}`).then(r => r.json()).then(data => {
+function loadLogs(limit = undefined) {
+    let url = '/logs';
+    if (limit !== undefined) {
+        url += `?limit=${limit}`;
+    }
+    fetch(url).then(r => r.json()).then(data => {
         const recordEl = document.getElementById('records');
         recordEl.textContent = '';
         if (map) {
@@ -101,7 +106,10 @@ function loadLogs(limit = 100) {
                 }).addTo(map);
             }
         });
-        addLog(`Loaded ${data.length} entries`);
+        if (data.length > lastLoaded) {
+            addLog(`Loaded ${data.length - lastLoaded} new entries`);
+        }
+        lastLoaded = data.length;
     }).catch(err => console.error(err)).finally(() => setTimeout(loadLogs, 10000));
 }
 


### PR DESCRIPTION
## Summary
- only record data if bike speed exceeds 7 km/h
- allow `/logs` to return all rows when no limit is given
- show new log entries without reprinting the count when unchanged

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`
- `python setup_env.py` *(fails: No suitable ODBC Driver for SQL Server found)*

------
https://chatgpt.com/codex/tasks/task_e_685169e8da348320a354d6d8cc39dda7