### PR TITLE
Add device info logging and UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This project collects road roughness data from mobile devices and stores it in a
 ## Endpoints
 
 - `POST /log` – Submit a new measurement. Requires JSON payload with latitude,
-  longitude, **speed in km/h**, direction and a list of Z-axis acceleration values.
+  longitude, **speed in km/h**, direction, a device identifier, the browser
+  user agent and a list of Z-axis acceleration values.
 - `GET /logs` – Fetch recent measurements. Accepts an optional `limit` query
   parameter (default 100).
 - `GET /debuglog` – Retrieve backend debug messages.
@@ -44,6 +45,8 @@ CREATE TABLE bike_data (
   longitude FLOAT,
   speed FLOAT,
   direction FLOAT,
-  roughness FLOAT
+  roughness FLOAT,
+  device_id NVARCHAR(100),
+  user_agent NVARCHAR(256)
 );
 ```

--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,8 @@
         #records {
             width: 100%;
             height: 150px;
-            overflow: auto;
+            overflow-y: auto;
+            overflow-x: hidden;
             border: 1px solid #ccc;
             margin-bottom: 1rem;
         }
@@ -37,6 +38,9 @@
 <button id="toggle">Start</button>
 <h3>Activity Log</h3>
 <div id="log"></div>
+<div id="map"></div>
+<h3>Debug Messages</h3>
+<textarea id="debug" readonly></textarea>
 <h3>Records</h3>
 <table id="records">
     <thead>
@@ -51,11 +55,14 @@
     </thead>
     <tbody></tbody>
 </table>
-<div id="map"></div>
-<h3>Debug Messages</h3>
-<textarea id="debug" readonly></textarea>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
+let deviceId = localStorage.getItem('deviceId');
+if (!deviceId) {
+    deviceId = crypto.randomUUID();
+    localStorage.setItem('deviceId', deviceId);
+}
+const userAgent = navigator.userAgent;
 let xValues = [];
 let yValues = [];
 let zValues = [];
@@ -197,7 +204,9 @@ function handlePosition(pos) {
                 longitude,
                 speed: lastSpeed,
                 direction: lastDir,
-                z_values: zValues
+                z_values: zValues,
+                device_id: deviceId,
+                user_agent: userAgent
             })
         }).then(r => r.json()).then(data => {
             if (data.roughness !== undefined) {


### PR DESCRIPTION
## Summary
- store `device_id` and `user_agent` for every uploaded log entry
- show Records table at the bottom of the page and make it scrollable vertically
- post device info from the frontend
- document updated database schema and request payload fields

## Testing
- `python -m py_compile main.py setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_68518f5cc1848320be9baec429e322c5