### PR TITLE
Add device-filter page and reorganise UI

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Device Records</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; }
+        #controls { margin-bottom: 1rem; }
+        button { padding: 0.5rem 1rem; font-size: 1rem; }
+        #map { width: 100%; height: 60vh; margin-top: 1rem; }
+        #controls input { margin-right: 0.5rem; }
+    </style>
+</head>
+<body>
+<h1>Device Records</h1>
+<div id="controls">
+    <input id="deviceId" placeholder="Device UUID">
+    <input id="startDate" type="datetime-local">
+    <input id="endDate" type="datetime-local">
+    <button id="load">Load</button>
+</div>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+let map;
+
+function initMap() {
+    map = L.map('map').setView([52.028, 5.168], 12);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        { attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
+}
+
+function colorForRoughness(r) {
+    const ratio = Math.min(Math.max((r - 0) / (5 - 0), 0), 1);
+    const red = Math.floor(255 * ratio);
+    const green = Math.floor(255 * (1 - ratio));
+    return `rgb(${red},${green},0)`;
+}
+
+function addMarker(lat, lon, roughness) {
+    L.circleMarker([lat, lon], {
+        radius: 6,
+        color: colorForRoughness(roughness),
+        fillColor: colorForRoughness(roughness),
+        fillOpacity: 0.8
+    }).addTo(map).bindPopup('Roughness: ' + roughness.toFixed(2));
+}
+
+function loadData() {
+    const device = document.getElementById('deviceId').value;
+    const start = document.getElementById('startDate').value;
+    const end = document.getElementById('endDate').value;
+    const params = new URLSearchParams();
+    if (device) params.append('device_id', device);
+    if (start) params.append('start', start);
+    if (end) params.append('end', end);
+    fetch('/filteredlogs?' + params.toString())
+        .then(r => r.json())
+        .then(data => {
+            map.eachLayer(layer => {
+                if (layer instanceof L.CircleMarker) map.removeLayer(layer);
+            });
+            data.rows.reverse().forEach(row =>
+                addMarker(row.latitude, row.longitude, row.roughness));
+        })
+        .catch(console.error);
+}
+
+initMap();
+document.getElementById('load').addEventListener('click', loadData);
+</script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -22,18 +22,22 @@
         }
         #map { width: 100%; height: 40vh; margin-bottom: 1rem; }
         #status { margin-bottom: 1rem; font-weight: bold; }
+        #button-bar { margin-bottom: 1rem; }
+        button { padding: 0.5rem 1rem; font-size: 1rem; }
     </style>
 </head>
 <body>
 <h1>Road Condition Indexer</h1>
 <div id="status"></div>
-<button id="toggle">Start</button>
+<div id="button-bar">
+    <button id="toggle">Start</button>
+    <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
+    <button id="update-button" style="margin-left:1rem;">Update Records</button>
+    <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
+</div>
+<div id="map"></div>
 <h3>Activity Log</h3>
 <div id="log"></div>
-<div id="map"></div>
-<button id="gpx-button">Generate GPX</button>
-<button id="update-button" style="margin-left:1rem;">Update Records</button>
-<a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 <h3>Debug Messages</h3>
 <textarea id="debug" readonly></textarea>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- move action buttons above the map and make them larger
- add `/device.html` page to filter records by uuid and date
- support backend filtering via `/filteredlogs`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852c59275a0832095283c7acca559ef