### PR TITLE
Add fullscreen toggle for maps

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -10,6 +10,7 @@
         #controls { margin-bottom: 1rem; }
         button { padding: 0.5rem 1rem; font-size: 1rem; }
         #map { width: 100%; height: 60vh; margin-top: 1rem; }
+        #map:fullscreen { width: 100%; height: 100%; }
         #controls input { margin-right: 0.5rem; }
     </style>
 </head>
@@ -20,6 +21,7 @@
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
     <button id="load">Load</button>
+    <button id="fullscreen-button">Fullscreen</button>
 </div>
 <div id="map"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
@@ -70,6 +72,24 @@ function loadData() {
 
 initMap();
 document.getElementById('load').addEventListener('click', loadData);
+document.getElementById('fullscreen-button').addEventListener('click', () => {
+    const el = document.getElementById('map');
+    if (!document.fullscreenElement) {
+        if (el.requestFullscreen) {
+            el.requestFullscreen();
+        }
+    } else {
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
+        }
+    }
+});
+
+document.addEventListener('fullscreenchange', () => {
+    if (map) {
+        map.invalidateSize();
+    }
+});
 </script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -21,6 +21,7 @@
             margin-top: 1rem;
         }
         #map { width: 100%; height: 40vh; margin-bottom: 1rem; }
+        #map:fullscreen { width: 100%; height: 100%; }
         #status { margin-bottom: 1rem; font-weight: bold; }
         #button-bar { margin-bottom: 1rem; }
         button { padding: 0.5rem 1rem; font-size: 1rem; }
@@ -33,6 +34,7 @@
     <button id="toggle">Start</button>
     <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
     <button id="update-button" style="margin-left:1rem;">Update Records</button>
+    <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 </div>
 <div id="map"></div>
@@ -381,6 +383,24 @@ document.getElementById('toggle').addEventListener('click', () => {
 
 document.getElementById('gpx-button').addEventListener('click', generateGpx);
 document.getElementById('update-button').addEventListener('click', loadLogs);
+document.getElementById('fullscreen-button').addEventListener('click', () => {
+    const el = document.getElementById('map');
+    if (!document.fullscreenElement) {
+        if (el.requestFullscreen) {
+            el.requestFullscreen();
+        }
+    } else {
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
+        }
+    }
+});
+
+document.addEventListener('fullscreenchange', () => {
+    if (map) {
+        map.invalidateSize();
+    }
+});
 
 let wakeLock = null;
 async function requestWakeLock() {


### PR DESCRIPTION
## Summary
- allow map to enter fullscreen mode on both main and device pages

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685330e028948320bc64f06129c08fc7