### PR TITLE
Add device filter dropdown and daterange defaults

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -17,7 +17,7 @@
 <body>
 <h1>Device Records</h1>
 <div id="controls">
-    <input id="deviceId" placeholder="Device UUID">
+    <select id="deviceId"></select>
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
     <button id="load">Load</button>
@@ -27,6 +27,32 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let map;
+
+function populateDeviceIds() {
+    fetch('/device_ids').then(r => r.json()).then(data => {
+        const sel = document.getElementById('deviceId');
+        sel.innerHTML = '';
+        const optAll = document.createElement('option');
+        optAll.value = '';
+        optAll.textContent = 'All Devices';
+        sel.appendChild(optAll);
+        data.ids.forEach(id => {
+            const opt = document.createElement('option');
+            opt.value = id;
+            opt.textContent = id;
+            sel.appendChild(opt);
+        });
+    }).then(() => setDateRange()).catch(console.error);
+}
+
+function setDateRange() {
+    const device = document.getElementById('deviceId').value;
+    const url = device ? `/date_range?device_id=${encodeURIComponent(device)}` : '/date_range';
+    fetch(url).then(r => r.json()).then(data => {
+        if (data.start) document.getElementById('startDate').value = data.start.slice(0,19);
+        if (data.end) document.getElementById('endDate').value = data.end.slice(0,19);
+    }).catch(console.error);
+}
 
 function initMap() {
     map = L.map('map').setView([52.028, 5.168], 12);
@@ -71,7 +97,9 @@ function loadData() {
 }
 
 initMap();
+populateDeviceIds();
 document.getElementById('load').addEventListener('click', loadData);
+document.getElementById('deviceId').addEventListener('change', setDateRange);
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');
     if (!document.fullscreenElement) {

--- a/static/index.html
+++ b/static/index.html
@@ -35,6 +35,8 @@
     <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
     <button id="update-button" style="margin-left:1rem;">Update Records</button>
     <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
+    <select id="device-filter" style="margin-left:1rem;"></select>
+    <a href="device.html" style="margin-left:1rem;">Device View</a>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 </div>
 <div id="map"></div>
@@ -63,6 +65,27 @@ const fingerprint = [
     navigator.platform,
     new Date().getTimezoneOffset()
 ].join('|');
+
+function populateDeviceFilter() {
+    fetch('/device_ids').then(r => r.json()).then(data => {
+        const select = document.getElementById('device-filter');
+        select.innerHTML = '';
+        data.ids.forEach(id => {
+            const opt = document.createElement('option');
+            opt.value = id;
+            opt.textContent = id;
+            select.appendChild(opt);
+        });
+        if (deviceId && !data.ids.includes(deviceId)) {
+            const opt = document.createElement('option');
+            opt.value = deviceId;
+            opt.textContent = deviceId;
+            select.appendChild(opt);
+        }
+        select.value = deviceId;
+    }).then(() => loadLogs())
+      .catch(console.error);
+}
 let xValues = [];
 let yValues = [];
 let zValues = [];
@@ -222,7 +245,9 @@ function addMarker(lat, lon, roughness, info = null) {
 }
 
 function loadLogs() {
-    fetch('/logs').then(r => r.json()).then(data => {
+    const filterId = document.getElementById('device-filter').value;
+    const url = filterId ? `/filteredlogs?device_id=${encodeURIComponent(filterId)}` : '/logs';
+    fetch(url).then(r => r.json()).then(data => {
         const rows = Array.isArray(data) ? data : data.rows;
         roughAvg = data.average || 0;
         if (map) {
@@ -368,7 +393,7 @@ function generateGpx() {
 
 updateStatus();
 initMap();
-loadLogs();
+populateDeviceFilter();
 pollDebug();
 
 document.getElementById('toggle').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add `/device_ids` and `/date_range` endpoints in `main.py`
- show device view link and new dropdown on main page
- default device filter to session UUID and load records for that ID
- switch `device.html` to dropdown for device selection
- automatically set date range to oldest and newest records

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6853da6010608320b3fc0d706740fff5