### PR TITLE
Improve roughness calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This project collects road roughness data from mobile devices and stores it in a
 
 - `POST /log` – Submit a new measurement. Requires JSON payload with latitude,
   longitude, **speed in km/h**, direction, a device identifier, the browser
-  user agent and a list of Z-axis acceleration values.
+  user agent and a list of Z-axis acceleration values. The server computes the
+  average speed since the previous update and ignores submissions when that
+  speed is below **5 km/h**.
 - `GET /logs` – Fetch recent measurements. Accepts an optional `limit` query
   parameter (default 100).
 - `GET /debuglog` – Retrieve backend debug messages.


### PR DESCRIPTION
## Summary
- add `compute_roughness` helper using an FFT based 1‑20 Hz band‑pass
- normalise RMS by the interval speed and return 0 below 5 km/h
- apply new roughness metric in `/log` endpoint
- compute average speed since last log and ignore updates below 5 km/h
- document new behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853dd5b05088320b127b81fa37651c5