### PR TITLE
Add nickname support and version filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,20 @@ CREATE TABLE bike_data (
   direction FLOAT,
   roughness FLOAT,
   device_id NVARCHAR(100),
-  user_agent NVARCHAR(256)
+  user_agent NVARCHAR(256),
+  ip_address NVARCHAR(45),
+  device_fp NVARCHAR(256),
+  version NVARCHAR(10) DEFAULT '0.2'
 );
 
 CREATE TABLE debug_log (
   id INT IDENTITY PRIMARY KEY,
   timestamp DATETIME DEFAULT GETDATE(),
   message NVARCHAR(4000)
+);
+
+CREATE TABLE device_nicknames (
+  device_id NVARCHAR(100) PRIMARY KEY,
+  nickname NVARCHAR(100)
 );
 ```

--- a/static/device.html
+++ b/static/device.html
@@ -18,6 +18,11 @@
 <h1>Device Records</h1>
 <div id="controls">
     <select id="deviceId"></select>
+    <select id="version">
+        <option value="">All Versions</option>
+        <option value="0.1">V0.1</option>
+        <option value="0.2">V0.2</option>
+    </select>
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
     <button id="load">Load</button>
@@ -36,10 +41,10 @@ function populateDeviceIds() {
         optAll.value = '';
         optAll.textContent = 'All Devices';
         sel.appendChild(optAll);
-        data.ids.forEach(id => {
+        data.ids.forEach(item => {
             const opt = document.createElement('option');
-            opt.value = id;
-            opt.textContent = id;
+            opt.value = item.id;
+            opt.textContent = item.nickname ? `${item.nickname} (${item.id})` : item.id;
             sel.appendChild(opt);
         });
     }).then(() => setDateRange()).catch(console.error);
@@ -80,10 +85,12 @@ function loadData() {
     const device = document.getElementById('deviceId').value;
     const start = document.getElementById('startDate').value;
     const end = document.getElementById('endDate').value;
+    const version = document.getElementById('version').value;
     const params = new URLSearchParams();
     if (device) params.append('device_id', device);
     if (start) params.append('start', start);
     if (end) params.append('end', end);
+    if (version) params.append('version', version);
     fetch('/filteredlogs?' + params.toString())
         .then(r => r.json())
         .then(data => {
@@ -100,6 +107,7 @@ initMap();
 populateDeviceIds();
 document.getElementById('load').addEventListener('click', loadData);
 document.getElementById('deviceId').addEventListener('change', setDateRange);
+document.getElementById('version').addEventListener('change', loadData);
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');
     if (!document.fullscreenElement) {

--- a/static/index.html
+++ b/static/index.html
@@ -36,6 +36,13 @@
     <button id="update-button" style="margin-left:1rem;">Update Records</button>
     <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
     <select id="device-filter" style="margin-left:1rem;"></select>
+    <select id="version-filter" style="margin-left:1rem;">
+        <option value="">All Versions</option>
+        <option value="0.1">V0.1</option>
+        <option value="0.2">V0.2</option>
+    </select>
+    <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
+    <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
     <a href="device.html" style="margin-left:1rem;">Device View</a>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 </div>
@@ -66,17 +73,36 @@ const fingerprint = [
     new Date().getTimezoneOffset()
 ].join('|');
 
+function loadNickname() {
+    fetch(`/nickname?device_id=${encodeURIComponent(deviceId)}`)
+        .then(r => r.json())
+        .then(data => {
+            document.getElementById('nickname').value = data.nickname || '';
+        })
+        .catch(console.error);
+}
+
+function saveNickname() {
+    const name = document.getElementById('nickname').value;
+    fetch('/nickname', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_id: deviceId, nickname: name })
+    }).then(() => populateDeviceFilter())
+      .catch(console.error);
+}
+
 function populateDeviceFilter() {
     fetch('/device_ids').then(r => r.json()).then(data => {
         const select = document.getElementById('device-filter');
         select.innerHTML = '';
-        data.ids.forEach(id => {
+        data.ids.forEach(item => {
             const opt = document.createElement('option');
-            opt.value = id;
-            opt.textContent = id;
+            opt.value = item.id;
+            opt.textContent = item.nickname ? `${item.nickname} (${item.id})` : item.id;
             select.appendChild(opt);
         });
-        if (deviceId && !data.ids.includes(deviceId)) {
+        if (deviceId && !data.ids.some(i => i.id === deviceId)) {
             const opt = document.createElement('option');
             opt.value = deviceId;
             opt.textContent = deviceId;
@@ -246,7 +272,14 @@ function addMarker(lat, lon, roughness, info = null) {
 
 function loadLogs() {
     const filterId = document.getElementById('device-filter').value;
-    const url = filterId ? `/filteredlogs?device_id=${encodeURIComponent(filterId)}` : '/logs';
+    const version = document.getElementById('version-filter').value;
+    let url = '/logs';
+    if (filterId || version) {
+        const params = new URLSearchParams();
+        if (filterId) params.append('device_id', filterId);
+        if (version) params.append('version', version);
+        url = '/filteredlogs?' + params.toString();
+    }
     fetch(url).then(r => r.json()).then(data => {
         const rows = Array.isArray(data) ? data : data.rows;
         roughAvg = data.average || 0;
@@ -394,6 +427,7 @@ function generateGpx() {
 updateStatus();
 initMap();
 populateDeviceFilter();
+loadNickname();
 pollDebug();
 
 document.getElementById('toggle').addEventListener('click', () => {
@@ -408,6 +442,8 @@ document.getElementById('toggle').addEventListener('click', () => {
 
 document.getElementById('gpx-button').addEventListener('click', generateGpx);
 document.getElementById('update-button').addEventListener('click', loadLogs);
+document.getElementById('version-filter').addEventListener('change', loadLogs);
+document.getElementById('save-nickname').addEventListener('click', saveNickname);
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');
     if (!document.fullscreenElement) {


### PR DESCRIPTION
## Summary
- add `version` column and `device_nicknames` table
- expose nickname endpoints and return nicknames in `/device_ids`
- support version filtering in `/filteredlogs`
- add nickname input and version filter to the main UI
- update device view to use nicknames and allow version selection
- document the updated schema

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e84738d8832086d8e29e18582a14