### PR TITLE
Enable editing nicknames on both pages

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -25,6 +25,8 @@
     </select>
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
+    <input id="nickname" placeholder="Nickname">
+    <button id="save-nickname">Save</button>
     <button id="load">Load</button>
     <button id="fullscreen-button">Fullscreen</button>
 </div>
@@ -47,7 +49,7 @@ function populateDeviceIds() {
             opt.textContent = item.nickname ? `${item.nickname} (${item.id})` : item.id;
             sel.appendChild(opt);
         });
-    }).then(() => setDateRange()).catch(console.error);
+    }).then(() => { setDateRange(); loadNickname(); }).catch(console.error);
 }
 
 function setDateRange() {
@@ -57,6 +59,32 @@ function setDateRange() {
         if (data.start) document.getElementById('startDate').value = data.start.slice(0,19);
         if (data.end) document.getElementById('endDate').value = data.end.slice(0,19);
     }).catch(console.error);
+}
+
+function loadNickname() {
+    const device = document.getElementById('deviceId').value;
+    if (!device) {
+        document.getElementById('nickname').value = '';
+        return;
+    }
+    fetch(`/nickname?device_id=${encodeURIComponent(device)}`)
+        .then(r => r.json())
+        .then(data => {
+            document.getElementById('nickname').value = data.nickname || '';
+        })
+        .catch(console.error);
+}
+
+function saveNickname() {
+    const device = document.getElementById('deviceId').value;
+    const name = document.getElementById('nickname').value;
+    if (!device) return;
+    fetch('/nickname', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_id: device, nickname: name })
+    }).then(() => populateDeviceIds())
+      .catch(console.error);
 }
 
 function initMap() {
@@ -106,8 +134,12 @@ function loadData() {
 initMap();
 populateDeviceIds();
 document.getElementById('load').addEventListener('click', loadData);
-document.getElementById('deviceId').addEventListener('change', setDateRange);
+document.getElementById('deviceId').addEventListener('change', () => {
+    setDateRange();
+    loadNickname();
+});
 document.getElementById('version').addEventListener('change', loadData);
+document.getElementById('save-nickname').addEventListener('click', saveNickname);
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');
     if (!document.fullscreenElement) {

--- a/static/index.html
+++ b/static/index.html
@@ -54,6 +54,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let deviceId = localStorage.getItem('deviceId');
+let selectedId = deviceId;
 function setCookie(name, value, days) {
     const expires = new Date(Date.now() + days * 864e5).toUTCString();
     document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
@@ -74,7 +75,11 @@ const fingerprint = [
 ].join('|');
 
 function loadNickname() {
-    fetch(`/nickname?device_id=${encodeURIComponent(deviceId)}`)
+    if (!selectedId) {
+        document.getElementById('nickname').value = '';
+        return;
+    }
+    fetch(`/nickname?device_id=${encodeURIComponent(selectedId)}`)
         .then(r => r.json())
         .then(data => {
             document.getElementById('nickname').value = data.nickname || '';
@@ -84,10 +89,11 @@ function loadNickname() {
 
 function saveNickname() {
     const name = document.getElementById('nickname').value;
+    if (!selectedId) return;
     fetch('/nickname', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_id: deviceId, nickname: name })
+        body: JSON.stringify({ device_id: selectedId, nickname: name })
     }).then(() => populateDeviceFilter())
       .catch(console.error);
 }
@@ -108,8 +114,9 @@ function populateDeviceFilter() {
             opt.textContent = deviceId;
             select.appendChild(opt);
         }
-        select.value = deviceId;
-    }).then(() => loadLogs())
+        select.value = selectedId || deviceId;
+        selectedId = select.value;
+    }).then(() => { loadNickname(); loadLogs(); })
       .catch(console.error);
 }
 let xValues = [];
@@ -427,7 +434,6 @@ function generateGpx() {
 updateStatus();
 initMap();
 populateDeviceFilter();
-loadNickname();
 pollDebug();
 
 document.getElementById('toggle').addEventListener('click', () => {
@@ -444,6 +450,11 @@ document.getElementById('gpx-button').addEventListener('click', generateGpx);
 document.getElementById('update-button').addEventListener('click', loadLogs);
 document.getElementById('version-filter').addEventListener('change', loadLogs);
 document.getElementById('save-nickname').addEventListener('click', saveNickname);
+document.getElementById('device-filter').addEventListener('change', () => {
+    selectedId = document.getElementById('device-filter').value;
+    loadNickname();
+    loadLogs();
+});
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');
     if (!document.fullscreenElement) {


### PR DESCRIPTION
## Summary
- let the selected uuid dictate nickname editing on the main page
- show nickname field on the device view and allow saving
- reload nickname whenever the device selection changes

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68540eb97cdc8320a9d2437756876a3d