### PR TITLE
Remove version field and update frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ CREATE TABLE bike_data (
   device_id NVARCHAR(100),
   user_agent NVARCHAR(256),
   ip_address NVARCHAR(45),
-  device_fp NVARCHAR(256),
-  version NVARCHAR(10) DEFAULT '0.2'
+  device_fp NVARCHAR(256)
 );
 
 CREATE TABLE debug_log (

--- a/static/db.html
+++ b/static/db.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Database Management</title>
     <style>
-        body { font-family: Arial, sans-serif; margin:1rem; }
+        body { font-family: Arial, sans-serif; margin:0 auto; padding:1rem; max-width:800px; }
+        #controls { display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:1rem; }
+        #controls > button, #controls > select { margin-bottom:0.5rem; }
         table { border-collapse: collapse; margin-bottom:1rem; }
         th, td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; }
         caption { font-weight:bold; margin-bottom:0.25rem; }
@@ -13,7 +15,8 @@
 </head>
 <body>
 <h1>Database Management</h1>
-<div>
+<p><a href="index.html">Back to Main</a></p>
+<div id="controls">
     <button onclick="loadTables()">Refresh Tables</button>
     <button onclick="insertTest()">Insert Test Data</button>
     <select id="table-select"></select>

--- a/static/device.html
+++ b/static/device.html
@@ -6,8 +6,8 @@
     <title>Device Records</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <style>
-        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; }
-        #controls { margin-bottom: 1rem; }
+        body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 800px; }
+        #controls { margin-bottom: 1rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
         button { padding: 0.5rem 1rem; font-size: 1rem; }
         #map { width: 100%; height: 60vh; margin-top: 1rem; }
         #map:fullscreen { width: 100%; height: 100%; }
@@ -16,13 +16,9 @@
 </head>
 <body>
 <h1>Device Records</h1>
+<p><a href="index.html">Back to Main</a></p>
 <div id="controls">
     <select id="deviceId"></select>
-    <select id="version">
-        <option value="">All Versions</option>
-        <option value="0.1">V0.1</option>
-        <option value="0.2">V0.2</option>
-    </select>
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
     <input id="nickname" placeholder="Nickname">
@@ -122,12 +118,10 @@ function loadData() {
     const device = document.getElementById('deviceId').value;
     const start = document.getElementById('startDate').value;
     const end = document.getElementById('endDate').value;
-    const version = document.getElementById('version').value;
     const params = new URLSearchParams();
     if (device) params.append('device_id', device);
     if (start) params.append('start', start);
     if (end) params.append('end', end);
-    if (version) params.append('version', version);
     fetch('/filteredlogs?' + params.toString())
         .then(r => r.json())
         .then(data => {
@@ -156,7 +150,6 @@ document.getElementById('deviceId').addEventListener('change', () => {
     setDateRange();
     loadNickname();
 });
-document.getElementById('version').addEventListener('change', loadData);
 document.getElementById('save-nickname').addEventListener('click', saveNickname);
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
     <title>Road Condition Indexer</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <style>
-        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; }
+        body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 800px; }
         #log {
             width: 100%;
             height: 150px;
@@ -23,7 +23,7 @@
         #map { width: 100%; height: 40vh; margin-bottom: 1rem; }
         #map:fullscreen { width: 100%; height: 100%; }
         #status { margin-bottom: 1rem; font-weight: bold; }
-        #button-bar { margin-bottom: 1rem; }
+        #button-bar { margin-bottom: 1rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
         button { padding: 0.5rem 1rem; font-size: 1rem; }
     </style>
 </head>
@@ -36,11 +36,6 @@
     <button id="update-button" style="margin-left:1rem;">Update Records</button>
     <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
     <select id="device-filter" style="margin-left:1rem;"></select>
-    <select id="version-filter" style="margin-left:1rem;">
-        <option value="">All Versions</option>
-        <option value="0.1">V0.1</option>
-        <option value="0.2">V0.2</option>
-    </select>
     <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
     <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
     <a href="device.html" style="margin-left:1rem;">Device View</a>
@@ -287,12 +282,10 @@ function addPoint(lat, lon, roughness, info = null, nickname = '') {
 
 function loadLogs() {
     const filterId = document.getElementById('device-filter').value;
-    const version = document.getElementById('version-filter').value;
     let url = '/logs';
-    if (filterId || version) {
+    if (filterId) {
         const params = new URLSearchParams();
-        if (filterId) params.append('device_id', filterId);
-        if (version) params.append('version', version);
+        params.append('device_id', filterId);
         url = '/filteredlogs?' + params.toString();
     }
     fetch(url).then(r => r.json()).then(data => {
@@ -451,7 +444,6 @@ document.getElementById('toggle').addEventListener('click', () => {
 
 document.getElementById('gpx-button').addEventListener('click', generateGpx);
 document.getElementById('update-button').addEventListener('click', loadLogs);
-document.getElementById('version-filter').addEventListener('change', loadLogs);
 document.getElementById('save-nickname').addEventListener('click', saveNickname);
 document.getElementById('device-filter').addEventListener('change', () => {
     selectedId = document.getElementById('device-filter').value;


### PR DESCRIPTION
## Summary
- drop `version` column from DB init
- remove version argument from `filteredlogs` and testdata insert
- update README schema
- clean UI of version filter
- add links back to main page and tweak layouts for mobile

## Testing
- `python -m py_compile main.py setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_68554ee242b08320add32fa1cad818c0