### PR TITLE
Center maps on current location

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -93,9 +93,21 @@ function saveNickname() {
 }
 
 function initMap() {
-    map = L.map('map').setView([52.028, 5.168], 12);
+    const defaultPos = [52.028, 5.168]; // Houten, NL
+    const zoom = 12;
+    map = L.map('map');
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         { attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
+    const setView = coords => map.setView(coords, zoom);
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+            pos => setView([pos.coords.latitude, pos.coords.longitude]),
+            () => setView(defaultPos),
+            { enableHighAccuracy: true, maximumAge: 0, timeout: 10000 }
+        );
+    } else {
+        setView(defaultPos);
+    }
 }
 
 function colorForRoughness(r) {

--- a/static/index.html
+++ b/static/index.html
@@ -179,11 +179,22 @@ if (navigator.geolocation) {
 }
 
 function initMap() {
-    // Show roughly a 10km area around Houten, NL
-    map = L.map('map').setView([52.028, 5.168], 12);
+    const defaultPos = [52.028, 5.168]; // Houten, NL
+    const zoom = 12;
+    map = L.map('map');
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
+    const setView = coords => map.setView(coords, zoom);
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+            pos => setView([pos.coords.latitude, pos.coords.longitude]),
+            () => setView(defaultPos),
+            GEO_OPTIONS
+        );
+    } else {
+        setView(defaultPos);
+    }
 }
 
 function addLog(msg) {


### PR DESCRIPTION
## Summary
- detect geolocation on page load and center maps accordingly

## Testing
- `python -m py_compile main.py setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_686fa44a664c8320a1cd8952e219f546