### PR TITLE
Improve Android responsive styling

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -4,14 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Database Management</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin:0 auto; padding:1rem; max-width:800px; }
-        #controls { display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:1rem; }
-        #controls > button, #controls > select { margin-bottom:0.5rem; }
-        table { border-collapse: collapse; margin-bottom:1rem; }
-        th, td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; }
-        caption { font-weight:bold; margin-bottom:0.25rem; }
-    </style>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+    <link rel="stylesheet" href="style.css">
+    <meta name="theme-color" content="#6200ee">
 </head>
 <body>
 <h1>Database Management</h1>
@@ -24,7 +19,7 @@
     <button onclick="backupTable()">Backup Table</button>
     <button onclick="renameTable()">Rename Table</button>
 </div>
-<div id="record-editor" style="display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem;">
+<div id="record-editor">
     <h3>Selected Record</h3>
     <form id="record-form">
         <div>ID <input id="rec-id" readonly></div>

--- a/static/device.html
+++ b/static/device.html
@@ -5,16 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Device Records</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-    <style>
-        body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 800px; }
-        #controls { margin-bottom: 1rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
-        button { padding: 0.5rem 1rem; font-size: 1rem; }
-        #map { width: 100%; height: 60vh; margin-top: 1rem; }
-        #map:fullscreen { width: 100%; height: 100%; }
-        #controls input { margin-right: 0.5rem; }
-    </style>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+    <link rel="stylesheet" href="style.css">
+    <meta name="theme-color" content="#6200ee">
 </head>
-<body>
+<body class="device-page">
 <h1>Device Records</h1>
 <p><a href="/">Back to Main</a></p>
 <div id="controls">

--- a/static/index.html
+++ b/static/index.html
@@ -5,54 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Road Condition Indexer</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-    <style>
-        body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 800px; }
-        #log {
-            width: 100%;
-            height: 150px;
-            overflow: auto;
-            border: 1px solid #ccc;
-            margin-bottom: 1rem;
-            white-space: pre;
-        }
-        #debug {
-            width: 100%;
-            height: 150px;
-            margin-top: 1rem;
-        }
-        #map { width: 100%; height: 40vh; margin-bottom: 1rem; }
-        #map:fullscreen { width: 100%; height: 100%; }
-        #status { margin-bottom: 1rem; font-weight: bold; }
-        #button-bar { margin-bottom: 1rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
-        button { padding: 0.5rem 1rem; font-size: 1rem; }
-        #scale-container {
-            display: flex;
-            align-items: center;
-            margin-bottom: 1rem;
-            gap: 0.5rem;
-        }
-        #scale-bar {
-            flex: 1;
-            height: 12px;
-            background: linear-gradient(to right, green, yellow, red);
-            border: 1px solid #ccc;
-        }
-    </style>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+    <link rel="stylesheet" href="style.css">
+    <meta name="theme-color" content="#6200ee">
 </head>
-<body>
+<body class="index-page">
 <h1>Road Condition Indexer</h1>
 <div id="status"></div>
 <div id="button-bar">
     <button id="toggle">Start</button>
-    <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
-    <button id="update-button" style="margin-left:1rem;">Update Records</button>
-    <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
-    <select id="device-filter" style="margin-left:1rem;"></select>
-    <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
-    <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
-    <a href="device.html" style="margin-left:1rem;">Device View</a>
-    <a href="db.html" style="margin-left:1rem;">DB Page</a>
-    <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
+    <button id="gpx-button">Generate GPX</button>
+    <button id="update-button">Update Records</button>
+    <button id="fullscreen-button">Fullscreen</button>
+    <select id="device-filter"></select>
+    <input id="nickname" placeholder="Nickname" />
+    <button id="save-nickname">Save</button>
+    <a href="device.html">Device View</a>
+    <a href="db.html">DB Page</a>
+    <a id="gpx-link">Download GPX</a>
 </div>
 <div id="map"></div>
 <div id="scale-container">
@@ -552,7 +522,7 @@ if ('wakeLock' in navigator) {
     });
 }
 </script>
-<div id="roughness-info" style="margin-top:1rem; border:1px solid #ccc; padding:0.5rem;">
+<div id="roughness-info">
     <strong>Roughness Calculation</strong> - vertical acceleration samples are filtered between 1&nbsp;and&nbsp;20&nbsp;Hz,
     the RMS of the filtered signal is normalised by average speed, and values recorded below
     5&nbsp;km/h are ignored.

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,99 @@
+body {
+    font-family: 'Roboto', Arial, sans-serif;
+    margin: 0 auto;
+    padding: 1rem;
+    max-width: 800px;
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+button {
+    padding: 0.6rem 1.2rem;
+    font-size: 1rem;
+    background-color: #6200ee;
+    color: white;
+    border: none;
+    border-radius: 4px;
+}
+
+button:active {
+    background-color: #3700b3;
+}
+
+#button-bar,
+#controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+#map {
+    width: 100%;
+    height: 40vh;
+    margin-bottom: 1rem;
+}
+
+#map:fullscreen {
+    width: 100%;
+    height: 100%;
+}
+
+
+#log,
+#debug,
+textarea {
+    width: 100%;
+    height: 150px;
+    overflow: auto;
+    border: 1px solid #ccc;
+    margin-bottom: 1rem;
+    white-space: pre;
+}
+
+textarea {
+    height: 150px;
+    margin-top: 1rem;
+}
+
+table {
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+}
+
+th,
+td {
+    border: 1px solid #ccc;
+    padding: 0.25rem 0.5rem;
+}
+
+caption {
+    font-weight: bold;
+    margin-bottom: 0.25rem;
+}
+
+#scale-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+}
+
+#scale-bar {
+    flex: 1;
+    height: 12px;
+    background: linear-gradient(to right, green, yellow, red);
+    border: 1px solid #ccc;
+}
+body.index-page #map {
+    height: 40vh;
+    margin-bottom: 1rem;
+}
+
+body.device-page #map {
+    height: 60vh;
+    margin-top: 1rem;
+}
+#gpx-link { display:none; margin-left:1rem; }
+#roughness-info { margin-top:1rem; border:1px solid #ccc; padding:0.5rem; background:#fff; }
+#record-editor { display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem; }

--- a/static/welcome.html
+++ b/static/welcome.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Welcome</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; }
-    </style>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+    <link rel="stylesheet" href="style.css">
+    <meta name="theme-color" content="#6200ee">
 </head>
 <body>
 <h1>Welkom bij de Road Condition Indexer</h1>


### PR DESCRIPTION
## Summary
- add new shared CSS with mobile-friendly styles
- update all HTML pages to use the new stylesheet and Roboto font
- remove old inline styles and set body classes for page-specific layout

## Testing
- `python -m py_compile main.py setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6872c91e968483208b48a9b7b8bbbb03