### PR TITLE
Add experimental logging with extra data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project collects road roughness data from mobile devices and stores it in a
 - `GET /logs` – Fetch recent measurements. Accepts an optional `limit` query
   parameter (default 100).
 - `GET /debuglog` – Retrieve backend debug messages.
+- `POST /experimental_log` – Same as `/log` but also stores raw samples for
+  analysis. Used by `experimental.html`.
 
 ## Setup
 
@@ -33,6 +35,11 @@ The built-in frontend is served from the `static/` directory under the
 `/static` path when the server is running. The main interface is
 available at `/`, and you can still visit `/welcome.html` for a simple
 welcome page.
+
+An additional page `/experimental.html` behaves the same as the main
+interface but sends data to `/experimental_log` so that all raw values
+used in the roughness calculation are stored in the `bike_data_experimental`
+table for further analysis.
 
 Use the **Update Records** button in the interface to reload the latest
 roughness records from the database and refresh the map.
@@ -67,5 +74,21 @@ CREATE TABLE device_nicknames (
   nickname NVARCHAR(100),
   user_agent NVARCHAR(256),
   device_fp NVARCHAR(256)
+);
+
+CREATE TABLE bike_data_experimental (
+  id INT IDENTITY PRIMARY KEY,
+  timestamp DATETIME DEFAULT GETDATE(),
+  latitude FLOAT,
+  longitude FLOAT,
+  speed FLOAT,
+  direction FLOAT,
+  roughness FLOAT,
+  distance_m FLOAT,
+  device_id NVARCHAR(100),
+  ip_address NVARCHAR(45),
+  z_values NVARCHAR(MAX),
+  avg_speed FLOAT,
+  interval_s FLOAT
 );
 ```

--- a/static/db.html
+++ b/static/db.html
@@ -17,7 +17,11 @@
 </head>
 <body>
 <h1>Database Management</h1>
-<p><a href="/">Back to Main</a></p>
+<div id="page-links" style="margin-bottom:1rem;">
+    <a href="/">Main</a> |
+    <a href="experimental.html">Experimental</a> |
+    <a href="device.html">Device View</a>
+</div>
 <div id="controls">
     <button onclick="loadTables()">Refresh Tables</button>
     <button onclick="insertTest()">Insert Test Data</button>

--- a/static/device.html
+++ b/static/device.html
@@ -16,7 +16,11 @@
 </head>
 <body>
 <h1>Device Records</h1>
-<p><a href="/">Back to Main</a></p>
+<div id="page-links" style="margin-bottom:1rem;">
+    <a href="/">Main</a> |
+    <a href="experimental.html">Experimental</a> |
+    <a href="db.html">DB Page</a>
+</div>
 <div id="controls">
     <select id="deviceId"></select>
     <input id="startDate" type="datetime-local">
@@ -29,6 +33,7 @@
 <div id="map"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
+const currentDeviceId = localStorage.getItem('deviceId');
 let map;
 let deviceNicknames = {};
 let currentNickname = '';
@@ -53,6 +58,13 @@ function populateDeviceIds() {
             opt.textContent = item.nickname ? `${item.nickname} (${item.id})` : item.id;
             sel.appendChild(opt);
         });
+        if (currentDeviceId && !data.ids.some(i => i.id === currentDeviceId)) {
+            const opt = document.createElement('option');
+            opt.value = currentDeviceId;
+            opt.textContent = currentDeviceId;
+            sel.appendChild(opt);
+        }
+        sel.value = currentDeviceId || '';
     }).then(() => { setDateRange(); loadNickname(); }).catch(console.error);
 }
 

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Road Condition Indexer</title>
+    <title>Road Condition Indexer - Experimental</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <style>
         body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 800px; }
@@ -40,7 +40,7 @@
     </style>
 </head>
 <body>
-<h1>Road Condition Indexer</h1>
+<h1>Road Condition Indexer - Experimental</h1>
 <div id="status"></div>
 <div id="button-bar">
     <button id="toggle">Start</button>
@@ -53,8 +53,8 @@
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 </div>
 <div id="page-links" style="margin-bottom:1rem;">
+    <a href="/">Main</a> |
     <a href="device.html">Device View</a> |
-    <a href="experimental.html">Experimental</a> |
     <a href="db.html">DB Page</a>
 </div>
 <div id="map"></div>
@@ -89,7 +89,7 @@ const fingerprint = [
     navigator.platform,
     new Date().getTimezoneOffset()
 ].join('|');
-const LOG_ENDPOINT = '/log';
+const LOG_ENDPOINT = '/experimental_log';
 
 function loadNickname() {
     if (!selectedId) {


### PR DESCRIPTION
## Summary
- default to filtering data from the current device when pages load
- add navigation bar above maps with links between pages
- create `experimental.html` that logs to `/experimental_log`
- store raw logging values in new table `bike_data_experimental`
- update README and database setup

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6873ddeec6088320b0c595f4b91a9282