### PR TITLE
Add map color scale and clarify roughness calc

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -13,6 +13,18 @@
         th, td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; }
         caption { font-weight:bold; margin-bottom:0.25rem; }
         #map { width:100%; height:40vh; margin-bottom:1rem; }
+        #scale-container {
+            display: flex;
+            align-items: center;
+            margin-bottom: 1rem;
+            gap: 0.5rem;
+        }
+        #scale-bar {
+            flex: 1;
+            height: 12px;
+            background: linear-gradient(to right, green, yellow, red);
+            border: 1px solid #ccc;
+        }
     </style>
 </head>
 <body>
@@ -31,6 +43,11 @@
     <button onclick="renameTable()">Rename Table</button>
 </div>
 <div id="map"></div>
+<div id="scale-container">
+    <span>Smooth</span>
+    <div id="scale-bar"></div>
+    <span>Rough</span>
+</div>
 <div id="record-editor" style="display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem;">
     <h3>Selected Record</h3>
     <form id="record-form">
@@ -51,6 +68,9 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let map;
+let roughMin = 0;
+let roughMax = 10;
+let roughAvg = 0;
 
 async function authFetch(url, options) {
     let res = await fetch(url, options);
@@ -85,9 +105,25 @@ function initMap() {
     }
 }
 
+function colorForRoughness(r) {
+    let ratio = 0;
+    if (roughAvg > 0) {
+        ratio = r / (roughAvg * 2);
+    } else if (roughMax !== roughMin) {
+        ratio = (r - roughMin) / (roughMax - roughMin);
+    }
+    ratio = Math.min(Math.max(ratio, 0), 1);
+    const red = Math.floor(255 * ratio);
+    const green = Math.floor(255 * (1 - ratio));
+    return `rgb(${red},${green},0)`;
+}
+
 function addPoint(lat, lon, info) {
     if (!map) return;
-    const marker = L.circleMarker([lat, lon], { radius:4, weight:1, opacity:0.9, fillOpacity:0.9 }).addTo(map);
+    const marker = L.circleMarker(
+        [lat, lon],
+        { radius:4, weight:1, opacity:0.9, fillOpacity:0.9, color: colorForRoughness(info ? info.roughness : 0) }
+    ).addTo(map);
     if (info) {
         marker.bindPopup('ID: ' + info.id + '<br>Roughness: ' + info.roughness.toFixed(2));
         marker.on('click', () => { localStorage.setItem('selectedRecordId', info.id); loadSelected(); });
@@ -98,6 +134,13 @@ async function loadLogs() {
     const res = await authFetch('/logs');
     const data = await res.json();
     const rows = Array.isArray(data) ? data : data.rows;
+    roughAvg = data.average || 0;
+    roughMin = 0;
+    roughMax = roughAvg > 0 ? roughAvg * 2 : 1;
+    if (rows.length > 0) {
+        roughMin = Math.min(...rows.map(r => r.roughness));
+        roughMax = Math.max(...rows.map(r => r.roughness));
+    }
     if (map) {
         map.eachLayer(l => { if (l instanceof L.CircleMarker) map.removeLayer(l); });
     }

--- a/static/device.html
+++ b/static/device.html
@@ -12,6 +12,18 @@
         #map { width: 100%; height: 60vh; margin-top: 1rem; }
         #map:fullscreen { width: 100%; height: 100%; }
         #controls input { margin-right: 0.5rem; }
+        #scale-container {
+            display: flex;
+            align-items: center;
+            margin-top: 0.5rem;
+            gap: 0.5rem;
+        }
+        #scale-bar {
+            flex: 1;
+            height: 12px;
+            background: linear-gradient(to right, green, yellow, red);
+            border: 1px solid #ccc;
+        }
     </style>
 </head>
 <body>
@@ -31,6 +43,11 @@
     <button id="fullscreen-button">Fullscreen</button>
 </div>
 <div id="map"></div>
+<div id="scale-container">
+    <span>Smooth</span>
+    <div id="scale-bar"></div>
+    <span>Rough</span>
+</div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const currentDeviceId = localStorage.getItem('deviceId');

--- a/static/index.html
+++ b/static/index.html
@@ -557,8 +557,11 @@ if ('wakeLock' in navigator) {
 }
 </script>
 <div id="roughness-info" style="margin-top:1rem; border:1px solid #ccc; padding:0.5rem;">
-    <strong>Roughness Calculation</strong> - vertical acceleration samples are filtered between 1&nbsp;and&nbsp;20&nbsp;Hz,
-    the RMS of the filtered signal is normalised by average speed, and values recorded below
+    <strong>Roughness Calculation</strong> - each acceleration sample is first rotated so that
+    the device's Z axis aligns with the real-world up direction derived from the orientation
+    angles. The resulting vertical values are filtered to keep vibrations between
+    1&nbsp;and&nbsp;20&nbsp;Hz. The root-mean-square of this signal is divided by the average
+    speed over the sample window. Records taken while travelling under
     5&nbsp;km/h are ignored.
 </div>
 </body>


### PR DESCRIPTION
## Summary
- show the green–yellow–red scale on the device view and DB pages
- colour DB page markers based on roughness
- compute roughness range on DB page
- elaborate on roughness calculation details

## Testing
- `python -m py_compile main.py setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6873e22ca2388320bcd00fb0c159cdc6