### PR TITLE
Enable multi-select for device filters

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -38,7 +38,7 @@
     <a href="db.html">DB Page</a>
 </div>
 <div id="controls">
-    <select id="deviceId"></select>
+    <select id="deviceId" multiple></select>
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
     <div id="range-container" style="flex-basis:100%; position:relative; height:30px;">
@@ -59,6 +59,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const currentDeviceId = localStorage.getItem('deviceId');
+let selectedIds = currentDeviceId ? [currentDeviceId] : [];
 let map;
 let deviceNicknames = {};
 let currentNickname = '';
@@ -91,13 +92,22 @@ function populateDeviceIds() {
             opt.textContent = currentDeviceId;
             sel.appendChild(opt);
         }
-        sel.value = currentDeviceId || '';
+        Array.from(sel.options).forEach(o => {
+            if (selectedIds.includes(o.value)) o.selected = true;
+        });
+        selectedIds = Array.from(sel.selectedOptions).map(o => o.value).filter(v => v);
     }).then(() => { setDateRange(); loadNickname(); }).catch(console.error);
 }
 
 function setDateRange() {
-    const device = document.getElementById('deviceId').value;
-    const url = device ? `/date_range?device_id=${encodeURIComponent(device)}` : '/date_range';
+    const sel = document.getElementById('deviceId');
+    const ids = Array.from(sel.selectedOptions).map(o => o.value).filter(v => v);
+    let url = '/date_range';
+    if (ids.length > 0) {
+        const params = new URLSearchParams();
+        ids.forEach(id => params.append('device_id', id));
+        url = '/date_range?' + params.toString();
+    }
     fetch(url).then(r => r.json()).then(data => {
         if (data.start) document.getElementById('startDate').value = data.start.slice(0,19);
         if (data.end) document.getElementById('endDate').value = data.end.slice(0,19);
@@ -108,13 +118,15 @@ function setDateRange() {
 }
 
 function loadNickname() {
-    const device = document.getElementById('deviceId').value;
-    if (!device) {
+    const sel = document.getElementById('deviceId');
+    const ids = Array.from(sel.selectedOptions).map(o => o.value).filter(v => v);
+    if (ids.length !== 1) {
         document.getElementById('nickname').value = '';
         currentNickname = '';
         return;
     }
-    fetch(`/nickname?device_id=${encodeURIComponent(device)}`)
+    const id = ids[0];
+    fetch(`/nickname?device_id=${encodeURIComponent(id)}`)
         .then(r => r.json())
         .then(data => {
             currentNickname = data.nickname || '';
@@ -136,13 +148,14 @@ function syncRanges() {
 }
 
 function saveNickname() {
-    const device = document.getElementById('deviceId').value;
+    const sel = document.getElementById('deviceId');
+    const ids = Array.from(sel.selectedOptions).map(o => o.value).filter(v => v);
     const name = document.getElementById('nickname').value;
-    if (!device) return;
+    if (ids.length !== 1) return;
     fetch('/nickname', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_id: device, nickname: name })
+        body: JSON.stringify({ device_id: ids[0], nickname: name })
     }).then(() => populateDeviceIds())
       .catch(console.error);
 }
@@ -234,11 +247,12 @@ function addPoint(lat, lon, roughness, info = null, nickname = '', min = null, m
 }
 
 function loadData() {
-    const device = document.getElementById('deviceId').value;
+    const sel = document.getElementById('deviceId');
+    const ids = Array.from(sel.selectedOptions).map(o => o.value).filter(v => v);
     const start = document.getElementById('startDate').value;
     const end = document.getElementById('endDate').value;
     const params = new URLSearchParams();
-    if (device) params.append('device_id', device);
+    ids.forEach(id => params.append('device_id', id));
     if (start) params.append('start', start);
     if (end) params.append('end', end);
     fetch('/filteredlogs?' + params.toString())
@@ -273,6 +287,8 @@ populateDeviceIds();
 syncRanges();
 document.getElementById('load').addEventListener('click', loadData);
 document.getElementById('deviceId').addEventListener('change', () => {
+    selectedIds = Array.from(document.getElementById('deviceId').selectedOptions)
+        .map(o => o.value).filter(v => v);
     setDateRange();
     loadNickname();
 });

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -47,7 +47,7 @@
     <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
     <button id="update-button" style="margin-left:1rem;">Update Records</button>
     <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
-    <select id="device-filter" style="margin-left:1rem;"></select>
+    <select id="device-filter" style="margin-left:1rem;" multiple></select>
     <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
     <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
@@ -70,7 +70,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let deviceId = localStorage.getItem('deviceId');
-let selectedId = deviceId || '';
+let selectedIds = deviceId ? [deviceId] : [];
 function setCookie(name, value, days) {
     const expires = new Date(Date.now() + days * 864e5).toUTCString();
     document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
@@ -92,12 +92,13 @@ const fingerprint = [
 const LOG_ENDPOINT = '/experimental_log';
 
 function loadNickname() {
-    if (!selectedId) {
+    if (selectedIds.length !== 1) {
         document.getElementById('nickname').value = '';
         currentNickname = '';
         return;
     }
-    fetch(`/nickname?device_id=${encodeURIComponent(selectedId)}`)
+    const id = selectedIds[0];
+    fetch(`/nickname?device_id=${encodeURIComponent(id)}`)
         .then(r => r.json())
         .then(data => {
             currentNickname = data.nickname || '';
@@ -108,11 +109,11 @@ function loadNickname() {
 
 function saveNickname() {
     const name = document.getElementById('nickname').value;
-    if (!selectedId) return;
+    if (selectedIds.length !== 1) return;
     fetch('/nickname', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_id: selectedId, nickname: name })
+        body: JSON.stringify({ device_id: selectedIds[0], nickname: name })
     }).then(() => populateDeviceFilter())
       .catch(console.error);
 }
@@ -139,8 +140,10 @@ function populateDeviceFilter() {
             opt.textContent = deviceId;
             select.appendChild(opt);
         }
-        select.value = selectedId || '';
-        selectedId = select.value;
+        Array.from(select.options).forEach(o => {
+            if (selectedIds.includes(o.value)) o.selected = true;
+        });
+        selectedIds = Array.from(select.selectedOptions).map(o => o.value).filter(v => v);
     }).then(() => { loadNickname(); loadLogs(); })
       .catch(console.error);
 }
@@ -324,11 +327,12 @@ function addPoint(lat, lon, roughness, info = null, nickname = '', min = null, m
 }
 
 function loadLogs() {
-    const filterId = document.getElementById('device-filter').value;
+    const select = document.getElementById('device-filter');
+    const ids = Array.from(select.selectedOptions).map(o => o.value).filter(v => v);
     let url = '/logs';
-    if (filterId) {
+    if (ids.length > 0) {
         const params = new URLSearchParams();
-        params.append('device_id', filterId);
+        ids.forEach(id => params.append('device_id', id));
         url = '/filteredlogs?' + params.toString();
     }
     fetch(url).then(r => r.json()).then(data => {
@@ -512,7 +516,8 @@ document.getElementById('save-nickname').addEventListener('click', () => {
     saveNickname();
 });
 document.getElementById('device-filter').addEventListener('change', () => {
-    selectedId = document.getElementById('device-filter').value;
+    selectedIds = Array.from(document.getElementById('device-filter').selectedOptions)
+        .map(o => o.value).filter(v => v);
     loadNickname();
     loadLogs();
 });

--- a/static/index.html
+++ b/static/index.html
@@ -47,7 +47,7 @@
     <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
     <button id="update-button" style="margin-left:1rem;">Update Records</button>
     <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
-    <select id="device-filter" style="margin-left:1rem;"></select>
+    <select id="device-filter" style="margin-left:1rem;" multiple></select>
     <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
     <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
@@ -70,7 +70,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let deviceId = localStorage.getItem('deviceId');
-let selectedId = deviceId || '';
+let selectedIds = deviceId ? [deviceId] : [];
 function setCookie(name, value, days) {
     const expires = new Date(Date.now() + days * 864e5).toUTCString();
     document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
@@ -92,12 +92,13 @@ const fingerprint = [
 const LOG_ENDPOINT = '/log';
 
 function loadNickname() {
-    if (!selectedId) {
+    if (selectedIds.length !== 1) {
         document.getElementById('nickname').value = '';
         currentNickname = '';
         return;
     }
-    fetch(`/nickname?device_id=${encodeURIComponent(selectedId)}`)
+    const id = selectedIds[0];
+    fetch(`/nickname?device_id=${encodeURIComponent(id)}`)
         .then(r => r.json())
         .then(data => {
             currentNickname = data.nickname || '';
@@ -108,11 +109,11 @@ function loadNickname() {
 
 function saveNickname() {
     const name = document.getElementById('nickname').value;
-    if (!selectedId) return;
+    if (selectedIds.length !== 1) return;
     fetch('/nickname', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_id: selectedId, nickname: name })
+        body: JSON.stringify({ device_id: selectedIds[0], nickname: name })
     }).then(() => populateDeviceFilter())
       .catch(console.error);
 }
@@ -139,8 +140,10 @@ function populateDeviceFilter() {
             opt.textContent = deviceId;
             select.appendChild(opt);
         }
-        select.value = selectedId || '';
-        selectedId = select.value;
+        Array.from(select.options).forEach(o => {
+            if (selectedIds.includes(o.value)) o.selected = true;
+        });
+        selectedIds = Array.from(select.selectedOptions).map(o => o.value).filter(v => v);
     }).then(() => { loadNickname(); loadLogs(); })
       .catch(console.error);
 }
@@ -324,11 +327,12 @@ function addPoint(lat, lon, roughness, info = null, nickname = '', min = null, m
 }
 
 function loadLogs() {
-    const filterId = document.getElementById('device-filter').value;
+    const select = document.getElementById('device-filter');
+    const ids = Array.from(select.selectedOptions).map(o => o.value).filter(v => v);
     let url = '/logs';
-    if (filterId) {
+    if (ids.length > 0) {
         const params = new URLSearchParams();
-        params.append('device_id', filterId);
+        ids.forEach(id => params.append('device_id', id));
         url = '/filteredlogs?' + params.toString();
     }
     fetch(url).then(r => r.json()).then(data => {
@@ -512,7 +516,8 @@ document.getElementById('save-nickname').addEventListener('click', () => {
     saveNickname();
 });
 document.getElementById('device-filter').addEventListener('change', () => {
-    selectedId = document.getElementById('device-filter').value;
+    selectedIds = Array.from(document.getElementById('device-filter').selectedOptions)
+        .map(o => o.value).filter(v => v);
     loadNickname();
     loadLogs();
 });


### PR DESCRIPTION
## Summary
- support multiple device filters by accepting list of IDs on the backend
- update frontend selects to allow multi-select and adapt JS logic

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687428efda048320aacec910b716f6b1