### PR TITLE
Add maintenance page and management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ interface but sends data to `/experimental_log` so that all raw values
 used in the roughness calculation are stored in the `bike_data_experimental`
 table for further analysis.
 
+The `/maintenance.html` page provides controls to inspect the current SQL
+database size and Azure App Service plan and lets you modify these settings.
+
 Use the **Update Records** button in the interface to reload the latest
 roughness records from the database and refresh the map.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pyodbc
 numpy
 python-dotenv
 requests
+azure-identity
+azure-mgmt-web

--- a/static/db.html
+++ b/static/db.html
@@ -32,7 +32,8 @@
 <div id="page-links" style="margin-bottom:1rem;">
     <a href="/">Main</a> |
     <a href="experimental.html">Experimental</a> |
-    <a href="device.html">Device View</a>
+    <a href="device.html">Device View</a> |
+    <a href="maintenance.html">Maintenance</a>
 </div>
 <div id="controls">
     <button onclick="loadTables()">Refresh Tables</button>

--- a/static/device.html
+++ b/static/device.html
@@ -35,7 +35,8 @@
 <div id="page-links" style="margin-bottom:1rem;">
     <a href="/">Main</a> |
     <a href="experimental.html">Experimental</a> |
-    <a href="db.html">DB Page</a>
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
 </div>
 <div id="controls">
     <select id="deviceId" multiple></select>

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -55,7 +55,8 @@
 <div id="page-links" style="margin-bottom:1rem;">
     <a href="/">Main</a> |
     <a href="device.html">Device View</a> |
-    <a href="db.html">DB Page</a>
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
 </div>
 <div id="map"></div>
 <div id="scale-container">

--- a/static/index.html
+++ b/static/index.html
@@ -55,7 +55,8 @@
 <div id="page-links" style="margin-bottom:1rem;">
     <a href="device.html">Device View</a> |
     <a href="experimental.html">Experimental</a> |
-    <a href="db.html">DB Page</a>
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
 </div>
 <div id="map"></div>
 <div id="scale-container">

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Maintenance</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 600px; }
+        #page-links { margin-bottom: 1rem; }
+        label { display:block; margin-top:0.5rem; }
+    </style>
+</head>
+<body>
+<h1>Maintenance</h1>
+<div id="page-links">
+    <a href="/">Main</a> |
+    <a href="experimental.html">Experimental</a> |
+    <a href="device.html">Device View</a> |
+    <a href="db.html">DB Page</a>
+</div>
+<section>
+    <h2>Database Size</h2>
+    <div id="db-info">Loading...</div>
+    <label>New MAXSIZE (GB) <input id="db-size" type="number" min="1"></label>
+    <button onclick="setDbSize()">Update Size</button>
+</section>
+<section style="margin-top:1rem;">
+    <h2>App Service Plan</h2>
+    <div id="plan-info">Loading...</div>
+    <label>SKU <input id="plan-sku"></label>
+    <label>Capacity <input id="plan-cap" type="number" min="1"></label>
+    <button onclick="setPlan()">Update Plan</button>
+</section>
+<script>
+async function authFetch(url, options) {
+    let res = await fetch(url, options);
+    if (res.status === 401) {
+        const pw = prompt('Password:');
+        if (!pw) throw new Error('Password required');
+        const loginRes = await fetch('/login', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({password: pw})
+        });
+        if (!loginRes.ok) throw new Error('Login failed');
+        res = await fetch(url, options);
+    }
+    return res;
+}
+async function loadDbInfo() {
+    const res = await authFetch('/manage/db_size');
+    if(!res.ok) { document.getElementById('db-info').textContent='Unavailable'; return; }
+    const data = await res.json();
+    document.getElementById('db-info').textContent = `Used: ${data.size_mb.toFixed(2)} MB, Max: ${data.max_size_gb ? data.max_size_gb.toFixed(2)+' GB' : 'unlimited'}`;
+}
+async function setDbSize() {
+    const val = document.getElementById('db-size').value;
+    if(!val) return;
+    await authFetch('/manage/set_db_size', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({max_size_gb: parseInt(val,10)})
+    });
+    loadDbInfo();
+}
+async function loadPlan() {
+    const res = await authFetch('/manage/app_plan');
+    if(!res.ok){ document.getElementById('plan-info').textContent='Unavailable'; return; }
+    const data = await res.json();
+    document.getElementById('plan-info').textContent = `Name: ${data.name}, SKU: ${data.sku}, Capacity: ${data.capacity}`;
+}
+async function setPlan() {
+    const sku = document.getElementById('plan-sku').value.trim();
+    const cap = parseInt(document.getElementById('plan-cap').value,10);
+    if(!sku && !cap) return;
+    const body = {};
+    if(sku) body.sku_name = sku;
+    if(cap) body.capacity = cap;
+    await authFetch('/manage/set_app_plan', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify(body)
+    });
+    loadPlan();
+}
+loadDbInfo();
+loadPlan();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add optional Azure management dependencies
- implement helper functions and endpoints to view and set DB and app plan size
- create `/maintenance.html` page
- link to the new page from existing navigation
- document the new page in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py setup_env.py`


------
https://chatgpt.com/codex/tasks/task_e_6874365de9748320a13333deae7f4d43