### PR TITLE
Update device page to auto refresh map on range changes

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -294,17 +294,25 @@ document.getElementById('deviceId').addEventListener('change', () => {
     loadNickname();
 });
 document.getElementById('save-nickname').addEventListener('click', saveNickname);
-document.getElementById('startDate').addEventListener('change', syncRanges);
-document.getElementById('endDate').addEventListener('change', syncRanges);
+document.getElementById('startDate').addEventListener('change', () => {
+    syncRanges();
+    loadData();
+});
+document.getElementById('endDate').addEventListener('change', () => {
+    syncRanges();
+    loadData();
+});
 document.getElementById('startRange').addEventListener('input', () => {
     const v = parseInt(document.getElementById('startRange').value, 10);
     document.getElementById('startDate').value = new Date(v).toISOString().slice(0,16);
     syncRanges();
+    loadData();
 });
 document.getElementById('endRange').addEventListener('input', () => {
     const v = parseInt(document.getElementById('endRange').value, 10);
     document.getElementById('endDate').value = new Date(v).toISOString().slice(0,16);
     syncRanges();
+    loadData();
 });
 document.getElementById('fullscreen-button').addEventListener('click', () => {
     const el = document.getElementById('map');


### PR DESCRIPTION
## Summary
- refresh map when slider positions or date/time fields change on device page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68751b2b6d048320b2757d809b56caa6