### PR TITLE
Update experimental roughness calculation

### DIFF
--- a/static/experimental.html
+++ b/static/experimental.html
@@ -563,7 +563,7 @@ if ('wakeLock' in navigator) {
 }
 </script>
 <div id="roughness-info" style="margin-top:1rem; border:1px solid #ccc; padding:0.5rem;">
-    <strong>Roughness Calculation</strong> - vertical acceleration samples are filtered between 1&nbsp;and&nbsp;20&nbsp;Hz,
+    <strong>Roughness Calculation</strong> - vertical acceleration samples are filtered between 0&nbsp;and&nbsp;20&nbsp;Hz,
     the RMS of the filtered signal is normalised by average speed, and values recorded below
     5&nbsp;km/h are ignored.
 </div>


### PR DESCRIPTION
## Summary
- add optional `freq_min` parameter to `compute_roughness`
- use 0 Hz lower bound for experimental logging
- add endpoint to recalculate stored experimental records
- update experimental page text

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687556fe9e7c832085b7a6075e08aa04