### PR TITLE
Add roughness filter

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -50,6 +50,14 @@
     <input id="filter-start" type="datetime-local">
     <input id="filter-end" type="datetime-local">
     <input id="filter-ids" placeholder="IDs (comma)">
+    <select id="roughness-filter">
+        <option value="">[All Roughness]</option>
+        <option>Very smooth</option>
+        <option>Smooth</option>
+        <option>Moderate</option>
+        <option>Rough</option>
+        <option>Very rough</option>
+    </select>
     <button onclick="loadFiltered()">Load Filter</button>
     <button onclick="deleteFiltered()">Delete Filter</button>
 </div>
@@ -155,6 +163,35 @@ function colorForRoughness(r) {
     return `rgb(${red},${green},0)`;
 }
 
+function roughnessLabel(r) {
+    if (roughAvg > 0) {
+        if (r < roughAvg * 0.5) return 'Very smooth';
+        if (r < roughAvg * 0.8) return 'Smooth';
+        if (r < roughAvg * 1.2) return 'Moderate';
+        if (r < roughAvg * 1.5) return 'Rough';
+        return 'Very rough';
+    }
+    if (roughMax !== roughMin) {
+        const step = (roughMax - roughMin) / 5;
+        if (r < roughMin + step) return 'Very smooth';
+        if (r < roughMin + step * 2) return 'Smooth';
+        if (r < roughMin + step * 3) return 'Moderate';
+        if (r < roughMin + step * 4) return 'Rough';
+        return 'Very rough';
+    }
+    if (r < 1) return 'Very smooth';
+    if (r < 2) return 'Smooth';
+    if (r < 3) return 'Moderate';
+    if (r < 4) return 'Rough';
+    return 'Very rough';
+}
+
+function filterRoughness(r) {
+    const sel = document.getElementById('roughness-filter');
+    if (!sel || !sel.value) return true;
+    return roughnessLabel(r) === sel.value;
+}
+
 function addPoint(lat, lon, info) {
     if (!map || (lat === 0 && lon === 0)) return;
     const rough = info && typeof info.roughness === 'number' ? info.roughness : 0;
@@ -191,7 +228,9 @@ function updateMap(rows) {
     }
     rows.slice().reverse().forEach(r => {
         if ('latitude' in r && 'longitude' in r) {
-            addPoint(parseFloat(r.latitude), parseFloat(r.longitude), r);
+            if (!('roughness' in r) || filterRoughness(parseFloat(r.roughness))) {
+                addPoint(parseFloat(r.latitude), parseFloat(r.longitude), r);
+            }
         }
     });
 }
@@ -462,6 +501,9 @@ initMap();
 populateDeviceOptions();
 loadTables().then(() => { loadSelectedTable(); });
 document.getElementById('table-select').addEventListener('change', loadSelectedTable);
+document.getElementById('roughness-filter').addEventListener('change', () => {
+    updateMap(tableRows);
+});
 loadLogs();
 loadSelected();
 </script>

--- a/static/device.html
+++ b/static/device.html
@@ -48,6 +48,14 @@
     </div>
     <input id="nickname" placeholder="Nickname">
     <button id="save-nickname">Save</button>
+    <select id="roughness-filter">
+        <option value="">[All Roughness]</option>
+        <option>Very smooth</option>
+        <option>Smooth</option>
+        <option>Moderate</option>
+        <option>Rough</option>
+        <option>Very rough</option>
+    </select>
     <button id="load">Load</button>
     <button id="fullscreen-button">Fullscreen</button>
 </div>
@@ -228,6 +236,12 @@ function roughnessLabel(r) {
     return 'Very rough';
 }
 
+function filterRoughness(r) {
+    const sel = document.getElementById('roughness-filter');
+    if (!sel || !sel.value) return true;
+    return roughnessLabel(r) === sel.value;
+}
+
 function addPoint(lat, lon, roughness, info = null, nickname = '', min = null, max = null) {
     if (!map || (lat === 0 && lon === 0)) return;
     const opts = {
@@ -288,6 +302,7 @@ function loadData() {
             });
             for (let i = rows.length - 1; i >= 0; i--) {
                 const row = rows[i];
+                if (!filterRoughness(row.roughness)) continue;
                 const name = deviceNicknames[row.device_id] || '';
                 const scale = roughScales[row.device_id] || {min:0,max:1};
                 addPoint(row.latitude, row.longitude, row.roughness, row, name, scale.min, scale.max);
@@ -310,6 +325,7 @@ document.getElementById('deviceId').addEventListener('change', () => {
     setDateRange();
     loadNickname();
 });
+document.getElementById('roughness-filter').addEventListener('change', loadData);
 document.getElementById('save-nickname').addEventListener('click', saveNickname);
 let sliderUpdating = false;
 document.getElementById('startDate').addEventListener('change', () => {

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -50,6 +50,14 @@
     <select id="device-filter" style="margin-left:1rem;" multiple></select>
     <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
     <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
+    <select id="roughness-filter" style="margin-left:1rem;">
+        <option value="">[All Roughness]</option>
+        <option>Very smooth</option>
+        <option>Smooth</option>
+        <option>Moderate</option>
+        <option>Rough</option>
+        <option>Very rough</option>
+    </select>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 </div>
 <div id="page-links" style="margin-bottom:1rem;">
@@ -286,6 +294,12 @@ function roughnessLabel(r) {
     return 'Very rough';
 }
 
+function filterRoughness(r) {
+    const sel = document.getElementById('roughness-filter');
+    if (!sel || !sel.value) return true;
+    return roughnessLabel(r) === sel.value;
+}
+
 function zUp(acc) {
     const beta = orientationData.beta * Math.PI / 180;
     const gamma = orientationData.gamma * Math.PI / 180;
@@ -356,6 +370,7 @@ function loadLogs() {
             roughScales[row.device_id] = s;
         });
         rows.reverse().forEach(row => {
+            if (!filterRoughness(row.roughness)) return;
             const name = deviceNicknames[row.device_id] || '';
             const scale = roughScales[row.device_id] || {min:0,max:1};
             addPoint(row.latitude, row.longitude, row.roughness, row, name, scale.min, scale.max);
@@ -414,12 +429,14 @@ function handlePosition(pos) {
                 addLog(`Record inserted, roughness: ${data.roughness.toFixed(2)}`);
                 updateStatus();
                 const scale = roughScales[deviceId] || {min: data.roughness, max: data.roughness};
-                addPoint(latitude, longitude, data.roughness, {
-                    timestamp: new Date().toISOString(),
-                    speed: lastSpeed,
-                    direction: lastDir,
-                    roughness: data.roughness
-                }, currentNickname, scale.min, scale.max);
+                if (filterRoughness(data.roughness)) {
+                    addPoint(latitude, longitude, data.roughness, {
+                        timestamp: new Date().toISOString(),
+                        speed: lastSpeed,
+                        direction: lastDir,
+                        roughness: data.roughness
+                    }, currentNickname, scale.min, scale.max);
+                }
                 scale.min = Math.min(scale.min, data.roughness);
                 scale.max = Math.max(scale.max, data.roughness);
                 roughScales[deviceId] = scale;
@@ -520,6 +537,9 @@ document.getElementById('device-filter').addEventListener('change', () => {
     selectedIds = Array.from(document.getElementById('device-filter').selectedOptions)
         .map(o => o.value).filter(v => v);
     loadNickname();
+    loadLogs();
+});
+document.getElementById('roughness-filter').addEventListener('change', () => {
     loadLogs();
 });
 document.getElementById('fullscreen-button').addEventListener('click', () => {

--- a/static/index.html
+++ b/static/index.html
@@ -50,6 +50,14 @@
     <select id="device-filter" style="margin-left:1rem;" multiple></select>
     <input id="nickname" placeholder="Nickname" style="margin-left:1rem;" />
     <button id="save-nickname" style="margin-left:0.5rem;">Save</button>
+    <select id="roughness-filter" style="margin-left:1rem;">
+        <option value="">[All Roughness]</option>
+        <option>Very smooth</option>
+        <option>Smooth</option>
+        <option>Moderate</option>
+        <option>Rough</option>
+        <option>Very rough</option>
+    </select>
     <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
 </div>
 <div id="page-links" style="margin-bottom:1rem;">
@@ -290,6 +298,12 @@ function roughnessLabel(r) {
     return 'Very rough';
 }
 
+function filterRoughness(r) {
+    const sel = document.getElementById('roughness-filter');
+    if (!sel || !sel.value) return true;
+    return roughnessLabel(r) === sel.value;
+}
+
 function zUp(acc) {
     const beta = orientationData.beta * Math.PI / 180;
     const gamma = orientationData.gamma * Math.PI / 180;
@@ -368,6 +382,7 @@ function loadLogs() {
         });
         for (let i = rows.length - 1; i >= 0; i--) {
             const row = rows[i];
+            if (!filterRoughness(row.roughness)) continue;
             const name = deviceNicknames[row.device_id] || '';
             const scale = roughScales[row.device_id] || {min:0,max:1};
             addPoint(row.latitude, row.longitude, row.roughness, row, name, scale.min, scale.max);
@@ -430,12 +445,14 @@ function handlePosition(pos) {
                 addLog(`Record inserted, roughness: ${data.roughness.toFixed(2)}`);
                 updateStatus();
                 const scale = roughScales[deviceId] || {min: data.roughness, max: data.roughness};
-                addPoint(latitude, longitude, data.roughness, {
-                    timestamp: new Date().toISOString(),
-                    speed: lastSpeed,
-                    direction: lastDir,
-                    roughness: data.roughness
-                }, currentNickname, scale.min, scale.max);
+                if (filterRoughness(data.roughness)) {
+                    addPoint(latitude, longitude, data.roughness, {
+                        timestamp: new Date().toISOString(),
+                        speed: lastSpeed,
+                        direction: lastDir,
+                        roughness: data.roughness
+                    }, currentNickname, scale.min, scale.max);
+                }
                 scale.min = Math.min(scale.min, data.roughness);
                 scale.max = Math.max(scale.max, data.roughness);
                 roughScales[deviceId] = scale;
@@ -536,6 +553,9 @@ document.getElementById('device-filter').addEventListener('change', () => {
     selectedIds = Array.from(document.getElementById('device-filter').selectedOptions)
         .map(o => o.value).filter(v => v);
     loadNickname();
+    loadLogs();
+});
+document.getElementById('roughness-filter').addEventListener('change', () => {
     loadLogs();
 });
 document.getElementById('fullscreen-button').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add roughness category filter to all map pages
- display only records matching selected roughness labels

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687558c128d08320ad45e101be4652dd