### PR TITLE
Refactor frontend layout

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -29,23 +29,13 @@
 </head>
 <body>
 <h1>Database Management</h1>
-<div id="page-links" style="margin-bottom:1rem;">
+<nav id="page-links" style="margin-bottom:1rem;">
     <a href="/">Main</a> |
     <a href="experimental.html">Experimental</a> |
     <a href="device.html">Device View</a> |
     <a href="maintenance.html">Maintenance</a>
-</div>
-<div id="controls">
-    <button onclick="loadTables()">Refresh Tables</button>
-    <button onclick="insertTest()">Insert Test Data</button>
-    <select id="table-select"></select>
-    <button onclick="loadSelectedTable()">Load Selected</button>
-    <button onclick="deleteRecords()">Delete All Records</button>
-    <button onclick="backupTable()">Backup Table</button>
-    <button onclick="renameTable()">Rename Table</button>
-    <select id="merge-old"></select>
-    <select id="merge-new"></select>
-    <button onclick="mergeIds()">Merge IDs</button>
+</nav>
+<section id="filters" style="margin-bottom:1rem;">
     <select id="filter-device" multiple></select>
     <input id="filter-start" type="datetime-local">
     <input id="filter-end" type="datetime-local">
@@ -80,31 +70,50 @@
     </select>
     <button onclick="loadFiltered()">Load Filter</button>
     <button onclick="deleteFiltered()">Delete Filter</button>
-</div>
-<button id="toggle-table" onclick="toggleTable()">Show Table</button>
+</section>
 <div id="map"></div>
 <div id="scale-container">
     <span>Smooth</span>
     <div id="scale-bar"></div>
     <span>Rough</span>
 </div>
-<div id="record-editor" style="display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem;">
-    <h3>Selected Record</h3>
-    <form id="record-form">
-        <div>ID <input id="rec-id" readonly></div>
-        <div>Latitude <input id="rec-lat"></div>
-        <div>Longitude <input id="rec-lon"></div>
-        <div>Speed <input id="rec-speed"></div>
-        <div>Direction <input id="rec-dir"></div>
-        <div>Roughness <input id="rec-rough"></div>
-        <div>Distance <input id="rec-dist"></div>
-        <div>Device ID <input id="rec-dev"></div>
-        <div>IP <input id="rec-ip"></div>
-        <button type="button" onclick="saveRecord()">Save Changes</button>
-        <button type="button" onclick="removeRecord()">Delete</button>
-    </form>
-</div>
-<div id="output" style="display:none;"></div>
+<section id="controls" style="margin-bottom:1rem;">
+    <button onclick="loadTables()">Refresh Tables</button>
+    <button onclick="insertTest()">Insert Test Data</button>
+    <select id="table-select"></select>
+    <button onclick="loadSelectedTable()">Load Selected</button>
+    <button onclick="deleteRecords()">Delete All Records</button>
+    <button onclick="backupTable()">Backup Table</button>
+    <button onclick="renameTable()">Rename Table</button>
+    <select id="merge-old"></select>
+    <select id="merge-new"></select>
+    <button onclick="mergeIds()">Merge IDs</button>
+    <button id="toggle-table" onclick="toggleTable()">Show Table</button>
+    <div id="record-editor" style="display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem;">
+        <h3>Selected Record</h3>
+        <form id="record-form">
+            <div>ID <input id="rec-id" readonly></div>
+            <div>Latitude <input id="rec-lat"></div>
+            <div>Longitude <input id="rec-lon"></div>
+            <div>Speed <input id="rec-speed"></div>
+            <div>Direction <input id="rec-dir"></div>
+            <div>Roughness <input id="rec-rough"></div>
+            <div>Distance <input id="rec-dist"></div>
+            <div>Device ID <input id="rec-dev"></div>
+            <div>IP <input id="rec-ip"></div>
+            <button type="button" onclick="saveRecord()">Save Changes</button>
+            <button type="button" onclick="removeRecord()">Delete</button>
+        </form>
+    </div>
+    <div id="output" style="display:none;"></div>
+</section>
+<section id="logs" style="margin-bottom:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
+
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let map;

--- a/static/device.html
+++ b/static/device.html
@@ -32,13 +32,13 @@
 </head>
 <body>
 <h1>Device Records</h1>
-<div id="page-links" style="margin-bottom:1rem;">
+<nav id="page-links" style="margin-bottom:1rem;">
     <a href="/">Main</a> |
     <a href="experimental.html">Experimental</a> |
     <a href="db.html">DB Page</a> |
     <a href="maintenance.html">Maintenance</a>
-</div>
-<div id="controls">
+</nav>
+<section id="filters" style="margin-bottom:1rem;">
     <select id="deviceId" multiple></select>
     <input id="startDate" type="datetime-local">
     <input id="endDate" type="datetime-local">
@@ -46,8 +46,6 @@
         <input id="startRange" type="range" style="position:absolute;left:0;right:0;width:100%;">
         <input id="endRange" type="range" style="position:absolute;left:0;right:0;width:100%;">
     </div>
-    <input id="nickname" placeholder="Nickname">
-    <button id="save-nickname">Save</button>
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
@@ -76,19 +74,29 @@
         <option value="24">24 - Severe ruts</option>
         <option value="25">25 - Impassable</option>
     </select>
-    <button id="load">Load</button>
-    <button id="fullscreen-button">Fullscreen</button>
-</div>
-<div id="loading" style="display:none;margin-bottom:1rem;">
-    <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
-    <span id="load-label"></span>
-</div>
+</section>
 <div id="map"></div>
 <div id="scale-container">
     <span>Smooth</span>
     <div id="scale-bar"></div>
     <span>Rough</span>
 </div>
+<section id="controls" style="margin-bottom:1rem;">
+    <input id="nickname" placeholder="Nickname">
+    <button id="save-nickname">Save</button>
+    <button id="load">Load</button>
+    <button id="fullscreen-button">Fullscreen</button>
+    <div id="loading" style="display:none; margin-top:1rem;">
+        <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
+        <span id="load-label"></span>
+    </div>
+</section>
+<section id="logs" style="margin-bottom:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const currentDeviceId = localStorage.getItem('deviceId');

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -41,16 +41,15 @@
 </head>
 <body>
 <h1>Road Condition Indexer - Experimental</h1>
-<div id="status"></div>
-<div id="button-bar">
-    <button id="toggle">Start</button>
-    <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
-    <button id="update-button" style="margin-left:1rem; display:none;">Update Records</button>
-    <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
-    <select id="device-filter" style="margin-left:1rem;" multiple></select>
-    <input id="nickname" placeholder="Nickname" style="margin-left:1rem; display:none;" />
-    <button id="save-nickname" style="margin-left:0.5rem; display:none;">Save</button>
-    <select id="roughness-filter" style="margin-left:1rem;" multiple>
+<nav id="page-links" style="margin-bottom:1rem;">
+    <a href="/">Main</a> |
+    <a href="device.html">Device View</a> |
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
+</nav>
+<section id="filters" style="margin-bottom:1rem;">
+    <select id="device-filter" multiple></select>
+    <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
         <option value="2">2 - Polished</option>
@@ -78,35 +77,42 @@
         <option value="24">24 - Severe ruts</option>
         <option value="25">25 - Impassable</option>
     </select>
-    <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
-</div>
-<div id="page-links" style="margin-bottom:1rem;">
-    <a href="/">Main</a> |
-    <a href="device.html">Device View</a> |
-    <a href="db.html">DB Page</a> |
-    <a href="maintenance.html">Maintenance</a>
-</div>
-<div id="loading" style="display:none;margin-bottom:1rem;">
-    <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
-    <span id="load-label"></span>
-</div>
-<div id="freq-controls" style="margin-bottom:1rem;">
-    Filter Hz:
-    <input id="freq-min" type="number" value="0" step="0.1" style="width:4rem;"> -
-    <input id="freq-max" type="number" value="20" step="0.1" style="width:4rem;">
-    <button id="freq-apply">Set</button>
-    <button id="recalc-btn">Recalculate</button>
-</div>
+    <div id="freq-controls" style="display:inline-block; margin-left:1rem;">
+        Filter Hz:
+        <input id="freq-min" type="number" value="0" step="0.1" style="width:4rem;"> -
+        <input id="freq-max" type="number" value="20" step="0.1" style="width:4rem;">
+        <button id="freq-apply">Set</button>
+        <button id="recalc-btn">Recalculate</button>
+    </div>
+</section>
 <div id="map"></div>
 <div id="scale-container">
     <span>Smooth</span>
     <div id="scale-bar"></div>
     <span>Rough</span>
 </div>
-<h3>Activity Log</h3>
-<div id="log"></div>
-<h3>Debug Messages</h3>
-<textarea id="debug" readonly></textarea>
+<section id="controls" style="margin-bottom:1rem;">
+    <div id="status"></div>
+    <div id="button-bar">
+        <button id="toggle">Start</button>
+        <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
+        <button id="update-button" style="margin-left:1rem; display:none;">Update Records</button>
+        <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
+        <input id="nickname" placeholder="Nickname" style="margin-left:1rem; display:none;" />
+        <button id="save-nickname" style="margin-left:0.5rem; display:none;">Save</button>
+        <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
+    </div>
+    <div id="loading" style="display:none; margin-top:1rem;">
+        <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
+        <span id="load-label"></span>
+    </div>
+</section>
+<section id="logs" style="margin-bottom:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let deviceId = localStorage.getItem('deviceId');

--- a/static/index.html
+++ b/static/index.html
@@ -41,16 +41,15 @@
 </head>
 <body>
 <h1>Road Condition Indexer</h1>
-<div id="status"></div>
-<div id="button-bar">
-    <button id="toggle">Start</button>
-    <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
-    <button id="update-button" style="margin-left:1rem; display:none;">Update Records</button>
-    <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
-    <select id="device-filter" style="margin-left:1rem;" multiple></select>
-    <input id="nickname" placeholder="Nickname" style="margin-left:1rem; display:none;" />
-    <button id="save-nickname" style="margin-left:0.5rem; display:none;">Save</button>
-    <select id="roughness-filter" style="margin-left:1rem;" multiple>
+<nav id="page-links" style="margin-bottom:1rem;">
+    <a href="device.html">Device View</a> |
+    <a href="experimental.html">Experimental</a> |
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
+</nav>
+<section id="filters" style="margin-bottom:1rem;">
+    <select id="device-filter" multiple></select>
+    <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
         <option value="2">2 - Polished</option>
@@ -78,28 +77,35 @@
         <option value="24">24 - Severe ruts</option>
         <option value="25">25 - Impassable</option>
     </select>
-    <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
-</div>
-<div id="page-links" style="margin-bottom:1rem;">
-    <a href="device.html">Device View</a> |
-    <a href="experimental.html">Experimental</a> |
-    <a href="db.html">DB Page</a> |
-    <a href="maintenance.html">Maintenance</a>
-</div>
-<div id="loading" style="display:none;margin-bottom:1rem;">
-    <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
-    <span id="load-label"></span>
-</div>
+</section>
 <div id="map"></div>
 <div id="scale-container">
     <span>Smooth</span>
     <div id="scale-bar"></div>
     <span>Rough</span>
 </div>
-<h3>Activity Log</h3>
-<div id="log"></div>
-<h3>Debug Messages</h3>
-<textarea id="debug" readonly></textarea>
+<section id="controls" style="margin-bottom:1rem;">
+    <div id="status"></div>
+    <div id="button-bar">
+        <button id="toggle">Start</button>
+        <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
+        <button id="update-button" style="margin-left:1rem; display:none;">Update Records</button>
+        <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
+        <input id="nickname" placeholder="Nickname" style="margin-left:1rem; display:none;" />
+        <button id="save-nickname" style="margin-left:0.5rem; display:none;">Save</button>
+        <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
+    </div>
+    <div id="loading" style="display:none; margin-top:1rem;">
+        <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
+        <span id="load-label"></span>
+    </div>
+</section>
+<section id="logs" style="margin-bottom:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 let deviceId = localStorage.getItem('deviceId');

--- a/static/login.html
+++ b/static/login.html
@@ -10,11 +10,27 @@
     </style>
 </head>
 <body>
+<h1>Login</h1>
+<nav id="page-links" style="margin-bottom:1rem;">
+    <a href="/">Main</a> |
+    <a href="experimental.html">Experimental</a> |
+    <a href="device.html">Device View</a> |
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
+</nav>
+<section id="controls" style="margin-bottom:1rem;">
 <div id="login-box">
     <h2>Please enter password</h2>
     <input type="password" id="pw" />
     <button onclick="doLogin()">Login</button>
 </div>
+</section>
+<section id="logs" style="margin-bottom:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
 <script>
 async function doLogin() {
     const pw = document.getElementById('pw').value;

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -12,12 +12,12 @@
 </head>
 <body>
 <h1>Maintenance</h1>
-<div id="page-links">
+<nav id="page-links">
     <a href="/">Main</a> |
     <a href="experimental.html">Experimental</a> |
     <a href="device.html">Device View</a> |
     <a href="db.html">DB Page</a>
-</div>
+</nav>
 <section>
     <h2>Database Size</h2>
     <div id="db-info">Loading...</div>
@@ -256,5 +256,11 @@ async function loadPlan() {
 loadDbInfo();
 loadPlan();
 </script>
+<section id="logs" style="margin-top:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
 </body>
 </html>

--- a/static/welcome.html
+++ b/static/welcome.html
@@ -9,8 +9,23 @@
     </style>
 </head>
 <body>
-<h1>Welkom bij de Road Condition Indexer</h1>
-<p>Deze pagina verwelkomt je bij de applicatie.</p>
-<p><a href="index.html">Ga naar de hoofdapplicatie</a></p>
+<h1>Welcome</h1>
+<nav id="page-links" style="margin-bottom:1rem;">
+    <a href="index.html">Main</a> |
+    <a href="experimental.html">Experimental</a> |
+    <a href="device.html">Device View</a> |
+    <a href="db.html">DB Page</a> |
+    <a href="maintenance.html">Maintenance</a>
+</nav>
+<section id="controls" style="margin-bottom:1rem;">
+    <p>Deze pagina verwelkomt je bij de applicatie.</p>
+    <p><a href="index.html">Ga naar de hoofdapplicatie</a></p>
+</section>
+<section id="logs" style="margin-bottom:1rem;">
+    <h3>Activity Log</h3>
+    <div id="log"></div>
+    <h3>Debug Messages</h3>
+    <textarea id="debug" readonly></textarea>
+</section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reorganize all HTML pages with unified sections
- add navigation links to each page
- move map filters and controls into consistent sections
- show Activity Log and debug areas across the interface

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68764708603483208e6c8689e10a9c5c