### PR TITLE
Implement 10-level logarithmic roughness scale

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -43,30 +43,15 @@
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
-        <option value="2">2 - Polished</option>
-        <option value="3">3 - Smooth concrete</option>
-        <option value="4">4 - New asphalt</option>
-        <option value="5">5 - Good asphalt</option>
-        <option value="6">6 - Worn asphalt</option>
-        <option value="7">7 - Coarse asphalt</option>
-        <option value="8">8 - Light chip seal</option>
-        <option value="9">9 - Medium chip seal</option>
-        <option value="10">10 - Heavy chip seal</option>
-        <option value="11">11 - Smooth cobbles</option>
-        <option value="12">12 - Worn cobbles</option>
-        <option value="13">13 - Rough cobbles</option>
-        <option value="14">14 - Packed dirt</option>
-        <option value="15">15 - Loose dirt</option>
-        <option value="16">16 - Fine gravel</option>
-        <option value="17">17 - Medium gravel</option>
-        <option value="18">18 - Coarse gravel</option>
-        <option value="19">19 - Rough gravel</option>
-        <option value="20">20 - Broken pavement</option>
-        <option value="21">21 - Small potholes</option>
-        <option value="22">22 - Large potholes</option>
-        <option value="23">23 - Very rough potholes</option>
-        <option value="24">24 - Severe ruts</option>
-        <option value="25">25 - Impassable</option>
+        <option value="2">2 - Smooth concrete</option>
+        <option value="3">3 - Good asphalt</option>
+        <option value="4">4 - Coarse asphalt</option>
+        <option value="5">5 - Medium chip seal</option>
+        <option value="6">6 - Worn cobbles</option>
+        <option value="7">7 - Fine gravel</option>
+        <option value="8">8 - Rough gravel</option>
+        <option value="9">9 - Large potholes</option>
+        <option value="10">10 - Impassable</option>
     </select>
     <button onclick="loadFiltered()">Load Filter</button>
     <button onclick="deleteFiltered()">Delete Filter</button>
@@ -118,7 +103,7 @@
 <script>
 let map;
 let roughMin = 0;
-const LABEL_COUNT = 25;
+const LABEL_COUNT = 10;
 let roughMax = LABEL_COUNT;
 let roughAvg = 0;
 let currentTable = '';
@@ -204,9 +189,12 @@ function roughnessLabel(r) {
             max = min + LABEL_COUNT;
         }
     }
-    const step = (max - min) / LABEL_COUNT;
-    if (step <= 0) return '1';
-    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor((r - min) / step)));
+    const offset = 1;
+    let logMin = Math.log(min + offset);
+    let logMax = Math.log(max + offset);
+    if (logMax === logMin) logMax = logMin + 1;
+    const ratio = (Math.log(r + offset) - logMin) / (logMax - logMin);
+    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor(ratio * LABEL_COUNT)));
     return String(idx + 1);
 }
 

--- a/static/device.html
+++ b/static/device.html
@@ -49,30 +49,15 @@
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
-        <option value="2">2 - Polished</option>
-        <option value="3">3 - Smooth concrete</option>
-        <option value="4">4 - New asphalt</option>
-        <option value="5">5 - Good asphalt</option>
-        <option value="6">6 - Worn asphalt</option>
-        <option value="7">7 - Coarse asphalt</option>
-        <option value="8">8 - Light chip seal</option>
-        <option value="9">9 - Medium chip seal</option>
-        <option value="10">10 - Heavy chip seal</option>
-        <option value="11">11 - Smooth cobbles</option>
-        <option value="12">12 - Worn cobbles</option>
-        <option value="13">13 - Rough cobbles</option>
-        <option value="14">14 - Packed dirt</option>
-        <option value="15">15 - Loose dirt</option>
-        <option value="16">16 - Fine gravel</option>
-        <option value="17">17 - Medium gravel</option>
-        <option value="18">18 - Coarse gravel</option>
-        <option value="19">19 - Rough gravel</option>
-        <option value="20">20 - Broken pavement</option>
-        <option value="21">21 - Small potholes</option>
-        <option value="22">22 - Large potholes</option>
-        <option value="23">23 - Very rough potholes</option>
-        <option value="24">24 - Severe ruts</option>
-        <option value="25">25 - Impassable</option>
+        <option value="2">2 - Smooth concrete</option>
+        <option value="3">3 - Good asphalt</option>
+        <option value="4">4 - Coarse asphalt</option>
+        <option value="5">5 - Medium chip seal</option>
+        <option value="6">6 - Worn cobbles</option>
+        <option value="7">7 - Fine gravel</option>
+        <option value="8">8 - Rough gravel</option>
+        <option value="9">9 - Large potholes</option>
+        <option value="10">10 - Impassable</option>
     </select>
 </section>
 <div id="map"></div>
@@ -105,7 +90,7 @@ let map;
 let deviceNicknames = {};
 let currentNickname = '';
 let roughMin = 0;
-const LABEL_COUNT = 25;
+const LABEL_COUNT = 10;
 let roughMax = LABEL_COUNT;
 let roughAvg = 0;
 let roughScales = {};
@@ -253,9 +238,12 @@ function roughnessLabel(r) {
             max = min + LABEL_COUNT;
         }
     }
-    const step = (max - min) / LABEL_COUNT;
-    if (step <= 0) return '1';
-    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor((r - min) / step)));
+    const offset = 1;
+    let logMin = Math.log(min + offset);
+    let logMax = Math.log(max + offset);
+    if (logMax === logMin) logMax = logMin + 1;
+    const ratio = (Math.log(r + offset) - logMin) / (logMax - logMin);
+    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor(ratio * LABEL_COUNT)));
     return String(idx + 1);
 }
 

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -52,30 +52,15 @@
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
-        <option value="2">2 - Polished</option>
-        <option value="3">3 - Smooth concrete</option>
-        <option value="4">4 - New asphalt</option>
-        <option value="5">5 - Good asphalt</option>
-        <option value="6">6 - Worn asphalt</option>
-        <option value="7">7 - Coarse asphalt</option>
-        <option value="8">8 - Light chip seal</option>
-        <option value="9">9 - Medium chip seal</option>
-        <option value="10">10 - Heavy chip seal</option>
-        <option value="11">11 - Smooth cobbles</option>
-        <option value="12">12 - Worn cobbles</option>
-        <option value="13">13 - Rough cobbles</option>
-        <option value="14">14 - Packed dirt</option>
-        <option value="15">15 - Loose dirt</option>
-        <option value="16">16 - Fine gravel</option>
-        <option value="17">17 - Medium gravel</option>
-        <option value="18">18 - Coarse gravel</option>
-        <option value="19">19 - Rough gravel</option>
-        <option value="20">20 - Broken pavement</option>
-        <option value="21">21 - Small potholes</option>
-        <option value="22">22 - Large potholes</option>
-        <option value="23">23 - Very rough potholes</option>
-        <option value="24">24 - Severe ruts</option>
-        <option value="25">25 - Impassable</option>
+        <option value="2">2 - Smooth concrete</option>
+        <option value="3">3 - Good asphalt</option>
+        <option value="4">4 - Coarse asphalt</option>
+        <option value="5">5 - Medium chip seal</option>
+        <option value="6">6 - Worn cobbles</option>
+        <option value="7">7 - Fine gravel</option>
+        <option value="8">8 - Rough gravel</option>
+        <option value="9">9 - Large potholes</option>
+        <option value="10">10 - Impassable</option>
     </select>
     <div id="freq-controls" style="display:inline-block; margin-left:1rem;">
         Filter Hz:
@@ -233,7 +218,7 @@ let lastAcc = {x:0, y:0, z:0};
 let map;
 let orientationData = {alpha:0, beta:0, gamma:0};
 let roughMin = 0;
-const LABEL_COUNT = 25;
+const LABEL_COUNT = 10;
 let roughMax = LABEL_COUNT;
 let roughAvg = 0;
 let roughScales = {};
@@ -348,9 +333,12 @@ function roughnessLabel(r) {
             max = min + LABEL_COUNT;
         }
     }
-    const step = (max - min) / LABEL_COUNT;
-    if (step <= 0) return '1';
-    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor((r - min) / step)));
+    const offset = 1;
+    let logMin = Math.log(min + offset);
+    let logMax = Math.log(max + offset);
+    if (logMax === logMin) logMax = logMin + 1;
+    const ratio = (Math.log(r + offset) - logMin) / (logMax - logMin);
+    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor(ratio * LABEL_COUNT)));
     return String(idx + 1);
 }
 
@@ -727,29 +715,14 @@ if ('wakeLock' in navigator) {
     <strong>Roughness Scale Reference</strong>
     <ol style="column-count:2; padding-left:1.25rem;">
         <li>Glass-smooth</li>
-        <li>Polished</li>
         <li>Smooth concrete</li>
-        <li>New asphalt</li>
         <li>Good asphalt</li>
-        <li>Worn asphalt</li>
         <li>Coarse asphalt</li>
-        <li>Light chip seal</li>
         <li>Medium chip seal</li>
-        <li>Heavy chip seal</li>
-        <li>Smooth cobbles</li>
         <li>Worn cobbles</li>
-        <li>Rough cobbles</li>
-        <li>Packed dirt</li>
-        <li>Loose dirt</li>
         <li>Fine gravel</li>
-        <li>Medium gravel</li>
-        <li>Coarse gravel</li>
         <li>Rough gravel</li>
-        <li>Broken pavement</li>
-        <li>Small potholes</li>
         <li>Large potholes</li>
-        <li>Very rough potholes</li>
-        <li>Severe ruts</li>
         <li>Impassable</li>
     </ol>
 </div>

--- a/static/index.html
+++ b/static/index.html
@@ -52,30 +52,15 @@
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
-        <option value="2">2 - Polished</option>
-        <option value="3">3 - Smooth concrete</option>
-        <option value="4">4 - New asphalt</option>
-        <option value="5">5 - Good asphalt</option>
-        <option value="6">6 - Worn asphalt</option>
-        <option value="7">7 - Coarse asphalt</option>
-        <option value="8">8 - Light chip seal</option>
-        <option value="9">9 - Medium chip seal</option>
-        <option value="10">10 - Heavy chip seal</option>
-        <option value="11">11 - Smooth cobbles</option>
-        <option value="12">12 - Worn cobbles</option>
-        <option value="13">13 - Rough cobbles</option>
-        <option value="14">14 - Packed dirt</option>
-        <option value="15">15 - Loose dirt</option>
-        <option value="16">16 - Fine gravel</option>
-        <option value="17">17 - Medium gravel</option>
-        <option value="18">18 - Coarse gravel</option>
-        <option value="19">19 - Rough gravel</option>
-        <option value="20">20 - Broken pavement</option>
-        <option value="21">21 - Small potholes</option>
-        <option value="22">22 - Large potholes</option>
-        <option value="23">23 - Very rough potholes</option>
-        <option value="24">24 - Severe ruts</option>
-        <option value="25">25 - Impassable</option>
+        <option value="2">2 - Smooth concrete</option>
+        <option value="3">3 - Good asphalt</option>
+        <option value="4">4 - Coarse asphalt</option>
+        <option value="5">5 - Medium chip seal</option>
+        <option value="6">6 - Worn cobbles</option>
+        <option value="7">7 - Fine gravel</option>
+        <option value="8">8 - Rough gravel</option>
+        <option value="9">9 - Large potholes</option>
+        <option value="10">10 - Impassable</option>
     </select>
 </section>
 <div id="map"></div>
@@ -204,7 +189,7 @@ let lastAcc = {x:0, y:0, z:0};
 let map;
 let orientationData = {alpha:0, beta:0, gamma:0};
 let roughMin = 0;
-const LABEL_COUNT = 25;
+const LABEL_COUNT = 10;
 let roughMax = LABEL_COUNT;
 let roughAvg = 0;
 let roughScales = {};
@@ -319,9 +304,12 @@ function roughnessLabel(r) {
             max = min + LABEL_COUNT;
         }
     }
-    const step = (max - min) / LABEL_COUNT;
-    if (step <= 0) return '1';
-    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor((r - min) / step)));
+    const offset = 1;
+    let logMin = Math.log(min + offset);
+    let logMax = Math.log(max + offset);
+    if (logMax === logMin) logMax = logMin + 1;
+    const ratio = (Math.log(r + offset) - logMin) / (logMax - logMin);
+    const idx = Math.max(0, Math.min(LABEL_COUNT - 1, Math.floor(ratio * LABEL_COUNT)));
     return String(idx + 1);
 }
 
@@ -645,29 +633,14 @@ if ('wakeLock' in navigator) {
     <strong>Roughness Scale Reference</strong>
     <ol style="column-count:2; padding-left:1.25rem;">
         <li>Glass-smooth</li>
-        <li>Polished</li>
         <li>Smooth concrete</li>
-        <li>New asphalt</li>
         <li>Good asphalt</li>
-        <li>Worn asphalt</li>
         <li>Coarse asphalt</li>
-        <li>Light chip seal</li>
         <li>Medium chip seal</li>
-        <li>Heavy chip seal</li>
-        <li>Smooth cobbles</li>
         <li>Worn cobbles</li>
-        <li>Rough cobbles</li>
-        <li>Packed dirt</li>
-        <li>Loose dirt</li>
         <li>Fine gravel</li>
-        <li>Medium gravel</li>
-        <li>Coarse gravel</li>
         <li>Rough gravel</li>
-        <li>Broken pavement</li>
-        <li>Small potholes</li>
         <li>Large potholes</li>
-        <li>Very rough potholes</li>
-        <li>Severe ruts</li>
         <li>Impassable</li>
     </ol>
 </div>


### PR DESCRIPTION
## Summary
- compress roughness categories to 10 values
- apply logarithmic bucket calculation
- update UI options and scale references

## Testing
- `python -m py_compile main.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876627444a88320961b564c3640c8e9