### PR TITLE
UI restructure and logging

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -35,11 +35,8 @@
     <a href="device.html">Device View</a> |
     <a href="maintenance.html">Maintenance</a>
 </nav>
-<section id="filters" style="margin-bottom:1rem;">
+<section id="filter-dev" style="margin-bottom:1rem;">
     <select id="filter-device" multiple></select>
-    <input id="filter-start" type="datetime-local">
-    <input id="filter-end" type="datetime-local">
-    <input id="filter-ids" placeholder="IDs (comma)">
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
@@ -53,6 +50,12 @@
         <option value="9">9 - Large potholes</option>
         <option value="10">10 - Impassable</option>
     </select>
+    </select>
+</section>
+<section id="filter-time" style="margin-bottom:1rem;">
+    <input id="filter-start" type="datetime-local">
+    <input id="filter-end" type="datetime-local">
+    <input id="filter-ids" placeholder="IDs (comma)">
     <button onclick="loadFiltered()">Load Filter</button>
     <button onclick="deleteFiltered()">Delete Filter</button>
 </section>
@@ -65,16 +68,22 @@
 <section id="controls" style="margin-bottom:1rem;">
     <button onclick="loadTables()">Refresh Tables</button>
     <button onclick="insertTest()">Insert Test Data</button>
-    <select id="table-select"></select>
+</section>
+<section id="table-actions" style="margin-bottom:1rem;">
+    <h3>Table: <select id="table-select"></select></h3>
     <button onclick="loadSelectedTable()">Load Selected</button>
     <button onclick="deleteRecords()">Delete All Records</button>
     <button onclick="backupTable()">Backup Table</button>
     <button onclick="renameTable()">Rename Table</button>
+    <button id="toggle-table" onclick="toggleTable()">Show Table</button>
+</section>
+<section id="merge-section" style="margin-bottom:1rem;">
+    <h3>Merge Device IDs</h3>
     <select id="merge-old"></select>
     <select id="merge-new"></select>
     <button onclick="mergeIds()">Merge IDs</button>
-    <button id="toggle-table" onclick="toggleTable()">Show Table</button>
-    <div id="record-editor" style="display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem;">
+</section>
+<div id="record-editor" style="display:none; border:1px solid #ccc; padding:0.5rem; margin-bottom:1rem;">
         <h3>Selected Record</h3>
         <form id="record-form">
             <div>ID <input id="rec-id" readonly></div>
@@ -141,6 +150,43 @@ function initMap() {
         );
     } else {
         setView(defaultPos);
+    }
+    addFullscreenControl(map);
+}
+
+function addFullscreenControl(m) {
+    const Full = L.Control.extend({
+        onAdd: function() {
+            const btn = L.DomUtil.create('button', 'leaflet-bar');
+            btn.textContent = '⤢';
+            L.DomEvent.on(btn, 'click', () => {
+                const el = m.getContainer();
+                addLog('Fullscreen button pressed');
+                if (!document.fullscreenElement) {
+                    el.requestFullscreen?.();
+                } else {
+                    document.exitFullscreen?.();
+                }
+            });
+            return btn;
+        }
+    });
+    m.addControl(new Full({position:'topleft'}));
+}
+
+function addLog(msg) {
+    const div = document.getElementById('log');
+    if (div) {
+        div.textContent += msg + '\n';
+        div.scrollTop = div.scrollHeight;
+    }
+}
+
+function addDebug(msg) {
+    const el = document.getElementById('debug');
+    if (el) {
+        el.value += msg + '\n';
+        el.scrollTop = el.scrollHeight;
     }
 }
 
@@ -257,6 +303,7 @@ async function loadLogs() {
 }
 
 async function loadTables(selected) {
+    addLog('Refresh Tables pressed');
     const res = await authFetch('/manage/tables');
     const data = await res.json();
     const select = document.getElementById('table-select');
@@ -272,18 +319,21 @@ async function loadTables(selected) {
 }
 async function insertTest() {
     const t = document.getElementById('table-select').value; if(!t) return;
+    addLog('Insert Test Data pressed');
     await authFetch('/manage/insert_testdata', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({table:t})});
     await loadTables(t);
     loadSelectedTable();
 }
 async function deleteRecords() {
     const t = document.getElementById('table-select').value; if(!t) return;
+    addLog('Delete All Records pressed');
     await authFetch('/manage/delete_all?table='+encodeURIComponent(t), {method:'DELETE'});
     await loadTables(t);
     loadSelectedTable();
 }
 async function backupTable() {
     const t = document.getElementById('table-select').value; if(!t) return;
+    addLog('Backup Table pressed');
     const res = await authFetch('/manage/backup_table', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
@@ -372,6 +422,7 @@ function showRow(row) {
 }
 
 async function loadSelectedTable() {
+    addLog('Load Selected Table pressed');
     const tableName = document.getElementById('table-select').value;
     if (!tableName) return;
     const res = await authFetch('/manage/table_rows?table=' + encodeURIComponent(tableName));
@@ -393,6 +444,7 @@ async function renameTable() {
     const t = document.getElementById('table-select').value; if(!t) return;
     const newName = prompt('New table name', t);
     if(!newName || newName === t) return;
+    addLog('Rename Table pressed');
     await authFetch('/manage/rename_table', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
@@ -406,6 +458,7 @@ async function mergeIds() {
     const oldId = document.getElementById('merge-old').value;
     const newId = document.getElementById('merge-new').value;
     if(!oldId || !newId || oldId === newId) return;
+    addLog('Merge IDs pressed');
     await authFetch('/manage/merge_device_ids', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
@@ -433,6 +486,7 @@ function buildFilterParams() {
 }
 
 async function loadFiltered() {
+    addLog('Load Filter pressed');
     const params = buildFilterParams();
     const res = await authFetch('/manage/filtered_records?' + params.toString());
     if(!res.ok) return;
@@ -451,6 +505,7 @@ async function loadFiltered() {
 }
 
 async function deleteFiltered() {
+    addLog('Delete Filter pressed');
     const params = buildFilterParams();
     const res = await authFetch('/manage/delete_filtered_records?' + params.toString(), {method:'DELETE'});
     if(res.ok) {
@@ -472,6 +527,7 @@ function loadSelected() {
 
 async function saveRecord() {
     if(currentTable !== 'bike_data') return;
+    addLog('Save Record pressed');
     const body = { id: parseInt(document.getElementById('rec-id').value,10) };
     currentColumns.forEach(col => {
         if(col === 'id') return;
@@ -492,6 +548,7 @@ async function saveRecord() {
 
 async function removeRecord() {
     if(currentTable !== 'bike_data') return;
+    addLog('Delete Record pressed');
     const id = document.getElementById('rec-id').value;
     if(!id) return;
     await authFetch('/manage/delete_record?record_id='+encodeURIComponent(id), {method:'DELETE'});
@@ -502,6 +559,7 @@ async function removeRecord() {
 
 function toggleTable() {
     showTable = !showTable;
+    addLog('Toggle Table pressed');
     document.getElementById('toggle-table').textContent = showTable ? 'Hide Table' : 'Show Table';
     if(showTable) {
         renderTable(currentTable, tableRows);

--- a/static/device.html
+++ b/static/device.html
@@ -38,14 +38,8 @@
     <a href="db.html">DB Page</a> |
     <a href="maintenance.html">Maintenance</a>
 </nav>
-<section id="filters" style="margin-bottom:1rem;">
+<section id="filter-dev" style="margin-bottom:1rem;">
     <select id="deviceId" multiple></select>
-    <input id="startDate" type="datetime-local">
-    <input id="endDate" type="datetime-local">
-    <div id="range-container" style="flex-basis:100%; position:relative; height:30px;">
-        <input id="startRange" type="range" style="position:absolute;left:0;right:0;width:100%;">
-        <input id="endRange" type="range" style="position:absolute;left:0;right:0;width:100%;">
-    </div>
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
         <option value="1">1 - Glass-smooth</option>
@@ -60,6 +54,14 @@
         <option value="10">10 - Impassable</option>
     </select>
 </section>
+<section id="filter-time" style="margin-bottom:1rem;">
+    <input id="startDate" type="datetime-local">
+    <input id="endDate" type="datetime-local">
+    <div id="range-container" style="flex-basis:100%; position:relative; height:30px;">
+        <input id="startRange" type="range" style="position:absolute;left:0;right:0;width:100%;">
+        <input id="endRange" type="range" style="position:absolute;left:0;right:0;width:100%;">
+    </div>
+</section>
 <div id="map"></div>
 <div id="scale-container">
     <span>Smooth</span>
@@ -70,7 +72,8 @@
     <input id="nickname" placeholder="Nickname">
     <button id="save-nickname">Save</button>
     <button id="load">Load</button>
-    <button id="fullscreen-button">Fullscreen</button>
+    <button id="gpx-button">Generate GPX</button>
+    <a id="gpx-link" style="display:none;">Download GPX</a>
     <div id="loading" style="display:none; margin-top:1rem;">
         <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
         <span id="load-label"></span>
@@ -203,6 +206,54 @@ function initMap() {
     } else {
         setView(defaultPos);
     }
+    addFullscreenControl(map);
+}
+
+function addFullscreenControl(m) {
+    const Full = L.Control.extend({
+        onAdd: function() {
+            const btn = L.DomUtil.create('button', 'leaflet-bar');
+            btn.textContent = '⤢';
+            L.DomEvent.on(btn, 'click', () => {
+                const el = m.getContainer();
+                addLog('Fullscreen button pressed');
+                if (!document.fullscreenElement) {
+                    el.requestFullscreen?.();
+                } else {
+                    document.exitFullscreen?.();
+                }
+            });
+            return btn;
+        }
+    });
+    m.addControl(new Full({position:'topleft'}));
+}
+
+function addLog(msg) {
+    const div = document.getElementById('log');
+    if (div) {
+        div.textContent += msg + '\n';
+        div.scrollTop = div.scrollHeight;
+    }
+}
+
+function addDebug(msg) {
+    const el = document.getElementById('debug');
+    if (el) {
+        el.value += msg + '\n';
+        el.scrollTop = el.scrollHeight;
+    }
+}
+
+function generateGpx() {
+    fetch('/gpx').then(r => r.blob()).then(blob => {
+        const url = URL.createObjectURL(blob);
+        const link = document.getElementById('gpx-link');
+        link.href = url;
+        link.download = 'records.gpx';
+        link.style.display = 'inline';
+        link.textContent = 'Download GPX';
+    }).catch(err => addDebug('GPX error: ' + err));
 }
 
 function colorForRoughness(r, min, max) {
@@ -331,7 +382,10 @@ function loadData() {
 initMap();
 populateDeviceIds();
 syncRanges();
-document.getElementById('load').addEventListener('click', loadData);
+document.getElementById('load').addEventListener('click', () => {
+    addLog('Load pressed');
+    loadData();
+});
 document.getElementById('deviceId').addEventListener('change', () => {
     selectedIds = Array.from(document.getElementById('deviceId').selectedOptions)
         .map(o => o.value).filter(v => v);
@@ -339,7 +393,14 @@ document.getElementById('deviceId').addEventListener('change', () => {
     loadNickname();
 });
 document.getElementById('roughness-filter').addEventListener('change', loadData);
-document.getElementById('save-nickname').addEventListener('click', saveNickname);
+document.getElementById('save-nickname').addEventListener('click', () => {
+    addLog('Save Nickname pressed');
+    saveNickname();
+});
+document.getElementById('gpx-button').addEventListener('click', () => {
+    addLog('Generate GPX pressed');
+    generateGpx();
+});
 let sliderUpdating = false;
 document.getElementById('startDate').addEventListener('change', () => {
     if (sliderUpdating) return;
@@ -366,18 +427,6 @@ document.getElementById('endRange').addEventListener('input', () => {
     syncRanges();
     loadData();
     sliderUpdating = false;
-});
-document.getElementById('fullscreen-button').addEventListener('click', () => {
-    const el = document.getElementById('map');
-    if (!document.fullscreenElement) {
-        if (el.requestFullscreen) {
-            el.requestFullscreen();
-        }
-    } else {
-        if (document.exitFullscreen) {
-            document.exitFullscreen();
-        }
-    }
 });
 
 document.addEventListener('fullscreenchange', () => {

--- a/static/experimental.html
+++ b/static/experimental.html
@@ -25,6 +25,7 @@
         #status { margin-bottom: 1rem; font-weight: bold; }
         #button-bar { margin-bottom: 1rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
         button { padding: 0.5rem 1rem; font-size: 1rem; }
+        #toggle { padding: 1rem 2rem; font-size: 1.25rem; }
         #scale-container {
             display: flex;
             align-items: center;
@@ -47,7 +48,7 @@
     <a href="db.html">DB Page</a> |
     <a href="maintenance.html">Maintenance</a>
 </nav>
-<section id="filters" style="margin-bottom:1rem;">
+<section id="filter-dev" style="margin-bottom:1rem;">
     <select id="device-filter" multiple></select>
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
@@ -80,12 +81,10 @@
     <div id="status"></div>
     <div id="button-bar">
         <button id="toggle">Start</button>
-        <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
         <button id="update-button" style="margin-left:1rem; display:none;">Update Records</button>
-        <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
         <input id="nickname" placeholder="Nickname" style="margin-left:1rem; display:none;" />
         <button id="save-nickname" style="margin-left:0.5rem; display:none;">Save</button>
-        <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
+        
     </div>
     <div id="loading" style="display:none; margin-top:1rem;">
         <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
@@ -280,6 +279,27 @@ function initMap() {
     } else {
         setView(defaultPos);
     }
+    addFullscreenControl(map);
+}
+
+function addFullscreenControl(m) {
+    const Full = L.Control.extend({
+        onAdd: function() {
+            const btn = L.DomUtil.create('button', 'leaflet-bar');
+            btn.textContent = '⤢';
+            L.DomEvent.on(btn, 'click', () => {
+                const el = m.getContainer();
+                addLog('Fullscreen button pressed');
+                if (!document.fullscreenElement) {
+                    el.requestFullscreen?.();
+                } else {
+                    document.exitFullscreen?.();
+                }
+            });
+            return btn;
+        }
+    });
+    m.addControl(new Full({position:'topleft'}));
 }
 
 function addLog(msg) {
@@ -558,16 +578,6 @@ function pollDebug() {
     }).catch(console.error).finally(() => setTimeout(pollDebug, 2000));
 }
 
-function generateGpx() {
-    fetch('/gpx').then(r => r.blob()).then(blob => {
-        const url = URL.createObjectURL(blob);
-        const link = document.getElementById('gpx-link');
-        link.href = url;
-        link.download = 'records.gpx';
-        link.style.display = 'inline';
-        link.textContent = 'Download GPX';
-    }).catch(err => addDebug('GPX error: ' + err));
-}
 
 updateStatus();
 initMap();
@@ -631,10 +641,6 @@ document.getElementById('toggle').addEventListener('click', () => {
     }
 });
 
-document.getElementById('gpx-button').addEventListener('click', () => {
-    addLog('Generate GPX pressed');
-    generateGpx();
-});
 const updateBtn = document.getElementById('update-button');
 if (updateBtn) {
     updateBtn.addEventListener('click', () => {
@@ -666,19 +672,6 @@ document.getElementById('freq-max').addEventListener('keydown', e => {
     if (e.key === 'Enter') applyFreqFilter();
 });
 document.getElementById('recalc-btn').addEventListener('click', recalcAll);
-document.getElementById('fullscreen-button').addEventListener('click', () => {
-    const el = document.getElementById('map');
-    addLog('Fullscreen button pressed');
-    if (!document.fullscreenElement) {
-        if (el.requestFullscreen) {
-            el.requestFullscreen();
-        }
-    } else {
-        if (document.exitFullscreen) {
-            document.exitFullscreen();
-        }
-    }
-});
 
 document.addEventListener('fullscreenchange', () => {
     if (map) {

--- a/static/index.html
+++ b/static/index.html
@@ -25,6 +25,7 @@
         #status { margin-bottom: 1rem; font-weight: bold; }
         #button-bar { margin-bottom: 1rem; display:flex; flex-wrap:wrap; gap:0.5rem; }
         button { padding: 0.5rem 1rem; font-size: 1rem; }
+        #toggle { padding: 1rem 2rem; font-size: 1.25rem; }
         #scale-container {
             display: flex;
             align-items: center;
@@ -47,7 +48,7 @@
     <a href="db.html">DB Page</a> |
     <a href="maintenance.html">Maintenance</a>
 </nav>
-<section id="filters" style="margin-bottom:1rem;">
+<section id="filter-dev" style="margin-bottom:1rem;">
     <select id="device-filter" multiple></select>
     <select id="roughness-filter" multiple>
         <option value="">[All Roughness]</option>
@@ -73,12 +74,9 @@
     <div id="status"></div>
     <div id="button-bar">
         <button id="toggle">Start</button>
-        <button id="gpx-button" style="margin-left:1rem;">Generate GPX</button>
         <button id="update-button" style="margin-left:1rem; display:none;">Update Records</button>
-        <button id="fullscreen-button" style="margin-left:1rem;">Fullscreen</button>
         <input id="nickname" placeholder="Nickname" style="margin-left:1rem; display:none;" />
         <button id="save-nickname" style="margin-left:0.5rem; display:none;">Save</button>
-        <a id="gpx-link" style="display:none; margin-left:1rem;">Download GPX</a>
     </div>
     <div id="loading" style="display:none; margin-top:1rem;">
         <progress id="load-progress" value="0" max="0" style="width:100%;"></progress>
@@ -251,6 +249,27 @@ function initMap() {
     } else {
         setView(defaultPos);
     }
+    addFullscreenControl(map);
+}
+
+function addFullscreenControl(m) {
+    const Full = L.Control.extend({
+        onAdd: function() {
+            const btn = L.DomUtil.create('button', 'leaflet-bar');
+            btn.textContent = '⤢';
+            L.DomEvent.on(btn, 'click', () => {
+                const el = m.getContainer();
+                addLog('Fullscreen button pressed');
+                if (!document.fullscreenElement) {
+                    el.requestFullscreen?.();
+                } else {
+                    document.exitFullscreen?.();
+                }
+            });
+            return btn;
+        }
+    });
+    m.addControl(new Full({ position: 'topleft' }));
 }
 
 function addLog(msg) {
@@ -526,16 +545,7 @@ function pollDebug() {
     }).catch(console.error).finally(() => setTimeout(pollDebug, 2000));
 }
 
-function generateGpx() {
-    fetch('/gpx').then(r => r.blob()).then(blob => {
-        const url = URL.createObjectURL(blob);
-        const link = document.getElementById('gpx-link');
-        link.href = url;
-        link.download = 'records.gpx';
-        link.style.display = 'inline';
-        link.textContent = 'Download GPX';
-    }).catch(err => addDebug('GPX error: ' + err));
-}
+
 
 updateStatus();
 initMap();
@@ -554,10 +564,6 @@ document.getElementById('toggle').addEventListener('click', () => {
     }
 });
 
-document.getElementById('gpx-button').addEventListener('click', () => {
-    addLog('Generate GPX pressed');
-    generateGpx();
-});
 const updateBtn = document.getElementById('update-button');
 if (updateBtn) {
     updateBtn.addEventListener('click', () => {
@@ -580,19 +586,6 @@ document.getElementById('device-filter').addEventListener('change', () => {
 });
 document.getElementById('roughness-filter').addEventListener('change', () => {
     loadLogs();
-});
-document.getElementById('fullscreen-button').addEventListener('click', () => {
-    const el = document.getElementById('map');
-    addLog('Fullscreen button pressed');
-    if (!document.fullscreenElement) {
-        if (el.requestFullscreen) {
-            el.requestFullscreen();
-        }
-    } else {
-        if (document.exitFullscreen) {
-            document.exitFullscreen();
-        }
-    }
 });
 
 document.addEventListener('fullscreenchange', () => {

--- a/static/login.html
+++ b/static/login.html
@@ -42,11 +42,29 @@ async function doLogin() {
     if (res.ok) {
         const params = new URLSearchParams(location.search);
         const next = params.get('next') || '/';
+        addLog('Login successful');
         location.href = next;
     } else {
         alert('Wrong password');
+        addLog('Login failed');
         document.getElementById('pw').value = '';
         document.getElementById('pw').focus();
+    }
+}
+
+function addLog(msg) {
+    const div = document.getElementById('log');
+    if (div) {
+        div.textContent += msg + '\n';
+        div.scrollTop = div.scrollHeight;
+    }
+}
+
+function addDebug(msg) {
+    const el = document.getElementById('debug');
+    if (el) {
+        el.value += msg + '\n';
+        el.scrollTop = el.scrollHeight;
     }
 }
 </script>

--- a/static/welcome.html
+++ b/static/welcome.html
@@ -25,7 +25,23 @@
     <h3>Activity Log</h3>
     <div id="log"></div>
     <h3>Debug Messages</h3>
-    <textarea id="debug" readonly></textarea>
+<textarea id="debug" readonly></textarea>
 </section>
+<script>
+function addLog(msg) {
+    const div = document.getElementById('log');
+    if (div) {
+        div.textContent += msg + '\n';
+        div.scrollTop = div.scrollHeight;
+    }
+}
+function addDebug(msg) {
+    const el = document.getElementById('debug');
+    if (el) {
+        el.value += msg + '\n';
+        el.scrollTop = el.scrollHeight;
+    }
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reorganize filter sections and table controls
- move GPX generation to the device view
- embed fullscreen toggle inside maps
- enlarge start/stop buttons
- ensure actions append messages to page logs

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68766f9296308320a5e954975fdb9bcc