### PR TITLE
Improve DB page date range handling

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -295,10 +295,33 @@ function updateMap(rows) {
     });
 }
 
+function setDateLimits(rows) {
+    const startInput = document.getElementById('filter-start');
+    const endInput = document.getElementById('filter-end');
+    if (!startInput || !endInput || !rows || rows.length === 0) return;
+    const stamps = rows
+        .map(r => Date.parse(r.timestamp))
+        .filter(t => !isNaN(t));
+    if (stamps.length === 0) return;
+    const min = new Date(Math.min(...stamps));
+    const max = new Date(Math.max(...stamps));
+    const toLocalIso = d => new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+            .toISOString().slice(0,16);
+    const minStr = toLocalIso(min);
+    const maxStr = toLocalIso(max);
+    startInput.min = minStr;
+    startInput.max = maxStr;
+    endInput.min = minStr;
+    endInput.max = maxStr;
+    if (!startInput.value) startInput.value = minStr;
+    if (!endInput.value) endInput.value = maxStr;
+}
+
 async function loadLogs() {
     const res = await authFetch('/logs');
     const data = await res.json();
     const rows = Array.isArray(data) ? data : data.rows;
+    setDateLimits(rows);
     updateMap(rows);
 }
 
@@ -432,6 +455,7 @@ async function loadSelectedTable() {
     currentTable = tableName;
     setCurrentColumns(rows.length > 0 ? Object.keys(rows[0]) : []);
     tableRows = rows;
+    setDateLimits(rows);
     if (showTable) {
         renderTable(tableName, rows);
         document.getElementById('output').style.display='block';
@@ -495,6 +519,7 @@ async function loadFiltered() {
     currentTable = 'bike_data';
     setCurrentColumns(rows.length > 0 ? Object.keys(rows[0]) : []);
     tableRows = rows;
+    setDateLimits(rows);
     if (showTable) {
         renderTable('bike_data', rows);
         document.getElementById('output').style.display='block';
@@ -577,6 +602,9 @@ document.getElementById('filter-device').addEventListener('change', loadFiltered
 document.getElementById('roughness-filter').addEventListener('change', () => {
     updateMap(tableRows);
 });
+document.getElementById('filter-start').addEventListener('change', loadFiltered);
+document.getElementById('filter-end').addEventListener('change', loadFiltered);
+document.getElementById('filter-ids').addEventListener('change', loadFiltered);
 loadLogs();
 loadSelected();
 </script>


### PR DESCRIPTION
## Summary
- update db page to auto-load when range filters change
- set date pickers to table min/max when data loads
- refresh map after selecting a roughness table

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687687d272348320b1d20fc471ba9850