### PR TITLE
Add table range API and auto-refresh in DB page

### DIFF
--- a/static/db.html
+++ b/static/db.html
@@ -317,6 +317,16 @@ async function loadTables(selected) {
     if (!select.value && select.options.length > 0)
         select.value = select.options[0].value;
 }
+
+async function setDateRange() {
+    const tableName = document.getElementById('table-select').value;
+    if (!tableName) return;
+    const res = await authFetch('/manage/table_range?table=' + encodeURIComponent(tableName));
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.start) document.getElementById('filter-start').value = data.start.slice(0,19);
+    if (data.end) document.getElementById('filter-end').value = data.end.slice(0,19);
+}
 async function insertTest() {
     const t = document.getElementById('table-select').value; if(!t) return;
     addLog('Insert Test Data pressed');
@@ -439,6 +449,7 @@ async function loadSelectedTable() {
         document.getElementById('output').style.display='none';
     }
     updateMap(rows);
+    setDateRange();
 }
 async function renameTable() {
     const t = document.getElementById('table-select').value; if(!t) return;
@@ -571,9 +582,14 @@ function toggleTable() {
 }
 initMap();
 populateDeviceOptions();
-loadTables().then(() => { loadSelectedTable(); });
-document.getElementById('table-select').addEventListener('change', loadSelectedTable);
+loadTables().then(() => { loadSelectedTable(); setDateRange(); });
+document.getElementById('table-select').addEventListener('change', () => {
+    loadSelectedTable();
+    setDateRange();
+});
 document.getElementById('filter-device').addEventListener('change', loadFiltered);
+document.getElementById('filter-start').addEventListener('change', loadFiltered);
+document.getElementById('filter-end').addEventListener('change', loadFiltered);
 document.getElementById('roughness-filter').addEventListener('change', () => {
     updateMap(tableRows);
 });


### PR DESCRIPTION
## Summary
- add `/manage/table_range` endpoint for getting timestamp range of a table
- auto-update date range and reload data when table or filter values change in `db.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768cc9d7d0832095021a4018e9f019