### PR TITLE
Show all device data by default

### DIFF
--- a/static/device.html
+++ b/static/device.html
@@ -100,7 +100,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const currentDeviceId = localStorage.getItem('deviceId');
-let selectedIds = currentDeviceId ? [currentDeviceId] : [];
+let selectedIds = [];
 let map;
 let deviceNicknames = {};
 let currentNickname = '';
@@ -150,7 +150,12 @@ function populateDeviceIds() {
             if (selectedIds.includes(o.value)) o.selected = true;
         });
         selectedIds = Array.from(sel.selectedOptions).map(o => o.value).filter(v => v);
-    }).then(() => { setDateRange(); loadNickname(); }).catch(console.error);
+    }).then(() =>
+        setDateRange().then(() => {
+            loadNickname();
+            loadData();
+        })
+    ).catch(console.error);
 }
 
 function setDateRange() {


### PR DESCRIPTION
## Summary
- load all roughness records when visiting the device page
- don't auto-select the saved device by default

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b5ee3bdf08320933579d2456598cd