### PR TITLE
Fix map update loop

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -543,7 +543,7 @@ function handlePosition(pos) {
                 scale.max = Math.max(scale.max, data.roughness);
                 roughScales[deviceId] = scale;
                 recordCount += 1;
-                loadLogs();
+                // Do not reload all logs during active recording
             }
         }).catch(err => addDebug('Error: ' + err));
         xValues = [];


### PR DESCRIPTION
## Summary
- stop calling `loadLogs` after each record

## Testing
- `pytest -q` *(skipped: no Python changes)*

------
https://chatgpt.com/codex/tasks/task_e_687b6d01c9308320b23144631c454e9c