### PR TITLE
Fix stray body tag in index page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -117,7 +117,6 @@
 <nav id="page-links" style="margin-bottom:1rem;">
     <a href="device.html">Device View</a>
 </nav>
-</body>
 <!-- Hidden maintenance link as a square at bottom right -->
 <a href="maintenance.html" id="maintenance-link" style="position:fixed;bottom:24px;right:24px;width:32px;height:32px;display:block;z-index:9999;opacity:0.2;background:#888;border-radius:6px;text-align:center;line-height:32px;text-decoration:none;font-size:1.5rem;transition:opacity 0.2s;" title="Maintenance">🛠️</a>
 <script>


### PR DESCRIPTION
## Summary
- remove unintended closing `</body>` tag inside `index.html`

## Testing
- `grep -n '</body>' -n static/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6880e4173a8883208ac6df861758eb5d