### PR TITLE
Fix date range defaults on device page

### DIFF
--- a/database.py
+++ b/database.py
@@ -923,8 +923,14 @@ class DatabaseManager:
             row = cursor.fetchone()
             start, end = row if row else (None, None)
             
-            start_str = start.isoformat() if start else None
-            end_str = end.isoformat() if end else None
+            if start is not None:
+                start_str = start.isoformat() if hasattr(start, "isoformat") else str(start)
+            else:
+                start_str = None
+            if end is not None:
+                end_str = end.isoformat() if hasattr(end, "isoformat") else str(end)
+            else:
+                end_str = None
             return start_str, end_str
         finally:
             conn.close()

--- a/static/device.html
+++ b/static/device.html
@@ -184,8 +184,8 @@ function setDateRange() {
         url = '/date_range?' + params.toString();
     }
     return fetch(url).then(r => r.json()).then(data => {
-        if (data.start) document.getElementById('startDate').value = data.start.slice(0,19);
-        if (data.end) document.getElementById('endDate').value = data.end.slice(0,19);
+        if (data.start) document.getElementById('startDate').value = toCESTDateTimeLocal(data.start);
+        if (data.end) document.getElementById('endDate').value = toCESTDateTimeLocal(data.end);
         sliderMin = Date.parse(data.start);
         sliderMax = Date.parse(data.end);
         syncRanges();


### PR DESCRIPTION
## Summary
- handle string timestamps in `get_date_range`
- convert date range defaults to local time in `device.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e85cd88c83208ff1b5deceeb2d14