### PR TITLE
Fix speed computation preventing data insertion

### DIFF
--- a/main.py
+++ b/main.py
@@ -415,6 +415,8 @@ def post_log(entry: LogEntry, request: Request):
             f"Calculated avg speed: {computed_speed:.2f} km/h over {dt_sec:.1f}s and {dist_km * 1000.0:.1f}m",
             device_id=entry.device_id,
         )
+        if computed_speed > 0:
+            avg_speed = computed_speed
 
     if dt_sec > MAX_INTERVAL_SEC or dist_km * 1000.0 > MAX_DISTANCE_M:
         log_warning(
@@ -453,7 +455,7 @@ def post_log(entry: LogEntry, request: Request):
         bike_data_id = db_manager.insert_bike_data(
             entry.latitude,
             entry.longitude,
-            entry.speed,
+            avg_speed,
             entry.direction,
             roughness,
             distance_m,

--- a/test_speed_calc.py
+++ b/test_speed_calc.py
@@ -1,0 +1,36 @@
+import time
+from fastapi.testclient import TestClient
+from main import app
+from database import db_manager, TABLE_BIKE_DATA
+
+client = TestClient(app)
+
+def test_computed_speed_allows_insert(tmp_path):
+    device_id = f"test-speed-{int(time.time())}"
+    db_manager.init_tables()
+    count_before = db_manager.execute_scalar(
+        f"SELECT COUNT(*) FROM {TABLE_BIKE_DATA} WHERE device_id=?", (device_id,)
+    ) or 0
+    payload1 = {
+        "latitude": 52.0,
+        "longitude": 5.0,
+        "speed": 0.0,
+        "direction": 0.0,
+        "device_id": device_id,
+        "z_values": [0.1, 0.2],
+    }
+    client.post("/log", json=payload1)
+    payload2 = {
+        "latitude": 52.0005,
+        "longitude": 5.0005,
+        "speed": 0.0,
+        "direction": 0.0,
+        "device_id": device_id,
+        "z_values": [0.1, 0.2],
+    }
+    resp = client.post("/log", json=payload2)
+    assert resp.status_code == 200
+    count_after = db_manager.execute_scalar(
+        f"SELECT COUNT(*) FROM {TABLE_BIKE_DATA} WHERE device_id=?", (device_id,)
+    )
+    assert count_after > count_before


### PR DESCRIPTION
## Summary
- compute average speed from distance/time when GPS speed is missing
- store computed speed in the database
- add regression test verifying insertion with zero GPS speed

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824d75bd5083208bb658612bc650b2