### PR TITLE
Fix GPS indicator update on data reception

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -954,6 +954,10 @@ function handlePosition(pos) {
     lastSpeed = (speed || 0) * 3.6; // convert to km/h
     lastDir = heading || 0;
     
+    // Update status indicator when GPS data is received
+    locationStatus = true;
+    updateStatusIndicator('location', true, 'GPS data received');
+
     // Update user location
     userLocation = [latitude, longitude];
     


### PR DESCRIPTION
## Summary
- update status indicator when GPS data is received so the location light turns green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882b70e13508320a186258d2d0c9633