### PR TITLE
Fix APP_PATH usage for Azure startup

### DIFF
--- a/azure_startup.sh
+++ b/azure_startup.sh
@@ -9,11 +9,13 @@ export PYTHONIOENCODING=utf-8
 export PYTHONWARNINGS="ignore::SyntaxWarning,ignore::DeprecationWarning,ignore::PendingDeprecationWarning"
 
 # Navigate to application directory
-cd /home/site/wwwroot || exit 1
+# Use Oryx-provided APP_PATH if available
+APP_DIR="${APP_PATH:-/home/site/wwwroot}"
+cd "$APP_DIR" || exit 1
 
 # Verify main application file exists
 if [ ! -f "main.py" ]; then
-    echo "❌ main.py not found"
+    echo "❌ main.py not found in $APP_DIR"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- make azure_startup.sh use APP_PATH so main.py is found

## Testing
- `python tests/test_runner.py` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884b788468483208bc5bda73540c37c