### PR TITLE
Set fiets as default login password

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ The application automatically falls back from Azure SQL to SQLite if Azure crede
 ### Authentication System
 - Cookie-based authentication with MD5 password hashing
 - Management endpoints require authentication
-- Default password hash: "df5f648063a4a2793f5f0427b210f4f7"
+- Default password hash: "08457aa99f426e5e8410798acd74c23b" ("fiets")
 
 ## API Endpoints
 

--- a/main.py
+++ b/main.py
@@ -71,7 +71,8 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Road Condition Indexer", lifespan=lifespan)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 
-PASSWORD_HASH = "e28f6f1ab660f33fda13a0a9a42e2b3d"
+# MD5 hash for the default password "fiets"
+PASSWORD_HASH = "08457aa99f426e5e8410798acd74c23b"
 
 # Thresholds for log filtering
 MAX_INTERVAL_SEC = float(os.getenv("RCI_MAX_INTERVAL_SEC", "15"))


### PR DESCRIPTION
## Summary
- update PASSWORD_HASH to match the MD5 of `fiets`
- document the new password hash in `AGENTS.md`

## Testing
- `python tests/test_runner.py` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e119146c83208c4055f8bd07ec6f