### PR TITLE
Remove robots.txt endpoint

### DIFF
--- a/AUTHENTICATION_FIXES.md
+++ b/AUTHENTICATION_FIXES.md
@@ -117,7 +117,6 @@ def get_logs(request: Request, limit: Optional[int] = None, dep: None = Depends(
 - `/login` - Authentication endpoint
 - `/auth_check` - Session validation
 - `/health` - Health check for monitoring
-- `/robots.txt` - Search engine directives
 - `/utils.js`, `/leaflet.css`, `/leaflet.js` - Required static assets
 - `/static/login.html` - Login page access
 

--- a/main.py
+++ b/main.py
@@ -267,12 +267,6 @@ def health_check():
         )
 
 
-# Respond to Azure's robots.txt health probes
-@app.get("/robots.txt", include_in_schema=False)
-@app.get("/robots{suffix}.txt", include_in_schema=False)
-def robots_txt(suffix: str = ""):
-    """Serve minimal robots.txt for health checks."""
-    return Response(content="User-agent: *\nDisallow:", media_type="text/plain")
 
 @app.get("/")
 def read_index(request: Request):


### PR DESCRIPTION
## Summary
- remove unused `/robots.txt` FastAPI route that interfered with automation
- update authentication fixes documentation

## Testing
- `RCI_TEST_MODE=database_only python tests/test_runner.py` *(fails: unable to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_6885dcac58108320b0b7543941669061