### PR TITLE
Centralize device id generation

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -368,17 +368,8 @@ function initializePage() {
     setInterval(checkDatabaseStatus, 30000);
 }
 
-let deviceId = localStorage.getItem('deviceId');
+let deviceId = initializeDeviceId();
 let selectedIds = deviceId ? [deviceId] : [];
-function setCookie(name, value, days) {
-    const expires = new Date(Date.now() + days * 864e5).toUTCString();
-    document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
-}
-if (!deviceId) {
-    deviceId = crypto.randomUUID();
-    localStorage.setItem('deviceId', deviceId);
-    setCookie('deviceId', deviceId, 365);
-}
 
 // Initialize source data recording toggle from localStorage
 let recordSourceData = localStorage.getItem('recordSourceData') === 'true';

--- a/static/logs-partial.html
+++ b/static/logs-partial.html
@@ -261,17 +261,6 @@
 let allLogMessages = [];
 let deviceId = '';
 
-// Initialize device ID from localStorage or generate new one
-function initializeDeviceId() {
-    deviceId = localStorage.getItem('deviceId') || '';
-    if (!deviceId) {
-        deviceId = crypto.randomUUID ? crypto.randomUUID() : 'unknown-' + Date.now();
-        localStorage.setItem('deviceId', deviceId);
-    }
-    // Take only last 8 characters for display
-    deviceId = deviceId.slice(-8);
-}
-
 // Format short date/time
 function formatShortDateTime() {
     const now = new Date();
@@ -484,7 +473,10 @@ function toggleLogs() {
 
 // Initialize when partial is loaded
 function initializeLogs() {
-    initializeDeviceId();
+    if (typeof window.initializeDeviceId === 'function') {
+        window.initializeDeviceId();
+    }
+    deviceId = (window.deviceId || '').slice(-8);
     // Add event listeners for filters
     const levelFilter = document.getElementById('log-level-filter');
     const categoryFilter = document.getElementById('log-category-filter');

--- a/static/utils.js
+++ b/static/utils.js
@@ -487,8 +487,15 @@ async function loadLogsPartial() {
 function initializeDeviceId() {
     let deviceId = localStorage.getItem('deviceId');
     if (!deviceId) {
-        deviceId = 'device-' + Math.random().toString(36).substr(2, 16);
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            deviceId = window.crypto.randomUUID();
+        } else {
+            deviceId = 'device-' + Date.now().toString(36) + '-' + Math.random().toString(36).substring(2, 8);
+        }
         localStorage.setItem('deviceId', deviceId);
+        if (typeof setCookie === 'function') {
+            setCookie('deviceId', deviceId, 365);
+        }
     }
     window.deviceId = deviceId;
     return deviceId;


### PR DESCRIPTION
## Summary
- centralize device ID creation in `utils.js`
- rely on `initializeDeviceId()` in `index.html`
- use the centralized helper in `logs-partial.html`

## Testing
- `python tests/test_runner.py` *(fails: Adaptive Server is unavailable or does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6885ddfbfc888320a72ea5bb410f3063