### PR TITLE
Add Text Compare tool

### DIFF
--- a/static/tools.html
+++ b/static/tools.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jsoneditor@10.0.3/dist/jsoneditor.min.js"></script>
     <link rel="stylesheet" href="/static/lib/simple-json-diff.css">
     <script src="/static/lib/simple-json-diff.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/diff@5.1.0/dist/diff.min.js"></script>
     <style>
         body { font-family: Arial, sans-serif; margin: 0 auto; padding: 1rem; max-width: 1000px; }
         #page-links { margin-bottom: 1rem; }
@@ -65,6 +66,7 @@
         .diff-modified { background-color: #fff3cd; border-left: 3px solid #ffc107; }
         .diff-unchanged { background-color: #f8f9fa; }
         .hidden { display: none !important; }
+        .diff-line { white-space: pre; }
     </style>
 </head>
 <body>
@@ -208,7 +210,43 @@
         <div id="json-merge-result" class="result-box"></div>
     </div>
 </div>
-	
+
+<!-- Text Compare Section -->
+<div class="section">
+    <div class="section-header" onclick="toggleSection('text-compare')">
+        <span>📝 Text Compare</span>
+        <span class="section-toggle" id="text-compare-toggle">▶</span>
+    </div>
+    <div class="section-content" id="text-compare-content">
+        <div class="compare-grid">
+            <div class="json-col">
+                <h4>Original</h4>
+                <div id="textA-drop" class="json-drop">Drag & drop file A here</div>
+                <div style="margin:6px 0;">
+                    <input type="file" id="textA-file">
+                    <span id="textA-name" style="font-size:0.9em;color:#555;margin-left:6px;"></span>
+                </div>
+                <textarea id="textA-text" rows="12" style="width:100%;" placeholder="Paste original text here..."></textarea>
+            </div>
+            <div class="json-col">
+                <h4>Modified</h4>
+                <div id="textB-drop" class="json-drop">Drag & drop file B here</div>
+                <div style="margin:6px 0;">
+                    <input type="file" id="textB-file">
+                    <span id="textB-name" style="font-size:0.9em;color:#555;margin-left:6px;"></span>
+                </div>
+                <textarea id="textB-text" rows="12" style="width:100%;" placeholder="Paste modified text here..."></textarea>
+            </div>
+        </div>
+        <div class="diff-controls" style="margin-top:8px;">
+            <label><input type="checkbox" id="show-added" checked> Show Added</label>
+            <label><input type="checkbox" id="show-removed" checked> Show Removed</label>
+            <label><input type="checkbox" id="show-modified" checked> Show Modified</label>
+        </div>
+        <div id="text-compare-result" class="diff-content"></div>
+    </div>
+</div>
+
 <!-- Video Downloader Section -->
 <div class="section">
     <div class="section-header" onclick="toggleSection('video-downloader')">
@@ -613,6 +651,80 @@ jsonMergeDownloadBtn.addEventListener('click', () => {
     a.click();
     URL.revokeObjectURL(url);
 });
+
+// Text Compare tool
+const textAFile = document.getElementById('textA-file');
+const textBFile = document.getElementById('textB-file');
+const textAName = document.getElementById('textA-name');
+const textBName = document.getElementById('textB-name');
+const textADrop = document.getElementById('textA-drop');
+const textBDrop = document.getElementById('textB-drop');
+const textAText = document.getElementById('textA-text');
+const textBText = document.getElementById('textB-text');
+const textCompareResult = document.getElementById('text-compare-result');
+const showAdded = document.getElementById('show-added');
+const showRemoved = document.getElementById('show-removed');
+const showModified = document.getElementById('show-modified');
+
+textAFile.addEventListener('change', e => readTextFileInto(e.target.files && e.target.files[0], textAText, textAName));
+textBFile.addEventListener('change', e => readTextFileInto(e.target.files && e.target.files[0], textBText, textBName));
+
+;['dragenter','dragover'].forEach(evt => {
+    [textADrop, textBDrop].forEach(el => el.addEventListener(evt, e => { e.preventDefault(); el.classList.add('hover'); }));
+});
+;['dragleave','drop'].forEach(evt => {
+    [textADrop, textBDrop].forEach(el => el.addEventListener(evt, e => { e.preventDefault(); el.classList.remove('hover'); }));
+});
+textADrop.addEventListener('drop', e => readTextFileInto(e.dataTransfer.files && e.dataTransfer.files[0], textAText, textAName));
+textBDrop.addEventListener('drop', e => readTextFileInto(e.dataTransfer.files && e.dataTransfer.files[0], textBText, textBName));
+
+[textAText, textBText].forEach(el => el.addEventListener('input', compareText));
+
+showAdded.addEventListener('change', applyTextFilters);
+showRemoved.addEventListener('change', applyTextFilters);
+showModified.addEventListener('change', applyTextFilters);
+
+function readTextFileInto(file, target, nameEl) {
+    if (!file) { if (nameEl) nameEl.textContent=''; return; }
+    if (nameEl) nameEl.textContent = file.name;
+    const reader = new FileReader();
+    reader.onload = ev => { target.value = ev.target.result || ''; compareText(); };
+    reader.onerror = () => alert('Failed to read file.');
+    reader.readAsText(file);
+}
+
+function compareText() {
+    const a = textAText.value;
+    const b = textBText.value;
+    if (!a || !b) { textCompareResult.innerHTML = ''; return; }
+    const diff = Diff.diffLines(a, b);
+    let html = '';
+    for (let i = 0; i < diff.length; i++) {
+        const part = diff[i];
+        if (part.added && diff[i-1] && diff[i-1].removed) {
+            const removedPart = diff[i-1];
+            html += removedPart.value.split('\n').map(line => line ? `<div class="diff-line diff-modified">- ${escapeHtml(line)}</div>` : '').join('');
+            html += part.value.split('\n').map(line => line ? `<div class="diff-line diff-modified">+ ${escapeHtml(line)}</div>` : '').join('');
+        } else if (part.removed && diff[i+1] && diff[i+1].added) {
+            continue;
+        } else {
+            const cls = part.added ? 'diff-added' : part.removed ? 'diff-removed' : 'diff-unchanged';
+            const prefix = part.added ? '+ ' : part.removed ? '- ' : '  ';
+            html += part.value.split('\n').map(line => line ? `<div class="diff-line ${cls}">${prefix}${escapeHtml(line)}</div>` : '').join('');
+        }
+    }
+    textCompareResult.innerHTML = html;
+    applyTextFilters();
+}
+
+function applyTextFilters() {
+    const showA = showAdded.checked;
+    const showR = showRemoved.checked;
+    const showM = showModified.checked;
+    textCompareResult.querySelectorAll('.diff-added').forEach(el => el.classList.toggle('hidden', !showA));
+    textCompareResult.querySelectorAll('.diff-removed').forEach(el => el.classList.toggle('hidden', !showR));
+    textCompareResult.querySelectorAll('.diff-modified').forEach(el => el.classList.toggle('hidden', !showM));
+}
 
 function parseJsonSafe(text, which) {
     try {


### PR DESCRIPTION
## Summary
- add Text Compare tool for side-by-side text comparison
- highlight added/removed/modified lines and allow filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bef436b5ac8320858ea43a10e7cfbc