### PR TITLE
Add memo recording workflow with speech transcription

### DIFF
--- a/static/memo.html
+++ b/static/memo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Memo's</title>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <link rel="stylesheet" href="/static/site.css">
+    <script src="/static/utils.js" defer></script>
+    <script src="/static/memo.js" defer></script>
+</head>
+<body>
+
+<nav id="page-links" class="page-links mb-1">
+    <a href="/">Main</a>
+    <a href="device.html">Device View</a>
+    <a href="database.html">Database Management</a>
+    <a href="maintenance.html">Maintenance</a>
+    <a href="tools.html">Tools</a>
+    <a href="memo.html" aria-current="page">Memo's</a>
+    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
+</nav>
+
+<h1 id="memo-page-title">
+    <img src="/static/logo.png" alt="Road Condition Indexer" class="rci-logo">
+    Memo's
+</h1>
+
+<main class="memo-layout" aria-labelledby="memo-page-title">
+    <section class="memo-controls rci-card" aria-labelledby="memo-create-heading">
+        <div class="memo-section-header">
+            <h2 id="memo-create-heading">Nieuwe memo opnemen</h2>
+            <p class="memo-description">Houd de knop ingedrukt en spreek om een memo op te nemen. Laat los om het transcript op te slaan.</p>
+        </div>
+        <div class="memo-record-wrapper">
+            <button id="memo-record-btn" type="button" class="memo-record-btn focus-ring">
+                🎙️ Houd ingedrukt om op te nemen
+            </button>
+            <div id="memo-live-transcript" class="memo-live-transcript" aria-live="polite" aria-atomic="true"></div>
+        </div>
+        <div class="memo-divider" role="presentation">of</div>
+        <div class="memo-manual">
+            <label for="memo-manual-input" class="memo-label">Typ een memo</label>
+            <textarea id="memo-manual-input" rows="3" placeholder="Schrijf hier je memo..."></textarea>
+            <button id="memo-manual-save" type="button" class="memo-manual-btn focus-ring">Memo opslaan</button>
+        </div>
+        <div id="memo-status" class="status-message" role="status" aria-live="polite"></div>
+    </section>
+
+    <section class="memo-list rci-card" aria-labelledby="memo-list-heading">
+        <div class="memo-section-header">
+            <h2 id="memo-list-heading">Memo-overzicht</h2>
+            <p class="rci-muted">De nieuwste memo verschijnt bovenaan.</p>
+        </div>
+        <div id="memo-list" class="memo-card-list" aria-live="polite" aria-atomic="false"></div>
+    </section>
+</main>
+
+</body>
+</html>

--- a/static/memo.js
+++ b/static/memo.js
@@ -1,0 +1,481 @@
+(function () {
+  'use strict';
+
+  const state = {
+    memos: []
+  };
+
+  const recordButton = document.getElementById('memo-record-btn');
+  const liveTranscriptEl = document.getElementById('memo-live-transcript');
+  const manualInput = document.getElementById('memo-manual-input');
+  const manualSaveButton = document.getElementById('memo-manual-save');
+  const statusEl = document.getElementById('memo-status');
+  const memoListEl = document.getElementById('memo-list');
+
+  let statusTimeoutId = null;
+
+  function formatMemoTime(isoString) {
+    if (!isoString) {
+      return '';
+    }
+    try {
+      if (typeof window.formatDutchTime === 'function') {
+        return window.formatDutchTime(isoString);
+      }
+      return new Date(isoString).toLocaleString('nl-NL');
+    } catch (error) {
+      return isoString;
+    }
+  }
+
+  function showStatus(message, type = 'info') {
+    if (!statusEl) {
+      return;
+    }
+
+    statusEl.textContent = message;
+    statusEl.classList.remove('status-success', 'status-error', 'status-warning');
+    statusEl.style.display = 'block';
+
+    const className = type === 'success'
+      ? 'status-success'
+      : type === 'error'
+        ? 'status-error'
+        : type === 'warning'
+          ? 'status-warning'
+          : '';
+
+    if (className) {
+      statusEl.classList.add(className);
+    }
+
+    if (statusTimeoutId) {
+      window.clearTimeout(statusTimeoutId);
+    }
+
+    statusTimeoutId = window.setTimeout(() => {
+      statusEl.style.display = 'none';
+      statusEl.classList.remove('status-success', 'status-error', 'status-warning');
+      statusTimeoutId = null;
+    }, 5000);
+  }
+
+  function clearStatus() {
+    if (!statusEl) {
+      return;
+    }
+    statusEl.style.display = 'none';
+    statusEl.textContent = '';
+    statusEl.classList.remove('status-success', 'status-error', 'status-warning');
+    if (statusTimeoutId) {
+      window.clearTimeout(statusTimeoutId);
+      statusTimeoutId = null;
+    }
+  }
+
+  function renderMemos() {
+    if (!memoListEl) {
+      return;
+    }
+
+    memoListEl.innerHTML = '';
+
+    if (!state.memos.length) {
+      const emptyMessage = document.createElement('p');
+      emptyMessage.className = 'memo-empty';
+      emptyMessage.textContent = 'Nog geen memo\'s opgeslagen.';
+      memoListEl.appendChild(emptyMessage);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    state.memos.forEach((memo) => {
+      fragment.appendChild(createMemoCard(memo));
+    });
+
+    memoListEl.appendChild(fragment);
+  }
+
+  function createMemoCard(memo) {
+    const card = document.createElement('article');
+    card.className = 'memo-card';
+    card.dataset.memoId = String(memo.id);
+
+    if (memo.__highlight) {
+      card.classList.add('memo-card--highlight');
+      window.setTimeout(() => {
+        card.classList.remove('memo-card--highlight');
+        delete memo.__highlight;
+      }, 1600);
+    }
+
+    const header = document.createElement('div');
+    header.className = 'memo-card__header';
+
+    const timestamps = document.createElement('div');
+    timestamps.className = 'memo-card__timestamps';
+
+    const created = document.createElement('span');
+    created.className = 'memo-card__timestamp';
+    created.textContent = `Aangemaakt: ${formatMemoTime(memo.created_at)}`;
+    timestamps.appendChild(created);
+
+    if (memo.updated_at && memo.updated_at !== memo.created_at) {
+      const updated = document.createElement('span');
+      updated.className = 'memo-card__timestamp memo-card__timestamp--updated';
+      updated.textContent = `Bijgewerkt: ${formatMemoTime(memo.updated_at)}`;
+      timestamps.appendChild(updated);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'memo-card__actions';
+
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'memo-edit-btn focus-ring';
+    editButton.textContent = '✏️ Bewerken';
+    actions.appendChild(editButton);
+
+    header.appendChild(timestamps);
+    header.appendChild(actions);
+
+    const content = document.createElement('p');
+    content.className = 'memo-card__content';
+    content.textContent = memo.content;
+
+    const editArea = document.createElement('div');
+    editArea.className = 'memo-edit-area';
+
+    const label = document.createElement('label');
+    label.className = 'sr-only';
+    label.setAttribute('for', `memo-edit-${memo.id}`);
+    label.textContent = 'Bewerk memo';
+
+    const textarea = document.createElement('textarea');
+    textarea.id = `memo-edit-${memo.id}`;
+    textarea.rows = 4;
+    textarea.value = memo.content;
+
+    const editActions = document.createElement('div');
+    editActions.className = 'memo-edit-actions';
+
+    const saveButton = document.createElement('button');
+    saveButton.type = 'button';
+    saveButton.className = 'memo-save-btn focus-ring';
+    saveButton.textContent = 'Opslaan';
+
+    const cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.className = 'memo-cancel-btn focus-ring';
+    cancelButton.textContent = 'Annuleren';
+
+    editActions.appendChild(saveButton);
+    editActions.appendChild(cancelButton);
+
+    editArea.appendChild(label);
+    editArea.appendChild(textarea);
+    editArea.appendChild(editActions);
+
+    card.appendChild(header);
+    card.appendChild(content);
+    card.appendChild(editArea);
+
+    editButton.addEventListener('click', () => {
+      const isEditing = card.classList.toggle('is-editing');
+      if (isEditing) {
+        textarea.focus();
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      } else {
+        textarea.value = memo.content;
+      }
+    });
+
+    cancelButton.addEventListener('click', () => {
+      card.classList.remove('is-editing');
+      textarea.value = memo.content;
+    });
+
+    saveButton.addEventListener('click', async () => {
+      const updatedContent = textarea.value.trim();
+      if (!updatedContent) {
+        showStatus('Memo mag niet leeg zijn.', 'warning');
+        textarea.focus();
+        return;
+      }
+
+      saveButton.disabled = true;
+      saveButton.textContent = 'Opslaan…';
+
+      try {
+        const response = await fetch(`/api/memos/${memo.id}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ content: updatedContent })
+        });
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || data.status !== 'ok') {
+          const detail = data && (data.detail || data.message);
+          throw new Error(detail || 'Onbekende fout bij het bijwerken van de memo.');
+        }
+
+        const updatedMemo = data.memo;
+        if (!updatedMemo) {
+          throw new Error('Ongeldig antwoord van de server.');
+        }
+
+        Object.assign(memo, updatedMemo, { __highlight: true });
+        card.classList.remove('is-editing');
+        renderMemos();
+        showStatus('Memo bijgewerkt.', 'success');
+      } catch (error) {
+        console.error('Failed to update memo', error);
+        showStatus(error.message || 'Bijwerken mislukt.', 'error');
+      } finally {
+        saveButton.disabled = false;
+        saveButton.textContent = 'Opslaan';
+      }
+    });
+
+    return card;
+  }
+
+  async function loadMemos() {
+    try {
+      const response = await fetch('/api/memos');
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data.status !== 'ok') {
+        const detail = data && (data.detail || data.message);
+        throw new Error(detail || 'Memo\'s konden niet geladen worden.');
+      }
+
+      const memos = Array.isArray(data.memos) ? data.memos : [];
+      state.memos = memos;
+      renderMemos();
+    } catch (error) {
+      console.error('Failed to load memos', error);
+      showStatus(error.message || 'Memo\'s konden niet geladen worden.', 'error');
+      state.memos = [];
+      renderMemos();
+    }
+  }
+
+  async function saveMemo(content) {
+    try {
+      const response = await fetch('/api/memos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ content })
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data.status !== 'ok') {
+        const detail = data && (data.detail || data.message);
+        throw new Error(detail || 'Memo kon niet opgeslagen worden.');
+      }
+
+      if (!data.memo) {
+        throw new Error('Ongeldig antwoord van de server.');
+      }
+
+      const newMemo = Object.assign({}, data.memo, { __highlight: true });
+      state.memos.unshift(newMemo);
+      renderMemos();
+      showStatus('Memo opgeslagen.', 'success');
+      return true;
+    } catch (error) {
+      console.error('Failed to save memo', error);
+      showStatus(error.message || 'Opslaan mislukt.', 'error');
+      return false;
+    }
+  }
+
+  async function handleManualSave() {
+    const value = manualInput.value.trim();
+    if (!value) {
+      showStatus('Vul eerst een memo in.', 'warning');
+      manualInput.focus();
+      return;
+    }
+
+    manualSaveButton.disabled = true;
+    manualSaveButton.textContent = 'Opslaan…';
+
+    const success = await saveMemo(value);
+    if (success) {
+      manualInput.value = '';
+      manualInput.focus();
+    }
+
+    manualSaveButton.disabled = false;
+    manualSaveButton.textContent = 'Memo opslaan';
+  }
+
+  function setupManualControls() {
+    if (!manualSaveButton || !manualInput) {
+      return;
+    }
+
+    manualSaveButton.addEventListener('click', handleManualSave);
+
+    manualInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        handleManualSave();
+      }
+    });
+  }
+
+  function setupSpeechRecording() {
+    if (!recordButton || !liveTranscriptEl) {
+      return;
+    }
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      recordButton.disabled = true;
+      recordButton.classList.add('memo-record-btn--disabled');
+      recordButton.textContent = 'Spraakopname niet beschikbaar';
+      showStatus('Spraakherkenning wordt niet door deze browser ondersteund. Gebruik het tekstveld om memo\'s te maken.', 'warning');
+      return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'nl-NL';
+    recognition.interimResults = true;
+    recognition.maxAlternatives = 1;
+    recognition.continuous = false;
+
+    let isRecording = false;
+    let recognitionHadError = false;
+    let transcriptParts = [];
+    let interimTranscript = '';
+
+    function resetRecordingUi() {
+      isRecording = false;
+      recordButton.classList.remove('memo-record-btn--recording');
+      recordButton.textContent = '🎙️ Houd ingedrukt om op te nemen';
+      liveTranscriptEl.textContent = '';
+      transcriptParts = [];
+      interimTranscript = '';
+    }
+
+    function startRecording() {
+      if (isRecording) {
+        return;
+      }
+
+      recognitionHadError = false;
+      transcriptParts = [];
+      interimTranscript = '';
+
+      try {
+        recognition.start();
+      } catch (error) {
+        console.error('Failed to start speech recognition', error);
+        showStatus('Kon de spraakopname niet starten.', 'error');
+      }
+    }
+
+    function stopRecording() {
+      if (!isRecording) {
+        return;
+      }
+      recognition.stop();
+    }
+
+    recognition.addEventListener('start', () => {
+      isRecording = true;
+      recordButton.classList.add('memo-record-btn--recording');
+      recordButton.textContent = '🎙️ Opnemen… laat los om te bewaren';
+      liveTranscriptEl.textContent = 'Luisteren…';
+    });
+
+    recognition.addEventListener('result', (event) => {
+      interimTranscript = '';
+      for (let i = event.resultIndex; i < event.results.length; i += 1) {
+        const result = event.results[i];
+        const transcript = result[0] && result[0].transcript ? result[0].transcript.trim() : '';
+        if (!transcript) {
+          continue;
+        }
+        if (result.isFinal) {
+          transcriptParts.push(transcript);
+        } else {
+          interimTranscript += `${transcript} `;
+        }
+      }
+      const combined = [...transcriptParts, interimTranscript.trim()].filter(Boolean).join(' ');
+      liveTranscriptEl.textContent = combined || 'Luisteren…';
+    });
+
+    recognition.addEventListener('error', (event) => {
+      recognitionHadError = true;
+      console.error('Speech recognition error', event);
+      if (event.error === 'no-speech') {
+        showStatus('Geen spraak gedetecteerd. Probeer het opnieuw.', 'warning');
+      } else if (event.error === 'not-allowed') {
+        showStatus('Toegang tot de microfoon geweigerd.', 'error');
+      } else {
+        showStatus(`Opnamefout: ${event.error}`, 'error');
+      }
+      resetRecordingUi();
+    });
+
+    recognition.addEventListener('end', () => {
+      const finalTranscript = (transcriptParts.join(' ').trim() || interimTranscript.trim());
+      const hadError = recognitionHadError;
+      resetRecordingUi();
+      if (hadError) {
+        return;
+      }
+      if (finalTranscript) {
+        saveMemo(finalTranscript);
+      } else {
+        showStatus('Geen tekst herkend. Probeer het opnieuw.', 'warning');
+      }
+    });
+
+    const startHandler = (event) => {
+      if (event.type === 'mousedown' && event.button !== 0) {
+        return;
+      }
+      event.preventDefault();
+      startRecording();
+    };
+
+    const stopHandler = (event) => {
+      event.preventDefault();
+      stopRecording();
+    };
+
+    recordButton.addEventListener('mousedown', startHandler);
+    recordButton.addEventListener('touchstart', startHandler, { passive: false });
+
+    recordButton.addEventListener('mouseup', stopHandler);
+    recordButton.addEventListener('mouseleave', stopHandler);
+    recordButton.addEventListener('touchend', stopHandler, { passive: false });
+    recordButton.addEventListener('touchcancel', stopHandler, { passive: false });
+
+    recordButton.addEventListener('click', (event) => {
+      event.preventDefault();
+    });
+  }
+
+  function init() {
+    setupManualControls();
+    setupSpeechRecording();
+    loadMemos();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/site.css
+++ b/static/site.css
@@ -69,6 +69,7 @@ body {
 .status-message { padding:10px; margin:10px 0; border-radius:4px; display:none; }
 .status-success { background:var(--rci-success-bg); color:var(--rci-success-text); border:1px solid #c3e6cb; }
 .status-error { background:var(--rci-error-bg); color:var(--rci-error-text); border:1px solid #f5c6cb; }
+.status-warning { background:#fff3cd; color:#856404; border:1px solid #ffeeba; }
 
 .object-preview { max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .object-link { color:var(--rci-primary); text-decoration:none; }
@@ -135,6 +136,7 @@ body {
 .status-message { box-shadow:var(--rci-shadow); }
 .badge { display:inline-block; background:var(--rci-primary); color:#fff; padding:2px 6px; border-radius:4px; font-size:10px; letter-spacing:.5px; text-transform:uppercase; }
 .status-error { border:1px solid var(--rci-error-border,#f5c6cb); }
+[data-theme="dark"] .status-warning { background:#5c4400; color:#ffd666; border:1px solid #8a6d1d; }
 /* Scrollbar styling (WebKit) */
 body::-webkit-scrollbar { width:10px; }
 body::-webkit-scrollbar-track { background:var(--rci-bg-alt); }
@@ -198,6 +200,48 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
 .status-red { background:#f44336; }
 .mono-tiny { font-family:monospace; font-size:.75rem; }
 .status-divider { border-top:1px solid var(--rci-border); padding-top:4px; margin-top:4px; }
+
+/* Memo page */
+.memo-layout { display:grid; gap:1.5rem; margin-top:1rem; }
+@media (min-width:960px){ .memo-layout { grid-template-columns:minmax(0,360px) minmax(0,1fr); align-items:start; } }
+.memo-section-header { display:flex; flex-direction:column; gap:0.35rem; margin-bottom:1rem; }
+.memo-description { margin:0; color:var(--rci-text-muted); }
+.memo-record-wrapper { display:flex; flex-direction:column; gap:0.75rem; align-items:flex-start; }
+.memo-record-btn { background:var(--rci-primary); color:#fff; border:none; border-radius:var(--rci-radius); padding:0.9rem 1.4rem; font-size:1rem; font-weight:600; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease; box-shadow:var(--rci-shadow); }
+.memo-record-btn:hover:not(:disabled) { transform:translateY(-1px); }
+.memo-record-btn--recording { background:#c62828; box-shadow:0 0 18px rgba(198,40,40,0.45); }
+.memo-record-btn--disabled { background:var(--rci-border); color:var(--rci-text-muted); cursor:not-allowed; box-shadow:none; }
+.memo-live-transcript { min-height:2.4rem; padding:0.75rem 1rem; border:1px dashed var(--rci-primary); border-radius:var(--rci-radius); background:var(--rci-surface-alt); width:100%; box-sizing:border-box; font-style:italic; color:var(--rci-text); }
+.memo-divider { position:relative; text-align:center; font-weight:600; color:var(--rci-text-muted); margin:1.25rem 0; }
+.memo-divider::before, .memo-divider::after { content:""; position:absolute; top:50%; width:38%; height:1px; background:var(--rci-border); }
+.memo-divider::before { left:0; }
+.memo-divider::after { right:0; }
+.memo-manual { display:flex; flex-direction:column; gap:0.6rem; width:100%; }
+.memo-manual textarea { width:100%; border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:0.75rem; min-height:110px; font-size:1rem; background:var(--rci-surface); color:var(--rci-text); }
+.memo-manual textarea:focus { outline:none; box-shadow:var(--rci-focus-ring); border-color:var(--rci-primary); }
+.memo-manual-btn { align-self:flex-start; padding:0.6rem 1.2rem; border:none; border-radius:var(--rci-radius); background:var(--rci-primary); color:#fff; cursor:pointer; font-weight:600; box-shadow:var(--rci-shadow); transition:transform .2s ease, box-shadow .2s ease; }
+.memo-manual-btn:hover:not(:disabled) { transform:translateY(-1px); }
+.memo-card-list { display:flex; flex-direction:column; gap:1rem; }
+.memo-card { border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:1rem; background:var(--rci-surface); box-shadow:var(--rci-shadow); transition:box-shadow .2s ease, transform .2s ease; }
+.memo-card--highlight { box-shadow:0 0 0 3px rgba(0,124,186,0.35); transform:translateY(-2px); }
+.memo-card__header { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem; flex-wrap:wrap; margin-bottom:0.75rem; }
+.memo-card__timestamps { display:flex; flex-direction:column; gap:0.25rem; font-size:0.9rem; color:var(--rci-text-muted); }
+.memo-card__timestamp--updated { font-style:italic; }
+.memo-card__actions { display:flex; gap:0.5rem; }
+.memo-edit-btn, .memo-save-btn, .memo-cancel-btn { padding:0.45rem 0.9rem; border-radius:var(--rci-radius); border:1px solid var(--rci-border); background:var(--rci-surface-alt); cursor:pointer; font-weight:600; transition:background .2s ease, color .2s ease; }
+.memo-edit-btn:hover, .memo-save-btn:hover, .memo-cancel-btn:hover { background:var(--rci-primary); color:#fff; }
+.memo-card__content { margin:0; line-height:1.5; white-space:pre-wrap; word-break:break-word; }
+.memo-edit-area { display:none; flex-direction:column; gap:0.6rem; }
+.memo-edit-area textarea { width:100%; border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:0.75rem; min-height:120px; font-size:1rem; resize:vertical; background:var(--rci-surface); color:var(--rci-text); }
+.memo-edit-actions { display:flex; gap:0.5rem; flex-wrap:wrap; }
+.memo-card.is-editing .memo-card__content { display:none; }
+.memo-card.is-editing .memo-edit-area { display:flex; }
+.memo-empty { margin:1rem 0; color:var(--rci-text-muted); font-style:italic; text-align:center; }
+.memo-label { font-weight:600; }
+.memo-manual-btn:disabled { opacity:0.6; cursor:not-allowed; transform:none; }
+[data-theme="dark"] .memo-live-transcript { border-color:var(--rci-primary); }
+[data-theme="dark"] .memo-divider::before,
+[data-theme="dark"] .memo-divider::after { background:var(--rci-border); }
 
 /* Maintenance link */
 .maintenance-link { position:fixed; bottom:24px; right:24px; width:32px; height:32px; display:block; z-index:9999; opacity:.2; background:var(--rci-text-muted); border-radius:6px; text-align:center; line-height:32px; text-decoration:none; font-size:1.5rem; transition:opacity .2s ease, background .3s ease; }

--- a/static/tools.html
+++ b/static/tools.html
@@ -25,6 +25,7 @@
     <a href="database.html">Database Management</a>
     <a href="maintenance.html">Maintenance</a>
     <a href="shared.html">Shared</a>
+    <a href="memo.html">Memo's</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/tests/core/test_memo_api.py
+++ b/tests/core/test_memo_api.py
@@ -1,0 +1,107 @@
+"""Unit tests for memo endpoint logic without HTTP dependencies."""
+
+import os
+from typing import List, Optional
+
+import pytest
+from fastapi import HTTPException
+
+REQUIRED_VARS = {
+    'AZURE_SQL_SERVER': 'stub.server.local',
+    'AZURE_SQL_PORT': '1433',
+    'AZURE_SQL_USER': 'test',
+    'AZURE_SQL_PASSWORD': 'secret',
+    'AZURE_SQL_DATABASE': 'testdb',
+}
+
+for key, value in REQUIRED_VARS.items():
+    os.environ.setdefault(key, value)
+
+
+class StubMemoDB:
+    """Simple in-memory replacement for the database manager during tests."""
+
+    def __init__(self) -> None:
+        self._memos: List[dict] = [
+            {
+                'id': 2,
+                'content': 'Nieuwere memo',
+                'created_at': '2024-01-02T10:00:00+00:00',
+                'updated_at': '2024-01-02T10:00:00+00:00',
+            },
+            {
+                'id': 1,
+                'content': 'Oude memo',
+                'created_at': '2024-01-01T08:00:00+00:00',
+                'updated_at': '2024-01-01T08:00:00+00:00',
+            },
+        ]
+
+    def get_memos(self, limit: Optional[int] = None):
+        if limit:
+            return self._memos[:limit]
+        return list(self._memos)
+
+    def create_memo(self, content: str) -> dict:
+        next_id = max((memo['id'] for memo in self._memos), default=0) + 1
+        memo = {
+            'id': next_id,
+            'content': content,
+            'created_at': '2024-01-03T12:00:00+00:00',
+            'updated_at': '2024-01-03T12:00:00+00:00',
+        }
+        self._memos.insert(0, memo)
+        return memo
+
+    def update_memo(self, memo_id: int, content: str) -> Optional[dict]:
+        for memo in self._memos:
+            if memo['id'] == memo_id:
+                memo['content'] = content
+                memo['updated_at'] = '2024-01-04T09:00:00+00:00'
+                return memo
+        return None
+
+
+@pytest.fixture()
+def memo_app(monkeypatch):
+    import importlib
+
+    main = importlib.import_module('main')
+    stub = StubMemoDB()
+    monkeypatch.setattr(main, 'db_manager', stub)
+    return main, stub
+
+
+def test_list_memos_returns_payload(memo_app):
+    main, stub = memo_app
+    payload = main.list_memos(limit=None)
+    assert payload['status'] == 'ok'
+    assert len(payload['memos']) == len(stub._memos)
+
+
+def test_create_memo_trims_content(memo_app):
+    main, stub = memo_app
+    result = main.create_memo(main.MemoCreateRequest(content='  Nieuwe memo  '))
+    assert result['status'] == 'ok'
+    assert stub._memos[0]['content'] == 'Nieuwe memo'
+
+
+def test_create_memo_rejects_empty(memo_app):
+    main, _ = memo_app
+    with pytest.raises(HTTPException) as exc:
+        main.create_memo(main.MemoCreateRequest(content='   '))
+    assert exc.value.status_code == 400
+
+
+def test_update_memo_success(memo_app):
+    main, stub = memo_app
+    result = main.update_memo(1, main.MemoUpdateRequest(content='Bijgewerkte memo'))
+    assert result['status'] == 'ok'
+    assert stub._memos[-1]['content'] == 'Bijgewerkte memo'
+
+
+def test_update_memo_not_found(memo_app):
+    main, _ = memo_app
+    with pytest.raises(HTTPException) as exc:
+        main.update_memo(999, main.MemoUpdateRequest(content='Bestaat niet'))
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- add memo database table and CRUD helpers to persist transcribed notes
- expose FastAPI endpoints and a protected memo.html route for managing memos
- build a memo UI with speech recording, manual entry, inline edits, and fresh styling, plus regression tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cdd330d6408320afb46aa635a2699b