### PR TITLE
Add media transcription workflow to memo page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core web framework and ASGI server
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
+python-multipart>=0.0.7
 
 # Database and ORM
 sqlalchemy>=2.0.0

--- a/static/memo.html
+++ b/static/memo.html
@@ -44,6 +44,23 @@
             <textarea id="memo-manual-input" rows="3" placeholder="Schrijf hier je memo..."></textarea>
             <button id="memo-manual-save" type="button" class="memo-manual-btn focus-ring">Memo opslaan</button>
         </div>
+        <div class="memo-divider" role="presentation">of</div>
+        <div class="memo-transcription" aria-labelledby="memo-transcription-heading">
+            <div class="memo-transcription-header">
+                <h3 id="memo-transcription-heading">Audio of video transcriberen</h3>
+                <p class="memo-description">Upload een audio- of videobestand of plak een URL om automatisch een memo te maken met sprekerherkenning.</p>
+            </div>
+            <form id="memo-transcription-form" class="memo-transcription-form">
+                <label for="memo-file-input" class="memo-label">Upload een bestand</label>
+                <input id="memo-file-input" type="file" accept="audio/*,video/*">
+                <div class="memo-transcription-separator" role="presentation">of</div>
+                <label for="memo-url-input" class="memo-label">Gebruik een URL</label>
+                <input id="memo-url-input" type="url" placeholder="https://voorbeeld.nl/bestand.mp3">
+                <button id="memo-transcription-submit" type="submit" class="memo-manual-btn focus-ring">Transcriberen</button>
+            </form>
+            <div id="memo-transcription-status" class="status-message" role="status" aria-live="polite"></div>
+            <div id="memo-transcription-result" class="memo-transcription-result" aria-live="polite"></div>
+        </div>
         <div id="memo-status" class="status-message" role="status" aria-live="polite"></div>
     </section>
 

--- a/static/site.css
+++ b/static/site.css
@@ -221,6 +221,18 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
 .memo-manual textarea:focus { outline:none; box-shadow:var(--rci-focus-ring); border-color:var(--rci-primary); }
 .memo-manual-btn { align-self:flex-start; padding:0.6rem 1.2rem; border:none; border-radius:var(--rci-radius); background:var(--rci-primary); color:#fff; cursor:pointer; font-weight:600; box-shadow:var(--rci-shadow); transition:transform .2s ease, box-shadow .2s ease; }
 .memo-manual-btn:hover:not(:disabled) { transform:translateY(-1px); }
+.memo-transcription { display:flex; flex-direction:column; gap:0.75rem; width:100%; }
+.memo-transcription-header h3 { margin:0; font-size:1.1rem; }
+.memo-transcription-form { display:flex; flex-direction:column; gap:0.6rem; width:100%; }
+.memo-transcription-form input[type="file"], .memo-transcription-form input[type="url"] { border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:0.65rem 0.75rem; font-size:1rem; background:var(--rci-surface); color:var(--rci-text); }
+.memo-transcription-form input[type="url"]:focus { outline:none; box-shadow:var(--rci-focus-ring); border-color:var(--rci-primary); }
+.memo-transcription-separator { text-align:center; color:var(--rci-text-muted); font-weight:600; }
+.memo-transcription-result { display:none; border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:0.75rem; background:var(--rci-surface-alt); white-space:pre-wrap; line-height:1.5; box-shadow:var(--rci-shadow); }
+.memo-transcription-result.is-visible { display:block; }
+.memo-transcription-segment { margin-bottom:0.5rem; }
+.memo-transcription-segment:last-child { margin-bottom:0; }
+.memo-transcription-speaker { font-weight:600; display:block; margin-bottom:0.15rem; }
+.memo-transcription-time { font-size:0.85rem; color:var(--rci-text-muted); margin-left:0.35rem; }
 .memo-card-list { display:flex; flex-direction:column; gap:1rem; }
 .memo-card { border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:1rem; background:var(--rci-surface); box-shadow:var(--rci-shadow); transition:box-shadow .2s ease, transform .2s ease; }
 .memo-card--highlight { box-shadow:0 0 0 3px rgba(0,124,186,0.35); transform:translateY(-2px); }

--- a/transcription.py
+++ b/transcription.py
@@ -1,0 +1,118 @@
+"""Utilities for transcribing audio and video content with speaker diarization."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Dict, Generator, Optional
+
+import requests
+
+
+class TranscriptionServiceError(RuntimeError):
+    """Base exception for transcription failures."""
+
+
+class TranscriptionConfigError(TranscriptionServiceError):
+    """Raised when the transcription service is misconfigured."""
+
+
+class TranscriptionFailedError(TranscriptionServiceError):
+    """Raised when the remote transcription service returns an error."""
+
+
+class TranscriptionService:
+    """High level helper for AssemblyAI-based transcriptions."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.assemblyai.com/v2",
+        poll_interval: float = 3.0,
+        max_wait_seconds: float = 600.0,
+    ) -> None:
+        self.api_key = api_key or os.getenv("ASSEMBLYAI_API_KEY")
+        self.base_url = base_url.rstrip("/")
+        self.poll_interval = poll_interval
+        self.max_wait_seconds = max_wait_seconds
+
+    @property
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise TranscriptionConfigError("AssemblyAI API-sleutel ontbreekt")
+        return {"authorization": self.api_key}
+
+    def transcribe(
+        self,
+        *,
+        file_path: Optional[Path] = None,
+        source_url: Optional[str] = None,
+    ) -> Dict[str, object]:
+        """Transcribe the provided media and return the raw API payload."""
+
+        if not file_path and not source_url:
+            raise ValueError("Bestand of URL vereist voor transcriptie")
+
+        headers = self._headers
+
+        if file_path is not None:
+            audio_url = self._upload_file(file_path, headers)
+        else:
+            audio_url = source_url
+
+        assert audio_url is not None
+
+        transcript_id = self._create_transcript(audio_url, headers)
+        return self._poll_transcript(transcript_id, headers)
+
+    def _upload_file(self, file_path: Path, headers: Dict[str, str]) -> str:
+        if not file_path.exists():
+            raise FileNotFoundError(f"Bestand niet gevonden: {file_path}")
+
+        upload_url = f"{self.base_url}/upload"
+        with file_path.open("rb") as stream:
+            response = requests.post(upload_url, headers=headers, data=self._read_file(stream))
+        response.raise_for_status()
+        payload = response.json()
+        audio_url = payload.get("upload_url")
+        if not audio_url:
+            raise TranscriptionFailedError("Upload mislukt: geen upload_url ontvangen")
+        return audio_url
+
+    def _create_transcript(self, audio_url: str, headers: Dict[str, str]) -> str:
+        create_url = f"{self.base_url}/transcript"
+        body = {"audio_url": audio_url, "speaker_labels": True}
+        response = requests.post(create_url, json=body, headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+        transcript_id = payload.get("id")
+        if not transcript_id:
+            raise TranscriptionFailedError("Transcriptie-aanvraag gaf geen ID terug")
+        return transcript_id
+
+    def _poll_transcript(self, transcript_id: str, headers: Dict[str, str]) -> Dict[str, object]:
+        status_url = f"{self.base_url}/transcript/{transcript_id}"
+        deadline = time.monotonic() + self.max_wait_seconds
+        while True:
+            response = requests.get(status_url, headers=headers)
+            response.raise_for_status()
+            payload = response.json()
+            status = payload.get("status")
+            if status == "completed":
+                return payload
+            if status == "error":
+                error_message = payload.get("error") or "Transcriptie mislukt"
+                raise TranscriptionFailedError(error_message)
+            if time.monotonic() > deadline:
+                raise TranscriptionFailedError("Transcriptie duurde te lang")
+            time.sleep(self.poll_interval)
+
+    @staticmethod
+    def _read_file(stream) -> Generator[bytes, None, None]:
+        chunk_size = 5 * 1024 * 1024
+        while True:
+            data = stream.read(chunk_size)
+            if not data:
+                break
+            yield data


### PR DESCRIPTION
## Summary
- add an AssemblyAI-backed transcription service and expose a /api/memos/transcribe endpoint that stores diarized memo text
- extend the memo page with upload/URL controls and transcript rendering with speaker segments
- include python-multipart as a dependency and cover the new API with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cefade4e7c83209bad23f20a203622