### PR TITLE
Add memo archive delete endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -2682,6 +2682,21 @@ def update_memo(memo_id: int, request: MemoUpdateRequest):
         raise HTTPException(status_code=500, detail=f"Failed to update memo: {str(exc)}")
 
 
+@app.delete("/api/memos/{memo_id}")
+def delete_memo(memo_id: int):
+    """Archive an existing memo instead of deleting it permanently."""
+    try:
+        archived = db_manager.archive_memo(memo_id)
+        if archived is None:
+            raise HTTPException(status_code=404, detail="Memo niet gevonden")
+        return {"status": "ok", "archived": archived}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_error(f"Failed to archive memo {memo_id}: {exc}")
+        raise HTTPException(status_code=500, detail=f"Failed to archive memo: {str(exc)}")
+
+
 @app.get("/shared.html")
 def read_shared(request: Request):
     """Serve the shared objects page."""

--- a/static/memo.js
+++ b/static/memo.js
@@ -435,6 +435,12 @@
     editButton.textContent = '✏️ Bewerken';
     actions.appendChild(editButton);
 
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'memo-delete-btn focus-ring';
+    deleteButton.textContent = '🗑️ Verwijderen';
+    actions.appendChild(deleteButton);
+
     header.appendChild(timestamps);
     header.appendChild(actions);
 
@@ -557,6 +563,39 @@
       } finally {
         saveButton.disabled = false;
         saveButton.textContent = 'Opslaan';
+      }
+    });
+
+    deleteButton.addEventListener('click', async () => {
+      const confirmed = window.confirm('Weet je zeker dat je deze memo wilt archiveren?');
+      if (!confirmed) {
+        return;
+      }
+
+      const originalText = deleteButton.textContent;
+      deleteButton.disabled = true;
+      deleteButton.textContent = 'Verwijderen…';
+
+      try {
+        const response = await fetch(`/api/memos/${memo.id}`, {
+          method: 'DELETE'
+        });
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || data.status !== 'ok') {
+          const detail = data && (data.detail || data.message);
+          throw new Error(detail || 'Onbekende fout bij het archiveren van de memo.');
+        }
+
+        state.memos = state.memos.filter((existing) => existing.id !== memo.id);
+        renderMemos();
+        showStatus('Memo verplaatst naar archief.', 'success');
+      } catch (error) {
+        console.error('Failed to archive memo', error);
+        showStatus(error.message || 'Archiveren mislukt.', 'error');
+      } finally {
+        deleteButton.disabled = false;
+        deleteButton.textContent = originalText;
       }
     });
 

--- a/static/site.css
+++ b/static/site.css
@@ -240,8 +240,8 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
 .memo-card__timestamps { display:flex; flex-direction:column; gap:0.25rem; font-size:0.9rem; color:var(--rci-text-muted); }
 .memo-card__timestamp--updated { font-style:italic; }
 .memo-card__actions { display:flex; gap:0.5rem; }
-.memo-edit-btn, .memo-save-btn, .memo-cancel-btn, .memo-copy-btn { padding:0.45rem 0.9rem; border-radius:var(--rci-radius); border:1px solid var(--rci-border); background:var(--rci-surface-alt); cursor:pointer; font-weight:600; transition:background .2s ease, color .2s ease; }
-.memo-edit-btn:hover, .memo-save-btn:hover, .memo-cancel-btn:hover, .memo-copy-btn:hover { background:var(--rci-primary); color:#fff; }
+.memo-edit-btn, .memo-save-btn, .memo-cancel-btn, .memo-copy-btn, .memo-delete-btn { padding:0.45rem 0.9rem; border-radius:var(--rci-radius); border:1px solid var(--rci-border); background:var(--rci-surface-alt); cursor:pointer; font-weight:600; transition:background .2s ease, color .2s ease; }
+.memo-edit-btn:hover, .memo-save-btn:hover, .memo-cancel-btn:hover, .memo-copy-btn:hover, .memo-delete-btn:hover { background:var(--rci-primary); color:#fff; }
 .memo-card__content { margin:0; line-height:1.5; white-space:pre-wrap; word-break:break-word; }
 .memo-edit-area { display:none; flex-direction:column; gap:0.6rem; }
 .memo-edit-area textarea { width:100%; border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:0.75rem; min-height:120px; font-size:1rem; resize:vertical; background:var(--rci-surface); color:var(--rci-text); }


### PR DESCRIPTION
## Summary
- create a memo_archive table and implement database support for moving deleted memos into it
- expose a DELETE /api/memos/{memo_id} endpoint that archives memos instead of removing them
- add UI controls and styling for archiving memos and expand memo API tests to cover the new behaviour

## Testing
- `pytest tests/core/test_memo_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf3d462fd48320ae21b51e30e08b04