### PR TITLE
Handle BarcodeDetector init failures on shared page

### DIFF
--- a/static/shared.html
+++ b/static/shared.html
@@ -655,7 +655,15 @@ window.onclick = function(event) {
     let stream = null;
     let scanning = false;
     let qrMode = true; // true => QR scan, false => photo capture
-    let barcodeDetector = ("BarcodeDetector" in window) ? new BarcodeDetector({formats:['qr_code','aztec','data_matrix','pdf417']}) : null;
+    let barcodeDetector = null;
+    if("BarcodeDetector" in window){
+        try {
+            barcodeDetector = new BarcodeDetector({formats:['qr_code','aztec','data_matrix','pdf417']});
+        } catch(err){
+            console.warn('BarcodeDetector initialization failed', err);
+            barcodeDetector = null;
+        }
+    }
 
     function handleManualSubmit(){
         const val = (manualInput.value || '').trim();
@@ -828,6 +836,7 @@ window.onclick = function(event) {
         qrMode = false;
         cameraModeBadge.textContent = 'PHOTO';
         captureBtn.disabled = false;
+        qrStatus.textContent = 'Photo mode ready (QR detection not supported)';
     }
 
     // Clean up if page unloads


### PR DESCRIPTION
## Summary
- guard the Shared Objects QR scanner against BarcodeDetector constructor failures
- fall back to photo mode with a status message when the browser cannot provide a detector

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06bf12d148320bb0b8720ca40c5b8