### PR TITLE
Add workflow to auto merge PRs into main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,24 +1,43 @@
-name: Auto approve and merge PRs into main
+name: Auto-merge pull requests into main
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
 
 jobs:
-  automerge:
+  auto-merge:
     if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: pascalgn/automerge-action@v0.15.6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve pull request
+        uses: actions/github-script@v7
         with:
-          mergeMethod: squash
-          mergeLabel: ''
-          mergeCommitMessage: pull-request-title
-          deleteBranchAfterMerge: true
-          approve: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE'
+            });
+
+      - name: Merge pull request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              merge_method: 'squash',
+              commit_title: context.payload.pull_request.title
+            });


### PR DESCRIPTION
## Summary
- replace the auto-merge workflow to actively approve and squash-merge pull requests targeting main

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d06ef923bc832083935a69ba5bee53