### PR TITLE
Enhance JSON compare interface

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -408,16 +408,43 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
 .diff-column { flex:1 1 0; display:flex; flex-direction:column; border:1px solid var(--rci-border); border-radius:4px; background:var(--rci-surface); box-shadow:var(--rci-shadow); min-width:0; }
 .diff-column-header { background:var(--rci-surface-alt); padding:8px 12px; font-weight:600; border-bottom:1px solid var(--rci-border); }
 .diff-column-content { flex:1 1 auto; padding:12px; max-height:500px; overflow:auto; font-family:monospace; font-size:.85rem; line-height:1.4; position:relative; }
-.diff-added { background:rgba(30, 142, 62, 0.18); border-left:3px solid #1e8e3e; }
-.diff-removed { background:rgba(220, 53, 69, 0.2); border-left:3px solid #c62828; }
-.diff-modified { background:rgba(255, 152, 0, 0.18); border-left:3px solid #ef6c00; }
+.diff-added { background:rgba(67, 160, 71, 0.18); border-left:3px solid #2e7d32; color:var(--rci-text); }
+.diff-removed { background:rgba(229, 57, 53, 0.18); border-left:3px solid #c62828; color:var(--rci-text); }
+.diff-modified { background:rgba(33, 150, 243, 0.18); border-left:3px solid #1565c0; color:var(--rci-text); }
 .diff-unchanged { background:var(--rci-surface-alt); }
-[data-theme="dark"] .diff-added { background:rgba(30, 142, 62, 0.28); }
-[data-theme="dark"] .diff-removed { background:rgba(198, 40, 40, 0.28); }
-[data-theme="dark"] .diff-modified { background:rgba(239, 108, 0, 0.28); }
-[data-theme="light"] .diff-added { background:rgba(30, 142, 62, 0.12); }
-[data-theme="light"] .diff-removed { background:rgba(220, 53, 69, 0.12); }
-[data-theme="light"] .diff-modified { background:rgba(255, 152, 0, 0.12); }
+[data-theme="dark"] .diff-added { background:rgba(102, 187, 106, 0.25); }
+[data-theme="dark"] .diff-removed { background:rgba(239, 83, 80, 0.25); }
+[data-theme="dark"] .diff-modified { background:rgba(66, 165, 245, 0.25); }
+[data-theme="light"] .diff-added { background:rgba(76, 175, 80, 0.12); }
+[data-theme="light"] .diff-removed { background:rgba(244, 67, 54, 0.12); }
+[data-theme="light"] .diff-modified { background:rgba(33, 150, 243, 0.12); }
+
+.diff-tree-controls { padding:8px 12px; background:var(--rci-bg); border:1px solid var(--rci-border); border-radius:4px; display:flex; flex-wrap:wrap; gap:.75rem; align-items:center; }
+.diff-tree-label { font-size:.8rem; font-weight:600; color:var(--rci-text); display:flex; align-items:center; gap:.35rem; }
+.diff-tree-controls select { padding:.3rem .5rem; border:1px solid var(--rci-border); border-radius:3px; font-size:.8rem; background:var(--rci-surface); color:var(--rci-text); }
+.diff-tree-controls button { padding:.3rem .6rem; font-size:.75rem; border:1px solid var(--rci-border); border-radius:3px; background:var(--rci-surface); color:var(--rci-text); cursor:pointer; transition:background .2s ease, border-color .2s ease; }
+.diff-tree-controls button:hover:not(:disabled) { background:var(--rci-surface-alt); border-color:var(--rci-primary); }
+.diff-tree-controls button:disabled, .diff-tree-controls select:disabled { cursor:not-allowed; opacity:.6; }
+.diff-tree-buttons { display:flex; gap:.5rem; flex-wrap:wrap; }
+
+.diff-summary { border:1px solid var(--rci-border); border-radius:4px; background:var(--rci-surface); box-shadow:var(--rci-shadow); padding:12px; display:flex; flex-direction:column; gap:.75rem; }
+.diff-summary-header { display:flex; justify-content:space-between; align-items:center; font-size:.85rem; }
+.diff-summary-count { font-size:.75rem; color:var(--rci-text-muted); }
+.diff-summary-table-container { border:1px solid var(--rci-border); border-radius:4px; overflow:auto; background:var(--rci-surface-alt); max-height:240px; }
+.diff-summary-table { width:100%; border-collapse:collapse; font-size:.8rem; }
+.diff-summary-table th, .diff-summary-table td { padding:8px 10px; text-align:left; border-bottom:1px solid var(--rci-border); }
+.diff-summary-table th { position:sticky; top:0; background:var(--rci-surface); z-index:5; font-weight:600; }
+.diff-summary-table tbody tr:nth-child(even) { background:var(--rci-bg); }
+.diff-summary-table tbody tr:hover { background:var(--rci-bg-alt); }
+.diff-summary-empty { font-size:.8rem; color:var(--rci-text-muted); }
+.diff-chip { display:inline-flex; align-items:center; padding:.15rem .6rem; border-radius:999px; font-size:.7rem; font-weight:600; text-transform:capitalize; }
+.diff-chip-added { background:rgba(76, 175, 80, 0.2); color:#1b5e20; }
+.diff-chip-removed { background:rgba(244, 67, 54, 0.2); color:#b71c1c; }
+.diff-chip-modified { background:rgba(33, 150, 243, 0.2); color:#0d47a1; }
+.diff-chip-unchanged { background:rgba(158, 158, 158, 0.2); color:#424242; }
+.diff-table-empty { color:var(--rci-text-muted); font-style:italic; }
+.diff-table-nested { font-family:monospace; color:var(--rci-text); }
+.diff-path { font-family:monospace; font-size:.8rem; color:var(--rci-text); }
 
 /* JSON tree rendering */
 .json-object { margin-left:1em; }
@@ -425,11 +452,11 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
 .json-group-root { margin-left:0; }
 .json-group { margin-left:0; display:flex; flex-direction:column; gap:2px; }
 .json-property { margin:2px 0; padding:2px 4px; border-radius:2px; }
-.json-key { font-weight:bold; color:var(--rci-primary); }
+.json-key { font-weight:600; color:var(--rci-primary); }
 .json-value { margin-left:.5em; }
-.json-string { color:#28a745; }
-.json-number { color:#dc3545; }
-.json-boolean { color:#6f42c1; }
+.json-string { color:#2e7d32; }
+.json-number { color:#ad1457; }
+.json-boolean { color:#1565c0; }
 .json-null { color:var(--rci-text-muted); font-style:italic; }
 .json-bracket { color:var(--rci-text-muted); font-weight:bold; }
 .json-expand { cursor:pointer; -webkit-user-select:none; user-select:none; color:var(--rci-primary); font-weight:bold; margin-right:.25em; background:transparent; border:none; padding:0 .25em; line-height:1; }

--- a/static/tools.html
+++ b/static/tools.html
@@ -872,6 +872,7 @@ function displayStructuredDiff(diffResult, leftTitle, rightTitle, mode) {
     const defaults = mode === 'similarities'
         ? { unchanged: true, modified: false, added: false, removed: false }
         : { unchanged: true, modified: true, added: true, removed: true };
+    const summaryHtml = buildDiffSummaryTable(diffResult);
 
     jsonCompareResult.innerHTML = `
         <div class="diff-wrapper">
@@ -881,6 +882,20 @@ function displayStructuredDiff(diffResult, leftTitle, rightTitle, mode) {
                 <label><input type="checkbox" id="json-show-added" ${defaults.added ? 'checked' : ''}> Show added</label>
                 <label><input type="checkbox" id="json-show-removed" ${defaults.removed ? 'checked' : ''}> Show removed</label>
             </div>
+            <div class="diff-tree-controls" role="group" aria-label="JSON tree expansion controls">
+                <label class="diff-tree-label">Level
+                    <select data-depth-select aria-label="Select depth level" disabled>
+                        <option value="0">Level 0</option>
+                    </select>
+                </label>
+                <div class="diff-tree-buttons">
+                    <button type="button" data-action="expand-level" disabled>Expand to level</button>
+                    <button type="button" data-action="collapse-level" disabled>Collapse from level</button>
+                    <button type="button" data-action="expand-all" disabled>Expand all</button>
+                    <button type="button" data-action="collapse-all" disabled>Collapse all</button>
+                </div>
+            </div>
+            ${summaryHtml}
             <div class="diff-columns">
                 <div class="diff-column" data-side="left">
                     <div class="diff-column-header">${leftTitle}</div>
@@ -902,6 +917,143 @@ function displayStructuredDiff(diffResult, leftTitle, rightTitle, mode) {
     setupDiffInteractions(jsonCompareResult);
 }
 
+function buildDiffSummaryTable(diffResult) {
+    const entries = collectDiffEntries(diffResult);
+    const total = entries.length;
+    if (!total) {
+        return `
+            <div class="diff-summary">
+                <div class="diff-summary-header">
+                    <strong>Change summary</strong>
+                    <span class="diff-summary-count" data-summary-count>0 entries</span>
+                </div>
+                <div class="diff-summary-empty" data-summary-empty>No entries to display.</div>
+            </div>
+        `;
+    }
+
+    const rowsHtml = entries.map(entry => `
+        <tr data-row-type="${entry.type}" data-depth="${entry.depth}">
+            <td><span class="diff-chip diff-chip-${entry.type}">${formatDiffTypeLabel(entry.type)}</span></td>
+            <td><code class="diff-path">${escapeHtml(entry.path || '(root)')}</code></td>
+            <td>${formatTableValue(entry.valueA)}</td>
+            <td>${formatTableValue(entry.valueB)}</td>
+        </tr>
+    `).join('');
+
+    return `
+        <div class="diff-summary">
+            <div class="diff-summary-header">
+                <strong>Change summary</strong>
+                <span class="diff-summary-count" data-summary-count>${total} entries</span>
+            </div>
+            <div class="diff-summary-table-container">
+                <table class="diff-summary-table" aria-label="Tabular view of JSON changes">
+                    <thead>
+                        <tr>
+                            <th scope="col">Type</th>
+                            <th scope="col">Path</th>
+                            <th scope="col">Original</th>
+                            <th scope="col">Modified</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${rowsHtml}
+                    </tbody>
+                </table>
+            </div>
+            <div class="diff-summary-empty hidden" data-summary-empty>No entries match the current filters.</div>
+        </div>
+    `;
+}
+
+function collectDiffEntries(diffResult, depth = 0) {
+    const entries = [];
+    const sections = [
+        { items: diffResult.unchanged, type: 'unchanged' },
+        { items: diffResult.modified, type: 'modified' },
+        { items: diffResult.added, type: 'added' },
+        { items: diffResult.removed, type: 'removed' }
+    ];
+
+    sections.forEach(({ items, type }) => {
+        if (!items || !items.length) return;
+        items.forEach(item => {
+            entries.push({
+                type,
+                path: item.path || '',
+                depth,
+                valueA: 'valueA' in item ? item.valueA : item.value,
+                valueB: 'valueB' in item ? item.valueB : item.value
+            });
+            if (item.nested) {
+                entries.push(...collectDiffEntries(item.nested, depth + 1));
+            }
+        });
+    });
+
+    return entries;
+}
+
+function formatDiffTypeLabel(type) {
+    switch (type) {
+        case 'added':
+            return 'Added';
+        case 'removed':
+            return 'Removed';
+        case 'modified':
+            return 'Modified';
+        case 'unchanged':
+        default:
+            return 'Unchanged';
+    }
+}
+
+function formatTableValue(value) {
+    if (typeof value === 'undefined') {
+        return '<span class="diff-table-empty">—</span>';
+    }
+
+    if (value === null) {
+        return '<span class="json-null">null</span>';
+    }
+
+    if (typeof value === 'string') {
+        const truncated = value.length > 60;
+        const preview = truncated ? `${value.slice(0, 60)}…` : value;
+        const tooltip = truncated ? `${value.slice(0, 500)}${value.length > 500 ? '…' : ''}` : value;
+        return `<span class="json-string" title="${escapeAttribute(tooltip)}">"${escapeHtml(preview)}"</span>`;
+    }
+
+    if (typeof value === 'number') {
+        return `<span class="json-number">${value}</span>`;
+    }
+
+    if (typeof value === 'boolean') {
+        return `<span class="json-boolean">${value}</span>`;
+    }
+
+    if (Array.isArray(value) || isObject(value)) {
+        const summary = summarizeValue(value, Array.isArray(value) ? 'array' : 'object');
+        const details = stringifyForTitle(value);
+        return `<span class="diff-table-nested" title="${escapeAttribute(details)}">${escapeHtml(summary)}</span>`;
+    }
+
+    return escapeHtml(String(value));
+}
+
+function stringifyForTitle(value) {
+    if (typeof value === 'string') {
+        return value;
+    }
+    try {
+        const text = JSON.stringify(value, null, 2) || '';
+        return text.length > 1000 ? `${text.slice(0, 1000)}…` : text;
+    } catch (err) {
+        return String(value);
+    }
+}
+
 function renderDiffContent(diffResult, side, mode, depth = 0) {
     const sections = [
         { items: diffResult.unchanged, type: 'unchanged' },
@@ -910,7 +1062,7 @@ function renderDiffContent(diffResult, side, mode, depth = 0) {
         { items: diffResult.removed, type: 'removed' }
     ];
 
-    let html = `<div class="json-group${depth === 0 ? ' json-group-root' : ''}">`;
+    let html = `<div class="json-group${depth === 0 ? ' json-group-root' : ''}" data-depth="${depth}">`;
     sections.forEach(section => {
         if (!section.items || section.items.length === 0) return;
         section.items.forEach(item => {
@@ -924,6 +1076,7 @@ function renderDiffContent(diffResult, side, mode, depth = 0) {
 function renderDiffItem(item, diffType, side, mode, depth) {
     const cssClass = `json-property diff-${diffType}`;
     const keyLabel = item.isArrayKey ? `[${item.key}]` : `"${escapeHtml(String(item.key))}"`;
+    const containerDepthAttr = `data-depth="${depth}"`;
 
     if (diffType === 'modified' && item.nested) {
         const bracketOpen = item.type === 'array' ? '[' : '{';
@@ -932,12 +1085,12 @@ function renderDiffItem(item, diffType, side, mode, depth) {
         const valueForPreview = side === 'left' ? item.valueA : item.valueB;
         const previewLabel = summarizeValue(valueForPreview, item.type);
         return `
-            <div class="${cssClass}" data-diff-type="${diffType}">
-                <button type="button" class="json-expand" data-toggle="${nodeId}" aria-expanded="false" aria-label="Toggle ${keyLabel}">▶</button>
+            <div class="${cssClass}" data-diff-type="${diffType}" ${containerDepthAttr}>
+                <button type="button" class="json-expand" data-toggle="${nodeId}" data-depth="${depth + 1}" aria-expanded="false" aria-label="Toggle ${keyLabel}">▶</button>
                 <span class="json-key">${keyLabel}</span>:
                 <span class="json-bracket">${bracketOpen}</span>
                 <span class="json-preview" data-preview="${nodeId}">${previewLabel}</span>
-                <div class="json-nested ${item.type === 'array' ? 'json-array' : 'json-object'} hidden" data-children="${nodeId}">
+                <div class="json-nested ${item.type === 'array' ? 'json-array' : 'json-object'} hidden" data-children="${nodeId}" data-depth="${depth + 1}">
                     ${renderDiffContent(item.nested, side, mode, depth + 1)}
                 </div>
                 <span class="json-bracket">${bracketClose}</span>
@@ -950,13 +1103,13 @@ function renderDiffItem(item, diffType, side, mode, depth) {
         : item.value;
 
     return `
-        <div class="${cssClass}" data-diff-type="${diffType}">
-            <span class="json-key">${keyLabel}</span>: ${formatValue(value, item.path)}
+        <div class="${cssClass}" data-diff-type="${diffType}" ${containerDepthAttr}>
+            <span class="json-key">${keyLabel}</span>: ${formatValue(value, item.path, depth + 1)}
         </div>
     `;
 }
 
-function formatValue(value, path) {
+function formatValue(value, path, depth = 0) {
     if (value === null) {
         return '<span class="json-null">null</span>';
     }
@@ -965,11 +1118,11 @@ function formatValue(value, path) {
         const nodeId = getExpandId(`${path}|array`, 'value');
         const previewLabel = summarizeValue(value, 'array');
         return `
-            <button type="button" class="json-expand" data-toggle="${nodeId}" aria-expanded="false" aria-label="Toggle ${path || 'array'}">▶</button>
+            <button type="button" class="json-expand" data-toggle="${nodeId}" data-depth="${depth}" aria-expanded="false" aria-label="Toggle ${path || 'array'}">▶</button>
             <span class="json-bracket">[</span>
             <span class="json-preview" data-preview="${nodeId}">${previewLabel}</span>
-            <div class="json-array hidden" data-children="${nodeId}">
-                ${value.map((item, index) => `<div class="json-property"><span class="json-key">[${index}]</span>: ${formatValue(item, `${path}[${index}]`)}</div>`).join('')}
+            <div class="json-array hidden" data-children="${nodeId}" data-depth="${depth}">
+                ${value.map((item, index) => `<div class="json-property" data-depth="${depth}"><span class="json-key">[${index}]</span>: ${formatValue(item, `${path}[${index}]`, depth + 1)}</div>`).join('')}
             </div>
             <span class="json-bracket">]</span>
         `;
@@ -980,11 +1133,11 @@ function formatValue(value, path) {
         const keys = Object.keys(value);
         const previewLabel = summarizeValue(value, 'object');
         return `
-            <button type="button" class="json-expand" data-toggle="${nodeId}" aria-expanded="false" aria-label="Toggle ${path || 'object'}">▶</button>
+            <button type="button" class="json-expand" data-toggle="${nodeId}" data-depth="${depth}" aria-expanded="false" aria-label="Toggle ${path || 'object'}">▶</button>
             <span class="json-bracket">{</span>
             <span class="json-preview" data-preview="${nodeId}">${previewLabel}</span>
-            <div class="json-object hidden" data-children="${nodeId}">
-                ${keys.map(key => `<div class="json-property"><span class="json-key">"${escapeHtml(key)}"</span>: ${formatValue(value[key], path ? `${path}.${key}` : key)}</div>`).join('')}
+            <div class="json-object hidden" data-children="${nodeId}" data-depth="${depth}">
+                ${keys.map(key => `<div class="json-property" data-depth="${depth}"><span class="json-key">"${escapeHtml(key)}"</span>: ${formatValue(value[key], path ? `${path}.${key}` : key, depth + 1)}</div>`).join('')}
             </div>
             <span class="json-bracket">}</span>
         `;
@@ -1057,6 +1210,10 @@ function toggleDiffType(container, type, show) {
     container.querySelectorAll(`.diff-${type}`).forEach(el => {
         el.classList.toggle('hidden', !show);
     });
+    container.querySelectorAll(`.diff-summary-table [data-row-type="${type}"]`).forEach(row => {
+        row.classList.toggle('hidden', !show);
+    });
+    updateDiffSummaryState(container);
 }
 
 function setupDiffInteractions(container) {
@@ -1066,6 +1223,7 @@ function setupDiffInteractions(container) {
         });
     });
 
+    initializeTreeControls(container);
     syncScrollContainers(container);
 }
 
@@ -1073,16 +1231,129 @@ function toggleNode(container, nodeId) {
     const sections = container.querySelectorAll(`[data-children="${nodeId}"]`);
     if (!sections.length) return;
     const shouldExpand = Array.from(sections).some(section => section.classList.contains('hidden'));
+    setNodeExpansion(container, nodeId, shouldExpand);
+}
+
+function setNodeExpansion(container, nodeId, expand) {
+    const sections = container.querySelectorAll(`[data-children="${nodeId}"]`);
+    if (!sections.length) return;
     sections.forEach(section => {
-        section.classList.toggle('hidden', !shouldExpand);
+        section.classList.toggle('hidden', !expand);
     });
     container.querySelectorAll(`[data-preview="${nodeId}"]`).forEach(preview => {
-        preview.classList.toggle('hidden', shouldExpand);
+        preview.classList.toggle('hidden', expand);
     });
     container.querySelectorAll(`[data-toggle="${nodeId}"]`).forEach(toggle => {
-        toggle.textContent = shouldExpand ? '▼' : '▶';
-        toggle.setAttribute('aria-expanded', shouldExpand);
+        toggle.textContent = expand ? '▼' : '▶';
+        toggle.setAttribute('aria-expanded', expand);
     });
+}
+
+function initializeTreeControls(container) {
+    const controls = container.querySelector('.diff-tree-controls');
+    if (!controls) return;
+    const depthSelect = controls.querySelector('[data-depth-select]');
+    const buttons = Array.from(controls.querySelectorAll('button'));
+    const toggles = Array.from(container.querySelectorAll('.json-expand[data-toggle]'));
+    const depths = toggles.map(toggle => Number(toggle.getAttribute('data-depth') || '0'));
+    const maxDepth = depths.length ? Math.max(...depths) : 0;
+
+    if (!depthSelect) return;
+
+    if (!depths.length) {
+        depthSelect.innerHTML = '<option value="0">Level 0</option>';
+        depthSelect.disabled = true;
+        buttons.forEach(btn => { btn.disabled = true; });
+        updateDiffSummaryState(container);
+        return;
+    }
+
+    const options = [];
+    for (let depth = 0; depth <= maxDepth; depth += 1) {
+        options.push(`<option value="${depth}">Level ${depth}</option>`);
+    }
+    depthSelect.innerHTML = options.join('');
+    depthSelect.disabled = false;
+    const defaultDepth = Math.min(maxDepth, 1);
+    depthSelect.value = String(defaultDepth);
+    buttons.forEach(btn => { btn.disabled = false; });
+
+    controls.addEventListener('click', event => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        const action = target.getAttribute('data-action');
+        if (!action) return;
+        const selectedDepth = Number(depthSelect.value || '0');
+        switch (action) {
+            case 'expand-level':
+                expandNodesToDepth(container, selectedDepth);
+                break;
+            case 'collapse-level':
+                collapseNodesFromDepth(container, selectedDepth);
+                break;
+            case 'expand-all':
+                expandNodesToDepth(container, Number.MAX_SAFE_INTEGER);
+                break;
+            case 'collapse-all':
+                collapseNodesFromDepth(container, 0);
+                break;
+            default:
+                break;
+        }
+    });
+
+    updateDiffSummaryState(container);
+}
+
+function expandNodesToDepth(container, depth) {
+    forEachNodeToggle(container, (nodeId, nodeDepth) => {
+        setNodeExpansion(container, nodeId, nodeDepth <= depth);
+    });
+}
+
+function collapseNodesFromDepth(container, depth) {
+    forEachNodeToggle(container, (nodeId, nodeDepth) => {
+        if (nodeDepth >= depth) {
+            setNodeExpansion(container, nodeId, false);
+        }
+    });
+}
+
+function forEachNodeToggle(container, callback) {
+    const toggles = Array.from(container.querySelectorAll('.json-expand[data-toggle]'));
+    const processed = new Set();
+    toggles.forEach(toggle => {
+        const nodeId = toggle.getAttribute('data-toggle');
+        if (!nodeId || processed.has(nodeId)) return;
+        processed.add(nodeId);
+        const nodeDepth = Number(toggle.getAttribute('data-depth') || '0');
+        callback(nodeId, nodeDepth);
+    });
+}
+
+function updateDiffSummaryState(container) {
+    const rows = Array.from(container.querySelectorAll('.diff-summary-table tbody tr'));
+    if (!rows.length) {
+        const emptyState = container.querySelector('[data-summary-empty]');
+        if (emptyState) {
+            emptyState.classList.remove('hidden');
+        }
+        const count = container.querySelector('[data-summary-count]');
+        if (count) {
+            count.textContent = '0 entries';
+        }
+        return;
+    }
+
+    const visibleRows = rows.filter(row => !row.classList.contains('hidden'));
+    const count = container.querySelector('[data-summary-count]');
+    if (count) {
+        count.textContent = `${visibleRows.length} of ${rows.length} entries shown`;
+    }
+    const emptyState = container.querySelector('[data-summary-empty]');
+    if (emptyState) {
+        emptyState.classList.toggle('hidden', visibleRows.length > 0);
+    }
 }
 
 function syncScrollContainers(container) {
@@ -1172,6 +1443,11 @@ videoDownloadBtn.addEventListener('click', async () => {
 });
 
 // Helper functions
+function escapeAttribute(text) {
+    if (text === undefined || text === null) return '';
+    return escapeHtml(String(text)).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;


### PR DESCRIPTION
## Summary
- refresh the JSON diff color palette for improved readability in light and dark themes
- add depth controls that expand or collapse the JSON compare tree to a chosen level or entirely
- introduce a synced change summary table that updates with visibility filters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5743fb7688320a0b0ca4f98366d91