### PR TITLE
Add monitor management UI and API

### DIFF
--- a/static/monitor.html
+++ b/static/monitor.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monitor</title>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <link rel="stylesheet" href="/static/site.css">
+    <script src="/static/utils.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha384-xw+leChX2NDSSSXoqV4bqKu7p710RYtyTCG9a5NmL5euj5cPNWW5UZ+4TL7CBrzE" crossorigin="anonymous" defer></script>
+    <script src="/static/monitor.js" defer></script>
+</head>
+<body>
+
+<nav id="page-links" class="page-links mb-1">
+    <a href="/">Main</a>
+    <a href="device.html">Device View</a>
+    <a href="database.html">Database Management</a>
+    <a href="maintenance.html">Maintenance</a>
+    <a href="tools.html">Tools</a>
+    <a href="monitor.html" aria-current="page">Monitor</a>
+    <a href="shared.html">Shared</a>
+    <a href="memo.html">Memo's</a>
+    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
+</nav>
+
+<header class="monitor-page-header">
+    <h1 id="monitor-title" class="monitor-title">
+        <img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">
+        Monitor
+    </h1>
+    <p class="monitor-subtitle rci-muted">Configureer servicebewaking, voer handmatige controles uit en bekijk recente resultaten.</p>
+</header>
+
+<main class="monitor-layout" aria-labelledby="monitor-title">
+    <section class="monitor-form rci-card" aria-labelledby="monitor-form-heading">
+        <div class="monitor-section-header">
+            <h2 id="monitor-form-heading">Nieuwe monitor toevoegen</h2>
+            <p class="rci-muted">Ondersteunt HTTP(S), URL-wijzigingsdetectie en veelgebruikte netwerkservices.</p>
+        </div>
+        <form id="monitor-form" class="monitor-form-grid" novalidate>
+            <div class="monitor-form-row">
+                <label for="monitor-name">Naam<span aria-hidden="true">*</span></label>
+                <input id="monitor-name" name="name" type="text" required placeholder="Bijvoorbeeld API-status" autocomplete="off">
+            </div>
+
+            <div class="monitor-inline-group">
+                <div class="monitor-form-row">
+                    <label for="monitor-service">Service<span aria-hidden="true">*</span></label>
+                    <select id="monitor-service" name="service" required></select>
+                </div>
+                <div class="monitor-form-row">
+                    <label for="monitor-target">Doel<span aria-hidden="true">*</span></label>
+                    <input id="monitor-target" name="target" type="text" required placeholder="URL, host of resource">
+                </div>
+            </div>
+
+            <div id="monitor-url-options" class="monitor-inline-group hidden" aria-hidden="true">
+                <div class="monitor-form-row">
+                    <label for="monitor-url-check">URL-controle</label>
+                    <select id="monitor-url-check" name="urlCheck">
+                        <option value="availability">Beschikbaarheid</option>
+                        <option value="change">Wijziging detecteren</option>
+                    </select>
+                </div>
+                <div class="monitor-form-row">
+                    <label for="monitor-timeout">Timeout (seconden)</label>
+                    <input id="monitor-timeout" name="timeout" type="number" min="1" max="60" step="1" placeholder="15">
+                </div>
+            </div>
+
+            <div class="monitor-inline-group">
+                <div class="monitor-form-row">
+                    <label for="monitor-interval-value">Polling-interval<span aria-hidden="true">*</span></label>
+                    <div class="monitor-interval-group">
+                        <input id="monitor-interval-value" name="intervalValue" type="number" min="1" value="5" required>
+                        <select id="monitor-interval-unit" name="intervalUnit">
+                            <option value="minutes">Minuten</option>
+                            <option value="seconds">Seconden</option>
+                            <option value="hours">Uren</option>
+                            <option value="days">Dagen</option>
+                        </select>
+                    </div>
+                </div>
+                <div id="monitor-port-wrapper" class="monitor-form-row">
+                    <label for="monitor-port">Poort</label>
+                    <input id="monitor-port" name="port" type="number" min="1" max="65535" placeholder="Bijvoorbeeld 443">
+                </div>
+            </div>
+
+            <div class="monitor-form-row">
+                <label for="monitor-notes">Notitie</label>
+                <textarea id="monitor-notes" name="notes" rows="3" placeholder="Extra details of instructies"></textarea>
+            </div>
+
+            <div class="monitor-actions">
+                <button type="submit" class="focus-ring">Opslaan</button>
+                <button type="button" id="monitor-cancel-edit" class="secondary-button focus-ring hidden">Annuleren</button>
+                <button type="button" id="monitor-refresh" class="secondary-button focus-ring">Vernieuwen</button>
+            </div>
+            <div id="monitor-form-status" class="status-message" role="status" aria-live="polite"></div>
+        </form>
+    </section>
+
+    <section class="monitor-list rci-card" aria-labelledby="monitor-list-heading">
+        <div class="monitor-section-header">
+            <h2 id="monitor-list-heading">Actieve monitors</h2>
+            <p class="rci-muted">Bekijk status, histogrammen en laatste controles.</p>
+        </div>
+        <div id="monitor-list" class="monitor-card-grid" aria-live="polite" aria-busy="false"></div>
+        <div id="monitor-empty" class="monitor-empty rci-muted" role="status">Er zijn nog geen monitors geconfigureerd.</div>
+    </section>
+</main>
+
+<div id="monitor-log-overlay" class="monitor-log-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="monitor-log-title">
+    <div class="monitor-log-panel rci-card">
+        <div class="monitor-log-header">
+            <h2 id="monitor-log-title">Monitorlog</h2>
+            <button type="button" id="monitor-log-close" class="secondary-button focus-ring">Sluiten</button>
+        </div>
+        <div id="monitor-log-content" class="monitor-log-content" aria-live="polite"></div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/static/monitor.js
+++ b/static/monitor.js
@@ -1,0 +1,618 @@
+(() => {
+    const state = {
+        services: [],
+        urlCheckTypes: [],
+        pollingUnits: [],
+        monitors: [],
+        editingId: null,
+        charts: new Map(),
+    };
+
+    const elements = {
+        form: document.getElementById('monitor-form'),
+        formHeading: document.getElementById('monitor-form-heading'),
+        name: document.getElementById('monitor-name'),
+        service: document.getElementById('monitor-service'),
+        target: document.getElementById('monitor-target'),
+        urlOptions: document.getElementById('monitor-url-options'),
+        urlCheck: document.getElementById('monitor-url-check'),
+        timeout: document.getElementById('monitor-timeout'),
+        intervalValue: document.getElementById('monitor-interval-value'),
+        intervalUnit: document.getElementById('monitor-interval-unit'),
+        portWrapper: document.getElementById('monitor-port-wrapper'),
+        port: document.getElementById('monitor-port'),
+        notes: document.getElementById('monitor-notes'),
+        cancelEdit: document.getElementById('monitor-cancel-edit'),
+        refresh: document.getElementById('monitor-refresh'),
+        status: document.getElementById('monitor-form-status'),
+        list: document.getElementById('monitor-list'),
+        empty: document.getElementById('monitor-empty'),
+        overlay: document.getElementById('monitor-log-overlay'),
+        overlayClose: document.getElementById('monitor-log-close'),
+        overlayContent: document.getElementById('monitor-log-content'),
+        overlayTitle: document.getElementById('monitor-log-title'),
+    };
+
+    const PORT_SERVICE_TYPES = new Set(['tcp', 'udp', 'smtp', 'imap', 'pop3', 'ftp', 'sftp', 'ssh', 'dns']);
+    const ACTIVE_RUN_TYPES = new Set(['http', 'https', 'url']);
+
+    const DEFAULT_PORT_PLACEHOLDERS = {
+        smtp: '25',
+        imap: '143',
+        pop3: '110',
+        ftp: '21',
+        sftp: '22',
+        ssh: '22',
+        dns: '53',
+    };
+
+    function escapeHtml(value) {
+        if (value == null) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function formatDate(value) {
+        if (!value) {
+            return '—';
+        }
+        try {
+            return typeof formatDutchTime === 'function' ? formatDutchTime(value) : new Date(value).toLocaleString();
+        } catch (error) {
+            return value;
+        }
+    }
+
+    function setFormStatus(message, type = 'info') {
+        if (!elements.status) return;
+        elements.status.textContent = message || '';
+        if (!message) {
+            elements.status.classList.remove('status-success', 'status-error');
+            elements.status.style.display = 'none';
+            return;
+        }
+        elements.status.style.display = 'block';
+        elements.status.classList.remove('status-success', 'status-error');
+        if (type === 'success') {
+            elements.status.classList.add('status-success');
+        } else if (type === 'error') {
+            elements.status.classList.add('status-error');
+        }
+    }
+
+    function toggleElement(element, show) {
+        if (!element) return;
+        element.classList.toggle('hidden', !show);
+        element.setAttribute('aria-hidden', show ? 'false' : 'true');
+        if (!show) {
+            element.querySelectorAll('input, select, textarea').forEach((input) => {
+                input.value = '';
+            });
+        }
+    }
+
+    function toggleUrlOptions(serviceType) {
+        const shouldShow = ACTIVE_RUN_TYPES.has(serviceType);
+        toggleElement(elements.urlOptions, shouldShow);
+        if (elements.urlCheck) {
+            elements.urlCheck.value = 'availability';
+        }
+        if (!shouldShow && elements.timeout) {
+            elements.timeout.value = '';
+        }
+    }
+
+    function togglePortField(serviceType) {
+        const shouldShow = PORT_SERVICE_TYPES.has(serviceType);
+        if (!elements.portWrapper) return;
+        elements.portWrapper.classList.toggle('hidden', !shouldShow);
+        elements.portWrapper.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+        if (shouldShow) {
+            const placeholder = DEFAULT_PORT_PLACEHOLDERS[serviceType] || 'Bijvoorbeeld 443';
+            elements.port.placeholder = placeholder;
+        } else {
+            elements.port.value = '';
+        }
+    }
+
+    function resetForm() {
+        state.editingId = null;
+        elements.formHeading.textContent = 'Nieuwe monitor toevoegen';
+        elements.form.reset();
+        elements.intervalValue.value = '5';
+        if (elements.intervalUnit) {
+            elements.intervalUnit.value = 'minutes';
+        }
+        toggleUrlOptions(elements.service.value || 'http');
+        togglePortField(elements.service.value || 'http');
+        elements.cancelEdit.classList.add('hidden');
+        setFormStatus('');
+        elements.name.focus();
+    }
+
+    function getIntervalParts(seconds) {
+        const mappings = [
+            { unit: 'days', label: 'days', seconds: 86400 },
+            { unit: 'hours', label: 'hours', seconds: 3600 },
+            { unit: 'minutes', label: 'minutes', seconds: 60 },
+            { unit: 'seconds', label: 'seconds', seconds: 1 },
+        ];
+
+        for (const mapping of mappings) {
+            if (seconds % mapping.seconds === 0) {
+                return { value: String(seconds / mapping.seconds), unit: mapping.unit };
+            }
+        }
+        return { value: String(seconds), unit: 'seconds' };
+    }
+
+    async function loadMetadata() {
+        try {
+            const response = await fetch('/api/monitors/metadata');
+            if (!response.ok) {
+                throw new Error('Kon metadata niet laden');
+            }
+            const payload = await response.json();
+            state.services = Array.isArray(payload.services) ? payload.services : [];
+            state.urlCheckTypes = Array.isArray(payload.url_check_types) ? payload.url_check_types : [];
+            state.pollingUnits = Array.isArray(payload.polling_units) ? payload.polling_units : ['seconds', 'minutes', 'hours', 'days'];
+
+            if (elements.service) {
+                elements.service.innerHTML = state.services
+                    .map((entry) => `<option value="${escapeHtml(entry.id)}">${escapeHtml(entry.label)}</option>`)
+                    .join('');
+            }
+
+            if (elements.urlCheck && state.urlCheckTypes.length) {
+                elements.urlCheck.innerHTML = state.urlCheckTypes
+                    .map((entry) => `<option value="${escapeHtml(entry)}">${escapeHtml(entry.charAt(0).toUpperCase() + entry.slice(1))}</option>`)
+                    .join('');
+            }
+
+            if (elements.intervalUnit && state.pollingUnits.length) {
+                elements.intervalUnit.innerHTML = state.pollingUnits
+                    .map((entry) => {
+                        const label = entry.charAt(0).toUpperCase() + entry.slice(1);
+                        return `<option value="${escapeHtml(entry)}">${escapeHtml(label)}</option>`;
+                    })
+                    .join('');
+                elements.intervalUnit.value = state.pollingUnits.includes('minutes') ? 'minutes' : state.pollingUnits[0];
+            }
+
+            toggleUrlOptions(elements.service.value || 'http');
+            togglePortField(elements.service.value || 'http');
+        } catch (error) {
+            console.error(error);
+            setFormStatus('Kon metadata niet laden.', 'error');
+        }
+    }
+
+    async function loadMonitors(showToast = false) {
+        elements.list.setAttribute('aria-busy', 'true');
+        try {
+            const response = await fetch('/api/monitors?include_history=true&history_limit=40');
+            if (!response.ok) {
+                throw new Error('Kon monitors niet ophalen');
+            }
+            const payload = await response.json();
+            state.monitors = Array.isArray(payload.monitors) ? payload.monitors : [];
+            renderMonitors();
+            if (showToast) {
+                setFormStatus('Monitoroverzicht vernieuwd.', 'success');
+            }
+        } catch (error) {
+            console.error(error);
+            setFormStatus('Kon monitors niet ophalen.', 'error');
+        } finally {
+            elements.list.setAttribute('aria-busy', 'false');
+        }
+    }
+
+    function destroyCharts() {
+        state.charts.forEach((chart) => {
+            if (chart && typeof chart.destroy === 'function') {
+                chart.destroy();
+            }
+        });
+        state.charts.clear();
+    }
+
+    function summarizeResults(results) {
+        const summary = { success: 0, warning: 0, failure: 0, change: 0 };
+        (results || []).forEach((result) => {
+            const status = (result.status || '').toLowerCase();
+            if (status === 'warning') {
+                summary.warning += 1;
+            } else if (status === 'success') {
+                summary.success += 1;
+            } else if (status === 'failure') {
+                summary.failure += 1;
+            } else {
+                summary.failure += 1;
+            }
+            if (result.change_detected) {
+                summary.change += 1;
+            }
+        });
+        return summary;
+    }
+
+    function renderHistogram(canvas, monitor) {
+        if (!canvas || typeof Chart === 'undefined') {
+            return;
+        }
+        const summary = summarizeResults(monitor.recent_results || []);
+        const dataset = [summary.success, summary.warning, summary.failure];
+        const chart = new Chart(canvas, {
+            type: 'bar',
+            data: {
+                labels: ['Succes', 'Waarschuwing', 'Fout'],
+                datasets: [
+                    {
+                        label: 'Aantal gebeurtenissen',
+                        data: dataset,
+                        backgroundColor: [
+                            'rgba(25,135,84,0.7)',
+                            'rgba(255,193,7,0.7)',
+                            'rgba(220,53,69,0.7)',
+                        ],
+                        borderRadius: 6,
+                        borderSkipped: false,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        grid: { display: false },
+                    },
+                    y: {
+                        beginAtZero: true,
+                        ticks: { precision: 0 },
+                        grid: { color: 'rgba(0,0,0,0.08)' },
+                    },
+                },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label(context) {
+                                return `${context.parsed.y} gebeurtenissen`;
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        state.charts.set(monitor.id, chart);
+    }
+
+    function getStatusMeta(monitor) {
+        const latest = (monitor.recent_results || [])[0] || null;
+        const statusValue = (latest && latest.status) || monitor.last_status || 'unknown';
+        const normalized = statusValue.toLowerCase();
+        let label = 'Onbekend';
+        let css = 'monitor-status-neutral';
+        if (normalized === 'success') {
+            label = 'Online';
+            css = 'monitor-status-success';
+        } else if (normalized === 'warning') {
+            label = 'Wijziging';
+            css = 'monitor-status-warning';
+        } else if (normalized === 'failure') {
+            label = 'Storing';
+            css = 'monitor-status-failure';
+        }
+        return { label, css, latest };
+    }
+
+    function renderMonitors() {
+        destroyCharts();
+        elements.list.innerHTML = '';
+        if (!state.monitors.length) {
+            elements.empty.classList.remove('hidden');
+            return;
+        }
+        elements.empty.classList.add('hidden');
+
+        state.monitors.forEach((monitor) => {
+            const card = document.createElement('article');
+            card.className = 'monitor-card';
+            const { label: statusLabel, css: statusClass, latest } = getStatusMeta(monitor);
+            const lastChecked = latest?.checked_at || monitor.last_checked_at;
+            const lastMessage = latest?.message || monitor.last_message || '—';
+            const responseTime = typeof latest?.response_time_ms === 'number' ? `${latest.response_time_ms} ms` : '—';
+            const availability = latest?.is_available == null ? '—' : latest.is_available ? 'Ja' : 'Nee';
+            const changeCount = summarizeResults(monitor.recent_results || []).change;
+
+            card.innerHTML = `
+                <div class="monitor-card-header">
+                    <div>
+                        <h3 class="monitor-card-title">${escapeHtml(monitor.name)}</h3>
+                        <p class="monitor-card-subtitle rci-muted">${escapeHtml(monitor.service_label || monitor.service_type)}</p>
+                    </div>
+                    <span class="monitor-status ${statusClass}">${escapeHtml(statusLabel)}</span>
+                </div>
+                <div class="monitor-card-body">
+                    <dl class="monitor-meta">
+                        <div>
+                            <dt>Doel</dt>
+                            <dd title="${escapeHtml(monitor.target)}">${escapeHtml(monitor.target)}</dd>
+                        </div>
+                        <div>
+                            <dt>Interval</dt>
+                            <dd>${escapeHtml(monitor.polling_interval?.display || '')}</dd>
+                        </div>
+                        <div>
+                            <dt>Laatst gecontroleerd</dt>
+                            <dd>${escapeHtml(formatDate(lastChecked))}</dd>
+                        </div>
+                        <div>
+                            <dt>Beschikbaar</dt>
+                            <dd>${escapeHtml(availability)}</dd>
+                        </div>
+                        <div>
+                            <dt>Respons</dt>
+                            <dd>${escapeHtml(responseTime)}</dd>
+                        </div>
+                    </dl>
+                    <p class="monitor-message">${escapeHtml(lastMessage)}</p>
+                    ${monitor.notes ? `<p class="monitor-notes rci-muted">${escapeHtml(monitor.notes)}</p>` : ''}
+                </div>
+                <div class="monitor-chart" aria-hidden="${(monitor.recent_results || []).length ? 'false' : 'true'}">
+                    <canvas aria-label="Beschikbaarheids-histogram" role="img"></canvas>
+                    <p class="monitor-chart-meta rci-muted">Wijzigingen gedetecteerd: ${changeCount}</p>
+                </div>
+                <div class="monitor-card-actions">
+                    <button type="button" class="focus-ring" data-action="edit">Bewerken</button>
+                    <button type="button" class="secondary-button focus-ring" data-action="log">Log bekijken</button>
+                    <button type="button" class="secondary-button focus-ring" data-action="run" ${ACTIVE_RUN_TYPES.has(monitor.service_type) ? '' : 'disabled title="Deze service ondersteunt geen directe controle"'}>Controleer nu</button>
+                    <button type="button" class="danger-button focus-ring" data-action="delete">Verwijderen</button>
+                </div>
+            `;
+
+            const canvas = card.querySelector('canvas');
+            if (canvas && (monitor.recent_results || []).length) {
+                renderHistogram(canvas, monitor);
+            }
+
+            card.querySelector('[data-action="edit"]').addEventListener('click', () => beginEditMonitor(monitor));
+            card.querySelector('[data-action="delete"]').addEventListener('click', () => deleteMonitor(monitor));
+            card.querySelector('[data-action="log"]').addEventListener('click', () => openLogOverlay(monitor));
+            const runButton = card.querySelector('[data-action="run"]');
+            if (runButton && !runButton.disabled) {
+                runButton.addEventListener('click', () => runMonitor(monitor));
+            }
+
+            elements.list.appendChild(card);
+        });
+    }
+
+    function populateForm(monitor) {
+        state.editingId = monitor.id;
+        elements.formHeading.textContent = 'Monitor bijwerken';
+        elements.name.value = monitor.name || '';
+        elements.service.value = monitor.service_type;
+        elements.target.value = monitor.target || '';
+        const intervalParts = getIntervalParts(Number(monitor.polling_interval?.seconds || monitor.polling_interval_seconds || 60));
+        elements.intervalValue.value = intervalParts.value;
+        elements.intervalUnit.value = intervalParts.unit;
+        toggleUrlOptions(monitor.service_type);
+        togglePortField(monitor.service_type);
+        if (ACTIVE_RUN_TYPES.has(monitor.service_type)) {
+            elements.urlCheck.value = monitor.url_check_type || 'availability';
+            elements.timeout.value = monitor.config?.timeout || '';
+        }
+        if (PORT_SERVICE_TYPES.has(monitor.service_type) && monitor.config?.port) {
+            elements.port.value = monitor.config.port;
+        }
+        elements.notes.value = monitor.notes || '';
+        elements.cancelEdit.classList.remove('hidden');
+        setFormStatus('');
+    }
+
+    async function submitForm(event) {
+        event.preventDefault();
+        setFormStatus('');
+
+        if (!elements.form.checkValidity()) {
+            setFormStatus('Controleer de invoer en probeer opnieuw.', 'error');
+            return;
+        }
+
+        const payload = {
+            name: elements.name.value.trim(),
+            service_type: elements.service.value,
+            target: elements.target.value.trim(),
+            polling_value: Number(elements.intervalValue.value || 0),
+            polling_unit: elements.intervalUnit.value,
+            url_check_type: ACTIVE_RUN_TYPES.has(elements.service.value) ? elements.urlCheck.value : null,
+            notes: elements.notes.value.trim() || null,
+            config: {},
+        };
+
+        if (elements.timeout && elements.timeout.value) {
+            const timeoutValue = Number(elements.timeout.value);
+            if (!Number.isNaN(timeoutValue)) {
+                payload.config.timeout = timeoutValue;
+            }
+        }
+
+        if (PORT_SERVICE_TYPES.has(elements.service.value)) {
+            const portValue = Number(elements.port.value);
+            if (!Number.isNaN(portValue) && portValue > 0) {
+                payload.config.port = portValue;
+            }
+        }
+
+        if (!Object.keys(payload.config).length) {
+            delete payload.config;
+        }
+
+        const isUpdate = state.editingId != null;
+        const endpoint = isUpdate ? `/api/monitors/${state.editingId}` : '/api/monitors';
+        const method = isUpdate ? 'PUT' : 'POST';
+
+        try {
+            const response = await fetch(endpoint, {
+                method,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            if (!response.ok) {
+                const errorPayload = await response.json().catch(() => ({}));
+                throw new Error(errorPayload.detail || 'Opslaan mislukt');
+            }
+            await loadMonitors();
+            setFormStatus(isUpdate ? 'Monitor bijgewerkt.' : 'Monitor toegevoegd.', 'success');
+            resetForm();
+        } catch (error) {
+            console.error(error);
+            setFormStatus(error.message || 'Opslaan mislukt.', 'error');
+        }
+    }
+
+    function beginEditMonitor(monitor) {
+        populateForm(monitor);
+        elements.name.focus();
+    }
+
+    async function deleteMonitor(monitor) {
+        if (!window.confirm(`Weet je zeker dat je '${monitor.name}' wilt verwijderen?`)) {
+            return;
+        }
+        try {
+            const response = await fetch(`/api/monitors/${monitor.id}`, { method: 'DELETE' });
+            if (!response.ok) {
+                const payload = await response.json().catch(() => ({}));
+                throw new Error(payload.detail || 'Verwijderen mislukt');
+            }
+            await loadMonitors();
+            setFormStatus('Monitor verwijderd.', 'success');
+            if (state.editingId === monitor.id) {
+                resetForm();
+            }
+        } catch (error) {
+            console.error(error);
+            setFormStatus(error.message || 'Verwijderen mislukt.', 'error');
+        }
+    }
+
+    async function runMonitor(monitor) {
+        try {
+            const response = await fetch(`/api/monitors/${monitor.id}/run`, { method: 'POST' });
+            if (!response.ok) {
+                const payload = await response.json().catch(() => ({}));
+                throw new Error(payload.detail || 'Controle uitvoeren mislukt');
+            }
+            await loadMonitors(true);
+        } catch (error) {
+            console.error(error);
+            setFormStatus(error.message || 'Controle uitvoeren mislukt.', 'error');
+        }
+    }
+
+    async function openLogOverlay(monitor) {
+        elements.overlay.classList.remove('hidden');
+        elements.overlayTitle.textContent = `Monitorlog · ${monitor.name}`;
+        elements.overlayContent.innerHTML = '<p class="rci-muted">Log wordt geladen...</p>';
+
+        try {
+            const response = await fetch(`/api/monitors/${monitor.id}/logs?limit=200`);
+            if (!response.ok) {
+                throw new Error('Kon monitorlog niet ophalen');
+            }
+            const payload = await response.json();
+            const results = payload.results || [];
+            if (!results.length) {
+                elements.overlayContent.innerHTML = '<p class="rci-muted">Nog geen loggegevens beschikbaar.</p>';
+                return;
+            }
+
+            const rows = results
+                .map((result) => {
+                    const status = escapeHtml((result.status || '').toUpperCase());
+                    const available = result.is_available == null ? '—' : result.is_available ? 'Ja' : 'Nee';
+                    const responseTime = typeof result.response_time_ms === 'number' ? `${result.response_time_ms} ms` : '—';
+                    return `
+                        <tr>
+                            <td>${escapeHtml(formatDate(result.checked_at))}</td>
+                            <td>${status}</td>
+                            <td>${escapeHtml(available)}</td>
+                            <td>${escapeHtml(responseTime)}</td>
+                            <td>${escapeHtml(result.message || '')}</td>
+                        </tr>
+                    `;
+                })
+                .join('');
+
+            elements.overlayContent.innerHTML = `
+                <table class="monitor-log-table">
+                    <thead>
+                        <tr>
+                            <th>Tijdstip</th>
+                            <th>Status</th>
+                            <th>Beschikbaar</th>
+                            <th>Respons</th>
+                            <th>Bericht</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            `;
+        } catch (error) {
+            console.error(error);
+            elements.overlayContent.innerHTML = '<p class="status-error">Kon monitorlog niet laden.</p>';
+        }
+
+        elements.overlayClose.focus();
+    }
+
+    function closeOverlay() {
+        elements.overlay.classList.add('hidden');
+        elements.overlayContent.innerHTML = '';
+    }
+
+    function handleServiceChange() {
+        const serviceType = elements.service.value;
+        toggleUrlOptions(serviceType);
+        togglePortField(serviceType);
+    }
+
+    function initialize() {
+        if (!elements.form) {
+            return;
+        }
+        elements.form.addEventListener('submit', submitForm);
+        elements.cancelEdit.addEventListener('click', resetForm);
+        elements.refresh.addEventListener('click', () => loadMonitors(true));
+        elements.service.addEventListener('change', handleServiceChange);
+        elements.overlayClose.addEventListener('click', closeOverlay);
+        elements.overlay.addEventListener('click', (event) => {
+            if (event.target === elements.overlay) {
+                closeOverlay();
+            }
+        });
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && !elements.overlay.classList.contains('hidden')) {
+                closeOverlay();
+            }
+        });
+
+        loadMetadata().then(() => loadMonitors());
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialize);
+    } else {
+        initialize();
+    }
+})();

--- a/static/site.css
+++ b/static/site.css
@@ -153,6 +153,10 @@ body::-webkit-scrollbar-thumb:hover { background:var(--rci-primary); }
 
 /* Panel / card generic style */
 .rci-card { background:var(--rci-surface); border:1px solid var(--rci-border); border-radius:8px; padding:12px; box-shadow:var(--rci-shadow); }
+.secondary-button { background:var(--rci-surface-alt); border:1px solid var(--rci-border); color:var(--rci-text); padding:0.5rem 1rem; border-radius:var(--rci-radius); cursor:pointer; transition:background .2s ease, color .2s ease, border-color .2s ease; }
+.secondary-button:hover { background:var(--rci-bg-alt); }
+.danger-button { background:var(--rci-danger); color:#fff; border:1px solid var(--rci-danger); border-radius:var(--rci-radius); padding:0.5rem 1rem; cursor:pointer; transition:opacity .2s ease; }
+.danger-button:hover { opacity:.85; }
 .flex-row { display:flex; gap:8px; align-items:center; }
 .flex-row.space-between { justify-content:space-between; }
 
@@ -526,3 +530,86 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
   .compare-grid, .side-by-side { grid-template-columns:1fr; }
 }
 
+
+/* Monitor page */
+.monitor-page-header { display:flex; flex-direction:column; gap:.5rem; margin-bottom:1.5rem; }
+.monitor-title { display:flex; align-items:center; gap:.75rem; margin:0; font-size:2rem; }
+.monitor-subtitle { margin:0; }
+.monitor-layout { display:grid; grid-template-columns: minmax(0, 380px) minmax(0, 1fr); gap:1.5rem; align-items:start; }
+.monitor-form { position:sticky; top:1rem; display:flex; flex-direction:column; gap:1rem; }
+.monitor-form-grid { display:grid; gap:1rem; }
+.monitor-form-row { display:flex; flex-direction:column; gap:.25rem; }
+.monitor-form-row input,
+.monitor-form-row select,
+.monitor-form-row textarea { padding:.55rem .6rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); font:inherit; background:var(--rci-surface); color:var(--rci-text); transition:border-color .2s ease, box-shadow .2s ease; }
+.monitor-form-row input:focus,
+.monitor-form-row select:focus,
+.monitor-form-row textarea:focus { outline:none; border-color:var(--rci-primary); box-shadow:var(--rci-focus-ring); }
+.monitor-inline-group { display:grid; gap:1rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.monitor-interval-group { display:flex; gap:.5rem; }
+.monitor-interval-group input { flex:1; }
+.monitor-interval-group select { min-width:120px; }
+.monitor-actions { display:flex; flex-wrap:wrap; gap:.75rem; align-items:center; }
+.monitor-actions button { padding:.55rem 1.1rem; border-radius:var(--rci-radius); border:1px solid var(--rci-primary); background:var(--rci-primary); color:#fff; cursor:pointer; transition:background .2s ease, border-color .2s ease; }
+.monitor-actions button:hover { background:var(--rci-primary-accent); border-color:var(--rci-primary-accent); }
+.monitor-actions .secondary-button { border-color:var(--rci-border); background:var(--rci-surface-alt); color:var(--rci-text); }
+.monitor-actions .secondary-button:hover { background:var(--rci-bg-alt); }
+.monitor-actions .danger-button { border-color:var(--rci-danger); background:var(--rci-danger); }
+.monitor-actions .danger-button:hover { background:#c82333; border-color:#c82333; }
+.monitor-list { display:flex; flex-direction:column; gap:1.25rem; }
+.monitor-card-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:1rem; }
+.monitor-card { background:var(--rci-surface); border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:1.2rem; box-shadow:var(--rci-shadow); display:flex; flex-direction:column; gap:1rem; }
+.monitor-card-header { display:flex; justify-content:space-between; gap:1rem; align-items:flex-start; }
+.monitor-card-title { margin:0; font-size:1.25rem; }
+.monitor-card-subtitle { margin:.25rem 0 0; font-size:.95rem; }
+.monitor-card-body { display:flex; flex-direction:column; gap:.75rem; }
+.monitor-meta { margin:0; display:grid; gap:.75rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.monitor-meta div { display:flex; flex-direction:column; gap:.25rem; }
+.monitor-meta dt { font-weight:600; font-size:.85rem; color:var(--rci-text-muted); }
+.monitor-meta dd { margin:0; font-size:.95rem; word-break:break-word; }
+.monitor-message { margin:0; font-size:.95rem; }
+.monitor-notes { margin:0; font-size:.9rem; }
+.monitor-chart { position:relative; height:160px; display:flex; flex-direction:column; gap:.5rem; }
+.monitor-chart canvas { width:100%; height:100%; }
+.monitor-chart-meta { margin:0; font-size:.85rem; }
+.monitor-card-actions { display:flex; flex-wrap:wrap; gap:.75rem; }
+.monitor-card-actions button { padding:.5rem 1rem; border-radius:var(--rci-radius); border:1px solid var(--rci-border); background:var(--rci-surface-alt); color:var(--rci-text); cursor:pointer; transition:background .2s ease, color .2s ease; }
+.monitor-card-actions button:hover:not([disabled]) { background:var(--rci-bg-alt); }
+.monitor-card-actions .danger-button { background:var(--rci-danger); color:#fff; border-color:var(--rci-danger); }
+.monitor-card-actions .danger-button:hover { opacity:.9; }
+.monitor-card-actions button[disabled] { opacity:.6; cursor:not-allowed; }
+.monitor-status { display:inline-flex; align-items:center; gap:.35rem; padding:.3rem .75rem; border-radius:999px; font-weight:600; font-size:.85rem; }
+.monitor-status-success { background:rgba(25,135,84,0.15); color:#198754; }
+.monitor-status-warning { background:rgba(255,193,7,0.18); color:#856404; }
+.monitor-status-failure { background:rgba(220,53,69,0.18); color:#b02a37; }
+.monitor-status-neutral { background:var(--rci-surface-alt); color:var(--rci-text-muted); }
+.monitor-empty { text-align:center; padding:2rem; border:1px dashed var(--rci-border); border-radius:var(--rci-radius); }
+.monitor-log-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.55); display:flex; align-items:center; justify-content:center; padding:2rem; z-index:1000; }
+.monitor-log-panel { width:min(90vw, 760px); max-height:80vh; overflow:auto; display:flex; flex-direction:column; gap:1rem; }
+.monitor-log-header { display:flex; justify-content:space-between; align-items:center; gap:1rem; }
+.monitor-log-content { overflow:auto; }
+.monitor-log-table { width:100%; border-collapse:collapse; }
+.monitor-log-table th,
+.monitor-log-table td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--rci-border); font-size:.95rem; }
+.monitor-log-table tbody tr:hover { background:var(--rci-bg-alt); }
+
+@media (max-width: 1080px) {
+  .monitor-layout { grid-template-columns: 1fr; }
+  .monitor-form { position:static; }
+}
+
+@media (max-width: 640px) {
+  .monitor-card-grid { grid-template-columns: 1fr; }
+  .monitor-card-actions { flex-direction:column; align-items:stretch; }
+  .monitor-card-actions button { width:100%; text-align:center; }
+}
+
+[data-theme="dark"] .monitor-card { background:#1f2a33; border-color:#2f3d47; }
+[data-theme="dark"] .monitor-form-row input,
+[data-theme="dark"] .monitor-form-row select,
+[data-theme="dark"] .monitor-form-row textarea { background:#1b242c; border-color:#2f3d47; color:#f5f5f5; }
+[data-theme="dark"] .monitor-card-actions button { background:#23303a; color:#f5f5f5; border-color:#2f3d47; }
+[data-theme="dark"] .monitor-card-actions button:hover:not([disabled]) { background:#2f3d47; }
+[data-theme="dark"] .monitor-chart-meta { color:#9fb3c8; }
+[data-theme="dark"] .monitor-log-panel { background:#1f2a33; border:1px solid #2f3d47; }
+[data-theme="dark"] .monitor-log-table tbody tr:hover { background:#2f3d47; }

--- a/static/tools.html
+++ b/static/tools.html
@@ -24,6 +24,7 @@
     <a href="device.html">Device View</a>
     <a href="database.html">Database Management</a>
     <a href="maintenance.html">Maintenance</a>
+    <a href="monitor.html">Monitor</a>
     <a href="shared.html">Shared</a>
     <a href="memo.html">Memo's</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>


### PR DESCRIPTION
## Summary
- extend the database schema with RCI_monitors and RCI_monitor_results plus CRUD helpers
- add FastAPI monitor endpoints, validation, and HTTP run support with change detection logic
- create a monitor management page with Chart.js visualisation, JavaScript controls, and updated styling/navigation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5a8bc7f608320a7a27022518079e8