### PR TITLE
Enable manual monitor runs for host monitors

### DIFF
--- a/static/monitor.js
+++ b/static/monitor.js
@@ -34,7 +34,19 @@
     };
 
     const PORT_SERVICE_TYPES = new Set(['tcp', 'udp', 'smtp', 'imap', 'pop3', 'ftp', 'sftp', 'ssh', 'dns']);
-    const ACTIVE_RUN_TYPES = new Set(['http', 'https', 'url']);
+    const URL_SERVICE_TYPES = new Set(['http', 'https', 'url']);
+    const ACTIVE_RUN_TYPES = new Set([
+        ...URL_SERVICE_TYPES,
+        'ping',
+        'tcp',
+        'smtp',
+        'imap',
+        'pop3',
+        'ftp',
+        'sftp',
+        'ssh',
+        'dns',
+    ]);
 
     const DEFAULT_PORT_PLACEHOLDERS = {
         smtp: '25',
@@ -98,7 +110,7 @@
     }
 
     function toggleUrlOptions(serviceType) {
-        const shouldShow = ACTIVE_RUN_TYPES.has(serviceType);
+        const shouldShow = URL_SERVICE_TYPES.has(serviceType);
         toggleElement(elements.urlOptions, shouldShow);
         if (elements.urlCheck) {
             elements.urlCheck.value = 'availability';


### PR DESCRIPTION
## Summary
- add backend network check helpers for ping, TCP-based services, and DNS
- allow manual runs for additional monitor types while keeping URL-only options scoped correctly

## Testing
- `pytest`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5bf92329883208cbf1f2d81f2b7a2