### PR TITLE
Bundle ping executable and update ping monitor fallback

### DIFF
--- a/bin/ping
+++ b/bin/ping
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Bundled ICMP ping utility for the monitoring service."""
+from __future__ import annotations
+
+import os
+import select
+import socket
+import struct
+import sys
+import time
+from typing import Optional, Tuple
+
+ICMP_ECHO_REQUEST = 8
+ICMP_ECHO_REPLY = 0
+
+
+def _checksum(data: bytes) -> int:
+    if len(data) % 2:
+        data += b"\x00"
+    checksum = 0
+    for i in range(0, len(data), 2):
+        word = data[i] << 8 | data[i + 1]
+        checksum += word
+        checksum = (checksum & 0xFFFF) + (checksum >> 16)
+    return (~checksum) & 0xFFFF
+
+
+def _create_socket(timeout: float) -> Tuple[socket.socket, bool]:
+    proto = socket.getprotobyname("icmp")
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, proto)
+        use_raw = True
+    except PermissionError:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, proto)
+        use_raw = False
+    sock.settimeout(max(timeout, 0.1))
+    return sock, use_raw
+
+
+def _build_packet(packet_id: int, sequence: int) -> bytes:
+    payload = struct.pack("!d", time.time())
+    header = struct.pack("!BBHHH", ICMP_ECHO_REQUEST, 0, 0, packet_id, sequence)
+    checksum = _checksum(header + payload)
+    return struct.pack("!BBHHH", ICMP_ECHO_REQUEST, 0, checksum, packet_id, sequence) + payload
+
+
+def _receive_response(
+    sock: socket.socket,
+    packet_id: int,
+    sequence: int,
+    timeout: float,
+    use_raw: bool,
+) -> Optional[float]:
+    deadline = time.time() + timeout
+    while True:
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            return None
+        ready = select.select([sock], [], [], remaining)
+        if not ready[0]:
+            return None
+        recv_time = time.time()
+        packet, _ = sock.recvfrom(1024)
+        if use_raw:
+            if len(packet) < 28:
+                continue
+            header = packet[20:28]
+        else:
+            if len(packet) < 8:
+                continue
+            header = packet[:8]
+        icmp_type, code, _, recv_id, recv_seq = struct.unpack("!BBHHH", header)
+        if icmp_type == ICMP_ECHO_REPLY and code == 0 and recv_id == packet_id and recv_seq == sequence:
+            return (recv_time - struct.unpack("!d", packet[-8:])[0]) * 1000.0
+
+
+def _parse_arguments(argv: list[str]) -> Tuple[int, float, Optional[str]]:
+    count = 4
+    timeout = 1.0
+    target: Optional[str] = None
+    idx = 0
+    while idx < len(argv):
+        arg = argv[idx]
+        if arg == "-c":
+            idx += 1
+            if idx >= len(argv):
+                raise ValueError("-c requires a value")
+            count = max(1, int(argv[idx]))
+        elif arg == "-W":
+            idx += 1
+            if idx >= len(argv):
+                raise ValueError("-W requires a value")
+            timeout = max(0.1, float(argv[idx]))
+        elif arg.startswith("-"):
+            raise ValueError(f"Unsupported option: {arg}")
+        else:
+            target = arg
+        idx += 1
+    return count, timeout, target
+
+
+def main() -> int:
+    try:
+        count, timeout, target = _parse_arguments(sys.argv[1:])
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if not target:
+        print("usage: ping [-c COUNT] [-W TIMEOUT] destination", file=sys.stderr)
+        return 2
+
+    try:
+        addr_info = socket.getaddrinfo(target, None, socket.AF_INET)[0]
+    except socket.gaierror as exc:
+        print(f"ping: cannot resolve {target}: {exc}", file=sys.stderr)
+        return 2
+
+    destination = addr_info[4][0]
+
+    try:
+        sock, use_raw = _create_socket(timeout)
+    except PermissionError:
+        print("ping: insufficient permissions to create ICMP socket", file=sys.stderr)
+        return 2
+
+    packet_id = os.getpid() & 0xFFFF
+    transmitted = 0
+    received = 0
+    rtt_samples = []
+
+    print(f"PING {target} ({destination}): 56 data bytes")
+
+    try:
+        for sequence in range(1, count + 1):
+            packet = _build_packet(packet_id, sequence)
+            send_time = time.time()
+            try:
+                sock.sendto(packet, (destination, 0))
+                transmitted += 1
+            except OSError as exc:
+                print(f"ping: send error: {exc}")
+                continue
+
+            rtt = _receive_response(sock, packet_id, sequence, timeout, use_raw)
+            if rtt is not None:
+                received += 1
+                rtt_samples.append(rtt)
+                print(f"64 bytes from {destination}: icmp_seq={sequence} ttl=64 time={rtt:.3f} ms")
+            else:
+                print(f"Request timeout for icmp_seq {sequence}")
+
+            delay = timeout - (time.time() - send_time)
+            if delay > 0:
+                time.sleep(min(delay, 0.1))
+    finally:
+        sock.close()
+
+    loss = 0.0 if transmitted == 0 else ((transmitted - received) / transmitted) * 100.0
+
+    print(f"\n--- {target} ping statistics ---")
+    print(f"{transmitted} packets transmitted, {received} packets received, {loss:.1f}% packet loss")
+
+    if rtt_samples:
+        min_rtt = min(rtt_samples)
+        avg_rtt = sum(rtt_samples) / len(rtt_samples)
+        max_rtt = max(rtt_samples)
+        print(f"round-trip min/avg/max = {min_rtt:.3f}/{avg_rtt:.3f}/{max_rtt:.3f} ms")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/test_ping_locator.py
+++ b/tests/core/test_ping_locator.py
@@ -1,0 +1,45 @@
+"""Unit tests for the ping executable resolution helper."""
+import stat
+from pathlib import Path
+
+import pytest
+
+import main
+
+
+def _make_executable(tmp_path: Path, name: str = "custom-ping") -> Path:
+    candidate = tmp_path / name
+    candidate.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    candidate.chmod(candidate.stat().st_mode | stat.S_IEXEC)
+    return candidate
+
+
+def test_find_ping_executable_prefers_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_ping = _make_executable(tmp_path)
+    monkeypatch.delenv("PING_EXECUTABLE", raising=False)
+    monkeypatch.delenv("PING_PATH", raising=False)
+
+    result = main._find_ping_executable({"ping_path": str(fake_ping)})
+    assert result == str(fake_ping)
+
+
+def test_find_ping_executable_uses_environment_variable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_ping = _make_executable(tmp_path, name="env-ping")
+    monkeypatch.setenv("PING_EXECUTABLE", str(fake_ping))
+    monkeypatch.delenv("PING_PATH", raising=False)
+
+    result = main._find_ping_executable({})
+    assert result == str(fake_ping)
+
+
+def test_find_ping_executable_falls_back_to_bundled_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    bundled_ping = main.BUNDLED_PING_DIR / "ping"
+    assert bundled_ping.exists(), "Bundled ping executable must be present"
+
+    monkeypatch.delenv("PING_EXECUTABLE", raising=False)
+    monkeypatch.delenv("PING_PATH", raising=False)
+    monkeypatch.setenv("PATH", "")
+
+    result = main._find_ping_executable({})
+    assert result == str(bundled_ping.resolve())
+


### PR DESCRIPTION
## Summary
- add a Python-based ping executable under bin/ so ping monitors work without system ping
- update the ping locator to prefer the bundled executable and expose its directory for which()
- extend the ping locator tests to cover the bundled fallback path

## Testing
- pytest tests/core/test_ping_locator.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b90f69e88320bbd9f6446d396fbe