### PR TITLE
Add monitor toggles, graph overlay, and ping averaging

### DIFF
--- a/static/monitor.html
+++ b/static/monitor.html
@@ -29,49 +29,49 @@
         <img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">
         Monitor
     </h1>
-    <p class="monitor-subtitle rci-muted">Configureer servicebewaking, voer handmatige controles uit en bekijk recente resultaten.</p>
 </header>
 
 <main class="monitor-layout" aria-labelledby="monitor-title">
     <section class="monitor-form rci-card" aria-labelledby="monitor-form-heading">
-        <div class="monitor-section-header">
-            <h2 id="monitor-form-heading">Nieuwe monitor toevoegen</h2>
-            <p class="rci-muted">Ondersteunt HTTP(S), URL-wijzigingsdetectie en veelgebruikte netwerkservices.</p>
-        </div>
+        <h2 id="monitor-form-heading">Monitor</h2>
         <form id="monitor-form" class="monitor-form-grid" novalidate>
             <div class="monitor-form-row">
                 <label for="monitor-name">Naam<span aria-hidden="true">*</span></label>
-                <input id="monitor-name" name="name" type="text" required placeholder="Bijvoorbeeld API-status" autocomplete="off">
+                <input id="monitor-name" name="name" type="text" required autocomplete="off">
             </div>
 
             <div class="monitor-inline-group">
                 <div class="monitor-form-row">
-                    <label for="monitor-service">Service<span aria-hidden="true">*</span></label>
+                    <label for="monitor-service">Type<span aria-hidden="true">*</span></label>
                     <select id="monitor-service" name="service" required></select>
                 </div>
                 <div class="monitor-form-row">
                     <label for="monitor-target">Doel<span aria-hidden="true">*</span></label>
-                    <input id="monitor-target" name="target" type="text" required placeholder="URL, host of resource">
+                    <input id="monitor-target" name="target" type="text" required>
+                </div>
+                <div class="monitor-form-row monitor-switch">
+                    <span class="monitor-switch-text" id="monitor-enabled-text">Actief</span>
+                    <label class="monitor-switch-wrapper" for="monitor-enabled">
+                        <input id="monitor-enabled" name="isEnabled" type="checkbox" class="monitor-switch-input" checked aria-labelledby="monitor-enabled-text">
+                        <span class="monitor-switch-control" aria-hidden="true"></span>
+                    </label>
                 </div>
             </div>
 
             <div id="monitor-url-options" class="monitor-inline-group hidden" aria-hidden="true">
                 <div class="monitor-form-row">
-                    <label for="monitor-url-check">URL-controle</label>
-                    <select id="monitor-url-check" name="urlCheck">
-                        <option value="availability">Beschikbaarheid</option>
-                        <option value="change">Wijziging detecteren</option>
-                    </select>
+                    <label for="monitor-url-check">URL</label>
+                    <select id="monitor-url-check" name="urlCheck"></select>
                 </div>
                 <div class="monitor-form-row">
-                    <label for="monitor-timeout">Timeout (seconden)</label>
-                    <input id="monitor-timeout" name="timeout" type="number" min="1" max="60" step="1" placeholder="15">
+                    <label for="monitor-timeout">Timeout</label>
+                    <input id="monitor-timeout" name="timeout" type="number" min="1" max="60" step="1">
                 </div>
             </div>
 
             <div class="monitor-inline-group">
                 <div class="monitor-form-row">
-                    <label for="monitor-interval-value">Polling-interval<span aria-hidden="true">*</span></label>
+                    <label for="monitor-interval-value">Interval<span aria-hidden="true">*</span></label>
                     <div class="monitor-interval-group">
                         <input id="monitor-interval-value" name="intervalValue" type="number" min="1" value="5" required>
                         <select id="monitor-interval-unit" name="intervalUnit">
@@ -84,31 +84,28 @@
                 </div>
                 <div id="monitor-port-wrapper" class="monitor-form-row">
                     <label for="monitor-port">Poort</label>
-                    <input id="monitor-port" name="port" type="number" min="1" max="65535" placeholder="Bijvoorbeeld 443">
+                    <input id="monitor-port" name="port" type="number" min="1" max="65535">
                 </div>
             </div>
 
             <div class="monitor-form-row">
                 <label for="monitor-notes">Notitie</label>
-                <textarea id="monitor-notes" name="notes" rows="3" placeholder="Extra details of instructies"></textarea>
+                <textarea id="monitor-notes" name="notes" rows="3"></textarea>
             </div>
 
             <div class="monitor-actions">
                 <button type="submit" class="focus-ring">Opslaan</button>
-                <button type="button" id="monitor-cancel-edit" class="secondary-button focus-ring hidden">Annuleren</button>
-                <button type="button" id="monitor-refresh" class="secondary-button focus-ring">Vernieuwen</button>
+                <button type="button" id="monitor-cancel-edit" class="secondary-button focus-ring hidden">Annuleer</button>
+                <button type="button" id="monitor-refresh" class="secondary-button focus-ring">Vernieuw</button>
             </div>
             <div id="monitor-form-status" class="status-message" role="status" aria-live="polite"></div>
         </form>
     </section>
 
     <section class="monitor-list rci-card" aria-labelledby="monitor-list-heading">
-        <div class="monitor-section-header">
-            <h2 id="monitor-list-heading">Actieve monitors</h2>
-            <p class="rci-muted">Bekijk status, histogrammen en laatste controles.</p>
-        </div>
+        <h2 id="monitor-list-heading">Overzicht</h2>
         <div id="monitor-list" class="monitor-card-grid" aria-live="polite" aria-busy="false"></div>
-        <div id="monitor-empty" class="monitor-empty rci-muted" role="status">Er zijn nog geen monitors geconfigureerd.</div>
+        <div id="monitor-empty" class="monitor-empty rci-muted" role="status">Geen monitors.</div>
     </section>
 </main>
 
@@ -119,6 +116,17 @@
             <button type="button" id="monitor-log-close" class="secondary-button focus-ring">Sluiten</button>
         </div>
         <div id="monitor-log-content" class="monitor-log-content" aria-live="polite"></div>
+    </div>
+</div>
+
+<div id="monitor-graph-overlay" class="monitor-log-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="monitor-graph-title">
+    <div class="monitor-log-panel rci-card monitor-graph-panel">
+        <div class="monitor-log-header">
+            <h2 id="monitor-graph-title">Grafiek</h2>
+            <button type="button" id="monitor-graph-close" class="secondary-button focus-ring">Sluiten</button>
+        </div>
+        <canvas id="monitor-graph-canvas" class="monitor-graph-canvas" aria-label="Resultaten over tijd" role="img"></canvas>
+        <p id="monitor-graph-empty" class="monitor-graph-empty hidden">Geen gegevens</p>
     </div>
 </div>
 

--- a/static/site.css
+++ b/static/site.css
@@ -532,87 +532,91 @@ select { padding:.5rem; font-size:1rem; border:1px solid var(--rci-border); bord
 
 
 /* Monitor page */
-.monitor-page-header { display:flex; flex-direction:column; gap:.5rem; margin-bottom:1.5rem; }
-.monitor-title { display:flex; align-items:center; gap:.75rem; margin:0; font-size:2rem; }
-.monitor-subtitle { margin:0; }
-.monitor-layout { display:grid; grid-template-columns: minmax(0, 320px) minmax(0, 1fr); gap:1rem; align-items:start; }
-.monitor-form { position:sticky; top:.75rem; display:flex; flex-direction:column; gap:.75rem; }
-.monitor-form-grid { display:grid; gap:.75rem; }
+.monitor-page-header { display:flex; align-items:center; justify-content:space-between; margin-bottom:1rem; }
+.monitor-title { display:flex; align-items:center; gap:.5rem; margin:0; font-size:1.75rem; }
+.monitor-layout { display:grid; grid-template-columns:minmax(0, 320px) minmax(0, 1fr); gap:.75rem; align-items:start; }
+.monitor-form { position:sticky; top:.5rem; display:flex; flex-direction:column; gap:.75rem; }
+.monitor-form h2 { margin:0; font-size:1rem; text-transform:uppercase; letter-spacing:.08em; }
+.monitor-form-grid { display:grid; gap:.5rem; grid-template-columns:repeat(auto-fit, minmax(150px, 1fr)); align-items:end; }
 .monitor-form-row { display:flex; flex-direction:column; gap:.25rem; }
+.monitor-form-row label { font-size:.7rem; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--rci-text-muted); }
 .monitor-form-row input,
 .monitor-form-row select,
-.monitor-form-row textarea { padding:.45rem .55rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); font:inherit; background:var(--rci-surface); color:var(--rci-text); transition:border-color .2s ease, box-shadow .2s ease; }
+.monitor-form-row textarea { padding:.35rem .45rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); font:inherit; background:var(--rci-surface); color:var(--rci-text); min-height:2.25rem; transition:border-color .2s ease, box-shadow .2s ease; }
 .monitor-form-row input:focus,
 .monitor-form-row select:focus,
 .monitor-form-row textarea:focus { outline:none; border-color:var(--rci-primary); box-shadow:var(--rci-focus-ring); }
-.monitor-inline-group { display:grid; gap:.75rem; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
-.monitor-interval-group { display:flex; gap:.45rem; align-items:center; }
+.monitor-inline-group { display:grid; gap:.5rem; grid-template-columns:repeat(auto-fit, minmax(150px, 1fr)); }
+.monitor-interval-group { display:flex; gap:.4rem; align-items:center; }
 .monitor-interval-group input { flex:1; }
-.monitor-interval-group select { min-width:110px; }
-.monitor-actions { display:flex; flex-wrap:wrap; gap:.6rem; align-items:center; }
-.monitor-actions button { padding:.45rem .95rem; border-radius:var(--rci-radius); border:1px solid var(--rci-primary); background:var(--rci-primary); color:#fff; cursor:pointer; transition:background .2s ease, border-color .2s ease; }
-.monitor-actions button:hover { background:var(--rci-primary-accent); border-color:var(--rci-primary-accent); }
+.monitor-actions { display:flex; flex-wrap:wrap; gap:.45rem; }
+.monitor-actions button { padding:.4rem .8rem; border-radius:var(--rci-radius); border:1px solid var(--rci-primary); background:var(--rci-primary); color:#fff; font-size:.85rem; cursor:pointer; transition:opacity .2s ease, background .2s ease; }
+.monitor-actions button:hover:not([disabled]) { opacity:.92; }
 .monitor-actions .secondary-button { border-color:var(--rci-border); background:var(--rci-surface-alt); color:var(--rci-text); }
-.monitor-actions .secondary-button:hover { background:var(--rci-bg-alt); }
+.monitor-actions .secondary-button:hover:not([disabled]) { background:var(--rci-bg-alt); }
 .monitor-actions .danger-button { border-color:var(--rci-danger); background:var(--rci-danger); }
-.monitor-actions .danger-button:hover { background:#c82333; border-color:#c82333; }
-.monitor-list { display:flex; flex-direction:column; gap:1rem; }
-.monitor-card-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap:.75rem; }
-.monitor-card { background:var(--rci-surface); border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:.9rem; box-shadow:var(--rci-shadow); display:flex; flex-direction:column; gap:.75rem; }
-.monitor-card-header { display:flex; justify-content:space-between; gap:.75rem; align-items:center; }
-.monitor-card-title { margin:0; font-size:1.1rem; }
-.monitor-card-subtitle { margin:.15rem 0 0; font-size:.9rem; }
-.monitor-card-main { display:grid; grid-template-columns:minmax(0,1fr) minmax(160px, .85fr); gap:.75rem; align-items:start; }
-.monitor-meta { margin:0; display:grid; gap:.6rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
-.monitor-meta div { display:flex; flex-direction:column; gap:.2rem; }
-.monitor-meta dt { font-weight:600; font-size:.8rem; color:var(--rci-text-muted); letter-spacing:.01em; }
-.monitor-meta dd { margin:0; font-size:.9rem; word-break:break-word; }
-.monitor-card-info { display:flex; flex-direction:column; gap:.4rem; }
-.monitor-message { margin:0; font-size:.9rem; }
-.monitor-notes { margin:0; font-size:.85rem; }
-.monitor-chart { position:relative; height:120px; display:flex; flex-direction:column; gap:.35rem; }
-.monitor-chart-empty { display:none; }
-.monitor-chart canvas { width:100%; height:100%; }
-.monitor-chart-meta { margin:0; font-size:.8rem; }
-.monitor-card-actions { display:flex; flex-wrap:wrap; gap:.6rem; }
-.monitor-card-actions button { padding:.4rem .85rem; border-radius:var(--rci-radius); border:1px solid var(--rci-border); background:var(--rci-surface-alt); color:var(--rci-text); cursor:pointer; transition:background .2s ease, color .2s ease; font-size:.9rem; }
-.monitor-card-actions button:hover:not([disabled]) { background:var(--rci-bg-alt); }
-.monitor-card-actions .danger-button { background:var(--rci-danger); color:#fff; border-color:var(--rci-danger); }
-.monitor-card-actions .danger-button:hover { opacity:.9; }
-.monitor-card-actions button[disabled] { opacity:.6; cursor:not-allowed; }
-.monitor-status { display:inline-flex; align-items:center; gap:.35rem; padding:.3rem .75rem; border-radius:999px; font-weight:600; font-size:.85rem; }
+.monitor-actions .danger-button:hover:not([disabled]) { background:#c82333; }
+.monitor-switch { display:flex; align-items:center; justify-content:space-between; gap:.5rem; }
+.monitor-switch-text { font-size:.7rem; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--rci-text-muted); }
+.monitor-switch-wrapper { position:relative; display:inline-flex; align-items:center; margin:0; cursor:pointer; }
+.monitor-switch-input { position:absolute; inset:0; opacity:0; cursor:pointer; }
+.monitor-switch-control { position:relative; width:38px; height:20px; border-radius:999px; background:var(--rci-border); transition:background .2s ease; display:inline-flex; align-items:center; padding:2px; }
+.monitor-switch-control::after { content:""; width:16px; height:16px; border-radius:50%; background:#fff; transform:translateX(0); transition:transform .2s ease; box-shadow:0 1px 2px rgba(0,0,0,.2); }
+.monitor-switch-input:checked + .monitor-switch-control { background:var(--rci-primary); }
+.monitor-switch-input:checked + .monitor-switch-control::after { transform:translateX(18px); }
+.monitor-list { display:flex; flex-direction:column; gap:.75rem; }
+.monitor-card-grid { display:flex; flex-direction:column; gap:.75rem; }
+.monitor-item { background:var(--rci-surface); border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:.75rem .85rem; display:flex; flex-direction:column; gap:.5rem; box-shadow:var(--rci-shadow); }
+.monitor-item-head { display:flex; align-items:center; justify-content:space-between; gap:.75rem; }
+.monitor-item-meta { display:flex; flex-direction:column; gap:.2rem; min-width:0; }
+.monitor-item-title { margin:0; font-size:1rem; line-height:1.2; }
+.monitor-item-type { font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; color:var(--rci-text-muted); }
+.monitor-item-controls { display:flex; align-items:center; gap:.5rem; }
+.monitor-toggle { border:none; border-radius:999px; padding:.25rem .7rem; font-size:.7rem; text-transform:uppercase; letter-spacing:.08em; cursor:pointer; background:var(--rci-primary); color:#fff; transition:background .2s ease, color .2s ease, opacity .2s ease; }
+.monitor-toggle.is-off { background:var(--rci-surface-alt); color:var(--rci-text-muted); border:1px solid var(--rci-border); }
+.monitor-toggle:disabled { opacity:.6; cursor:not-allowed; }
+.monitor-status { display:inline-flex; align-items:center; gap:.25rem; padding:.25rem .6rem; border-radius:999px; font-weight:600; font-size:.75rem; }
 .monitor-status-success { background:rgba(25,135,84,0.15); color:#198754; }
 .monitor-status-warning { background:rgba(255,193,7,0.18); color:#856404; }
 .monitor-status-failure { background:rgba(220,53,69,0.18); color:#b02a37; }
 .monitor-status-neutral { background:var(--rci-surface-alt); color:var(--rci-text-muted); }
-.monitor-empty { text-align:center; padding:1.2rem; border:1px dashed var(--rci-border); border-radius:var(--rci-radius); font-size:.95rem; }
+.monitor-item-grid { display:grid; gap:.35rem .75rem; grid-template-columns:repeat(auto-fit, minmax(120px, 1fr)); font-size:.8rem; }
+.monitor-item-grid div { display:flex; flex-direction:column; gap:.1rem; min-width:0; }
+.monitor-item-grid dt { font-size:.65rem; font-weight:600; letter-spacing:.05em; color:var(--rci-text-muted); text-transform:uppercase; }
+.monitor-item-grid dd { margin:0; font-size:.85rem; word-break:break-word; }
+.monitor-item-message { margin:0; font-size:.8rem; color:var(--rci-text); overflow-wrap:anywhere; }
+.monitor-item-notes { margin:0; font-size:.75rem; color:var(--rci-text-muted); }
+.monitor-item-actions { display:flex; flex-wrap:wrap; gap:.4rem; }
+.monitor-item-actions button { padding:.35rem .65rem; font-size:.78rem; border-radius:var(--rci-radius); border:1px solid var(--rci-border); background:var(--rci-surface-alt); color:var(--rci-text); cursor:pointer; }
+.monitor-item-actions button:hover:not([disabled]) { background:var(--rci-bg-alt); }
+.monitor-item-actions .danger-button { border-color:var(--rci-danger); background:var(--rci-danger); color:#fff; }
+.monitor-item-actions .danger-button:hover { opacity:.92; }
+.monitor-item-actions button[disabled] { opacity:.6; cursor:not-allowed; }
+.monitor-empty { text-align:center; padding:.8rem; border:1px dashed var(--rci-border); border-radius:var(--rci-radius); font-size:.85rem; }
 .monitor-log-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.55); display:flex; align-items:center; justify-content:center; padding:2rem; z-index:1000; }
-.monitor-log-panel { width:min(90vw, 760px); max-height:80vh; overflow:auto; display:flex; flex-direction:column; gap:1rem; }
+.monitor-log-panel { width:min(90vw, 760px); max-height:80vh; overflow:auto; display:flex; flex-direction:column; gap:.75rem; }
 .monitor-log-header { display:flex; justify-content:space-between; align-items:center; gap:1rem; }
 .monitor-log-content { overflow:auto; }
 .monitor-log-table { width:100%; border-collapse:collapse; }
 .monitor-log-table th,
-.monitor-log-table td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--rci-border); font-size:.95rem; }
+.monitor-log-table td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--rci-border); font-size:.9rem; }
 .monitor-log-table tbody tr:hover { background:var(--rci-bg-alt); }
+.monitor-graph-panel { gap:.75rem; }
+.monitor-graph-canvas { width:100%; height:240px; }
+.monitor-graph-empty { text-align:center; font-size:.85rem; color:var(--rci-text-muted); }
 
-@media (max-width: 1080px) {
+@media (max-width: 960px) {
   .monitor-layout { grid-template-columns: 1fr; }
   .monitor-form { position:static; }
 }
 
-@media (max-width: 640px) {
-  .monitor-card-grid { grid-template-columns: 1fr; }
-  .monitor-card-main { grid-template-columns: 1fr; }
-  .monitor-card-actions { flex-direction:column; align-items:stretch; }
-  .monitor-card-actions button { width:100%; text-align:center; }
-}
-
-[data-theme="dark"] .monitor-card { background:#1f2a33; border-color:#2f3d47; }
+[data-theme="dark"] .monitor-item { background:#1f2a33; border-color:#2f3d47; }
 [data-theme="dark"] .monitor-form-row input,
 [data-theme="dark"] .monitor-form-row select,
 [data-theme="dark"] .monitor-form-row textarea { background:#1b242c; border-color:#2f3d47; color:#f5f5f5; }
-[data-theme="dark"] .monitor-card-actions button { background:#23303a; color:#f5f5f5; border-color:#2f3d47; }
-[data-theme="dark"] .monitor-card-actions button:hover:not([disabled]) { background:#2f3d47; }
-[data-theme="dark"] .monitor-chart-meta { color:#9fb3c8; }
+[data-theme="dark"] .monitor-item-actions button { background:#23303a; color:#f5f5f5; border-color:#2f3d47; }
+[data-theme="dark"] .monitor-item-actions button:hover:not([disabled]) { background:#2f3d47; }
+[data-theme="dark"] .monitor-toggle.is-off { background:#23303a; color:#9fb3c8; border-color:#2f3d47; }
+[data-theme="dark"] .monitor-graph-panel { background:#1f2a33; border:1px solid #2f3d47; }
 [data-theme="dark"] .monitor-log-panel { background:#1f2a33; border:1px solid #2f3d47; }
-[data-theme="dark"] .monitor-log-table tbody tr:hover { background:#2f3d47; }
+[data-theme="dark"] .monitor-graph-empty { color:#9fb3c8; }


### PR DESCRIPTION
## Summary
- record average round-trip time for ping monitors and store it with results
- add monitor enable/disable support across the database, API, and UI
- redesign the monitor page with a compact layout and a historical graph overlay

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d99305dfc883209ca93aaf4c1d7bf5