### PR TITLE
Add httpx dependency required for FastAPI test client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytz>=2023.3
 
 # HTTP client for external APIs
 requests>=2.31.0
+httpx>=0.27.0             # Required by starlette.testclient in FastAPI tests
 
 # HTML content processing for change detection
 beautifulsoup4>=4.12.0


### PR DESCRIPTION
### Motivation
- Test collection using `starlette.testclient` (imported by `fastapi.testclient`) failed during `pytest` because the `httpx` package was not installed.

### Description
- Add `httpx>=0.27.0` to `requirements.txt` to satisfy the `starlette.testclient` runtime dependency.

### Testing
- Installed `httpx` and ran `pytest -q tests/core/test_dumpert_pages.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a7d9eed883209dd428d3f7f77535)