### PR TITLE
Rewrite Dumpert .m3u8 playlists in media proxy

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ from datetime import datetime, timedelta
 from html import unescape
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Literal
-from urllib.parse import parse_qsl, urlencode, urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse
 
 import pytz
 
@@ -1611,6 +1611,34 @@ def _validate_dumpert_media_url(raw_url: str) -> str:
     return raw_url
 
 
+def _proxied_dumpert_url(media_url: str) -> str:
+    return f"/api/dumpert/media-proxy?url={quote(media_url, safe='')}"
+
+
+def _rewrite_m3u8_playlist(playlist_text: str, source_url: str) -> str:
+    """Rewrite playlist URLs so all nested requests stay routed through the proxy."""
+    rewritten_lines: List[str] = []
+    for line in playlist_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            rewritten_lines.append(line)
+            continue
+        if stripped.startswith("#"):
+            def _replace_attr(match: re.Match[str]) -> str:
+                attr_url = match.group(1)
+                resolved = urljoin(source_url, attr_url)
+                return f'URI="{_proxied_dumpert_url(resolved)}"'
+
+            rewritten = re.sub(r'URI="([^"]+)"', _replace_attr, line)
+            rewritten_lines.append(rewritten)
+            continue
+
+        resolved = urljoin(source_url, stripped)
+        rewritten_lines.append(_proxied_dumpert_url(resolved))
+
+    return "\n".join(rewritten_lines) + ("\n" if playlist_text.endswith("\n") else "")
+
+
 @app.get("/api/dumpert/media-diagnostics")
 async def dumpert_media_diagnostics(url: str = Query(..., min_length=10)):
     """Return remote media response diagnostics (status/headers/sniff bytes)."""
@@ -1679,6 +1707,18 @@ async def dumpert_media_proxy(
     if upstream.status_code >= 400:
         upstream.close()
         raise HTTPException(status_code=upstream.status_code, detail="Dumpert media upstream returned error")
+
+    content_type = (upstream.headers.get("content-type") or "").lower()
+    is_m3u8 = ".m3u8" in clean_url.lower() or "mpegurl" in content_type
+    if is_m3u8 and not range_header:
+        playlist_content = upstream.text
+        upstream.close()
+        rewritten = _rewrite_m3u8_playlist(playlist_content, clean_url)
+        return Response(
+            content=rewritten.encode("utf-8"),
+            media_type="application/vnd.apple.mpegurl",
+            headers={"cache-control": upstream.headers.get("cache-control", "no-cache")},
+        )
 
     passthrough_headers: Dict[str, str] = {}
     for name in ("content-type", "content-length", "content-range", "accept-ranges", "cache-control", "etag", "last-modified"):

--- a/tests/core/test_dumpert_media_proxy.py
+++ b/tests/core/test_dumpert_media_proxy.py
@@ -1,0 +1,40 @@
+"""Tests for Dumpert media proxy playlist rewriting."""
+
+import importlib
+import os
+
+from fastapi.dependencies import utils as fastapi_utils
+
+REQUIRED_VARS = {
+    "AZURE_SQL_SERVER": "stub.server.local",
+    "AZURE_SQL_PORT": "1433",
+    "AZURE_SQL_USER": "test",
+    "AZURE_SQL_PASSWORD": "secret",
+    "AZURE_SQL_DATABASE": "testdb",
+}
+
+for key, value in REQUIRED_VARS.items():
+    os.environ.setdefault(key, value)
+
+
+def _load_main(monkeypatch):
+    monkeypatch.setattr(fastapi_utils, "ensure_multipart_is_installed", lambda: None)
+    return importlib.import_module("main")
+
+
+def test_rewrite_m3u8_playlist_rewrites_segment_and_key_urls(monkeypatch):
+    main = _load_main(monkeypatch)
+    source_url = "https://media.dumpert.nl/dmp/media/video/x/y/z/270/index.m3u8"
+    playlist = """#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-KEY:METHOD=AES-128,URI="key.bin"
+#EXTINF:4.000,
+chunk_001.ts
+https://media.dumpert.nl/direct/chunk_002.ts
+"""
+
+    rewritten = main._rewrite_m3u8_playlist(playlist, source_url)
+
+    assert '/api/dumpert/media-proxy?url=https%3A%2F%2Fmedia.dumpert.nl%2Fdmp%2Fmedia%2Fvideo%2Fx%2Fy%2Fz%2F270%2Fchunk_001.ts' in rewritten
+    assert '/api/dumpert/media-proxy?url=https%3A%2F%2Fmedia.dumpert.nl%2Fdirect%2Fchunk_002.ts' in rewritten
+    assert 'URI="/api/dumpert/media-proxy?url=https%3A%2F%2Fmedia.dumpert.nl%2Fdmp%2Fmedia%2Fvideo%2Fx%2Fy%2Fz%2F270%2Fkey.bin"' in rewritten


### PR DESCRIPTION
### Motivation
- Native HLS playback via the backend proxy broke because relative segment and key URLs inside `.m3u8` playlists were not routed back through the proxy, causing the browser to resolve them incorrectly against the proxy path.

### Description
- Added `_proxied_dumpert_url` and `_rewrite_m3u8_playlist` helpers and imported `quote` and `urljoin` to build proxied absolute URLs and rewrite playlist lines and `URI="..."` attributes. 
- Updated `/api/dumpert/media-proxy` to detect playlist responses and return a rewritten `.m3u8` payload that routes nested segment and key requests through the proxy while preserving passthrough behavior for non-playlist and ranged requests. 
- Added `tests/core/test_dumpert_media_proxy.py` to validate rewriting of relative segment paths and `EXT-X-KEY` URIs. 

### Testing
- Ran `pytest -q tests/core/test_dumpert_media_proxy.py` which passed (`1 passed`).
- Ran `python -m py_compile main.py` which succeeded with no syntax errors.
- Attempted combined test run `pytest -q tests/core/test_dumpert_pages.py tests/core/test_dumpert_media_proxy.py` but collection failed due to the environment missing the `httpx` dependency required by Starlette `TestClient` (not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a9f2b524832080ee5876ecb4e47e)