### PR TITLE
Skip Dumpert page test when httpx is not installed

### DIFF
--- a/tests/core/test_dumpert_pages.py
+++ b/tests/core/test_dumpert_pages.py
@@ -3,7 +3,10 @@
 import importlib
 import os
 
+import pytest
 from fastapi.dependencies import utils as fastapi_utils
+
+pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 REQUIRED_VARS = {


### PR DESCRIPTION
### Motivation
- Avoid a collection-time `RuntimeError` from `starlette.testclient` when `httpx` is not available in minimal environments by guarding the test module.

### Description
- Add `pytest.importorskip("httpx")` to `tests/core/test_dumpert_pages.py` so the module is skipped if `httpx` is not installed.

### Testing
- Ran `pytest -q tests/core/test_dumpert_pages.py tests/core/test_dumpert_media_proxy.py`, which completed with `1 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ab8ebba88320869b2a4eb3606a6f)