### PR TITLE
Add comprehensive documentation hub and maintenance policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ For detailed testing documentation, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 This project includes comprehensive documentation organized into the following guides:
 
+- **[docs/README.md](docs/README.md)** - Documentation hub and navigation across all technical docs
+- **[docs/AI_AGENT_CONTEXT.md](docs/AI_AGENT_CONTEXT.md)** - Fast-start context for AI agents and contributors
+- **[docs/FEATURE_CATALOG.md](docs/FEATURE_CATALOG.md)** - Full feature and endpoint catalog
+- **[docs/WEBSITE_GUIDE.md](docs/WEBSITE_GUIDE.md)** - Website page/module behaviors and frontend architecture
+- **[docs/OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md)** - Setup, startup, and operational runbook
+- **[docs/DOCUMENTATION_MAINTENANCE.md](docs/DOCUMENTATION_MAINTENANCE.md)** - Required process for keeping docs current
 - **[DEVELOPMENT.md](DEVELOPMENT.md)** - Developer guidelines, testing, logging, and code architecture
 - **[DEPLOYMENT.md](DEPLOYMENT.md)** - Azure deployment, CI/CD, and production configuration
 - **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues, error codes, and recovery procedures

--- a/docs/AI_AGENT_CONTEXT.md
+++ b/docs/AI_AGENT_CONTEXT.md
@@ -1,0 +1,85 @@
+# AI Agent Context Playbook
+
+Use this document as a fast-operating context pack before making changes in this repository.
+
+## 1. Repository intent
+
+Road Condition Indexer is a multi-purpose FastAPI application centered on road-condition ingest and indexing, with extended operational tooling, diagnostics, monitoring, memo/transcription utilities, and media workflows.
+
+## 2. High-signal file map
+
+- `main.py`: API routes, startup lifecycle, and app orchestration.
+- `database.py`: table constants, persistence layer, data access and safety filters.
+- `log_utils.py`: unified logging helpers and log level/category conventions.
+- `transcription.py`: transcription service and error model.
+- `static/`: all website pages/assets/js used by the served frontend.
+- `tests/`: test suites grouped by scope (`core`, `extended`, `legacy`, top-level).
+
+## 3. Feature domains and likely edit targets
+
+- Ingestion/roughness: `main.py`, `database.py`, data table schema docs.
+- UI behavior: `static/*.html`, `static/*.js`, `static/site.css`, route exposure in `main.py`.
+- Monitor subsystem: monitor endpoints in `main.py`, corresponding monitor UI scripts.
+- Maintenance/admin behavior: `/manage/*` routes + maintenance pages.
+- Memo/transcription: memo routes in `main.py`, service code in `transcription.py`, memo page scripts.
+
+## 4. Operational assumptions
+
+- Azure SQL configuration is required for full runtime operation.
+- Startup executes SQL connectivity checks and reports diagnostics.
+- Static pages are expected to be directly routable under explicit endpoints.
+- The app mixes end-user features and admin/debug surfaces in one process.
+
+## 5. Safe change workflow for agents
+
+1. Read relevant docs first:
+   - `README.md`
+   - `DEVELOPMENT.md`
+   - `docs/FEATURE_CATALOG.md`
+   - `docs/WEBSITE_GUIDE.md`
+2. Locate exact call sites/routes/static integrations before editing.
+3. Make smallest change set that satisfies the request.
+4. Update documentation in the same PR when behavior changes.
+5. Run tests only when functionality changes (skip for doc-only updates when instructed).
+
+## 6. Documentation update contract
+
+If code/behavior changes, update at least one of:
+- `docs/FEATURE_CATALOG.md` (backend/API/data behavior)
+- `docs/WEBSITE_GUIDE.md` (page/UX/module behavior)
+- `docs/OPERATIONS_RUNBOOK.md` (setup/ops/startup/deployment behavior)
+- `README.md` (project-level behavior changes)
+
+## 7. Agent checklist before commit
+
+- [ ] Changed files are scoped and intentional.
+- [ ] Docs updated for all behavior changes.
+- [ ] No accidental endpoint naming drift.
+- [ ] Static asset paths and routes stay consistent.
+- [ ] Destructive admin endpoints were not modified without safety notes.
+- [ ] Commit message summarizes both code and documentation impact.
+
+## 8. Rapid task routing for AI agents
+
+- “Add endpoint” → `main.py`, request model, db usage, docs update.
+- “Fix table query bug” → `database.py`, related route(s), tests, docs.
+- “Update monitor UI” → `static/monitor.*`, monitor API route checks, docs.
+- “Add page” → new `static/*.html`, route in `main.py`, CSS/JS updates, docs.
+- “Deploy issue” → `DEPLOYMENT.md`, startup scripts, env vars, troubleshooting docs.
+
+## 9. Change impact matrix
+
+| Change type | Must update docs |
+|---|---|
+| New/changed endpoint | `docs/FEATURE_CATALOG.md` (+ `README.md` if user-visible) |
+| New/changed page/UI flow | `docs/WEBSITE_GUIDE.md` |
+| Setup/config/startup change | `docs/OPERATIONS_RUNBOOK.md` + `README.md` |
+| New troubleshooting path | `TROUBLESHOOTING.md` |
+| Static asset loading/routing change | `STATIC_FILES_GUIDE.md` + `docs/WEBSITE_GUIDE.md` |
+
+## 10. Definition of done for agent-driven repository updates
+
+A change is not done until:
+- implementation is complete,
+- related docs are updated,
+- and commit/PR text explains what changed and why.

--- a/docs/DOCUMENTATION_MAINTENANCE.md
+++ b/docs/DOCUMENTATION_MAINTENANCE.md
@@ -1,0 +1,98 @@
+# Documentation Maintenance Policy
+
+This policy defines how documentation must be maintained as the repository evolves.
+
+## 1. Core rule
+
+**Any behavior change must include documentation updates in the same pull request.**
+
+Behavior change includes:
+- API contract changes.
+- Data model/schema changes.
+- Setup/deployment/startup changes.
+- Frontend page/flow/UI changes.
+- Logging/monitoring/admin process changes.
+
+## 2. Ownership model
+
+- PR author owns initial documentation updates.
+- Reviewer verifies docs are accurate and complete before approval.
+- Maintainers enforce policy during merge review.
+
+## 3. Required doc touchpoints by change type
+
+### API and backend logic
+Update:
+- `docs/FEATURE_CATALOG.md`
+- `README.md` (if externally visible behavior changed)
+- `DEVELOPMENT.md` (if workflow/testing guidance changed)
+
+### Website/frontend behavior
+Update:
+- `docs/WEBSITE_GUIDE.md`
+- `STATIC_FILES_GUIDE.md` (if static conventions/routing changed)
+
+### Operations/setup/deployment
+Update:
+- `docs/OPERATIONS_RUNBOOK.md`
+- `README.md`
+- `DEPLOYMENT.md` or `TROUBLESHOOTING.md` where applicable
+
+### AI/developer workflow
+Update:
+- `docs/AI_AGENT_CONTEXT.md`
+
+## 4. PR template checklist (copy into PR descriptions)
+
+- [ ] I updated docs for all changed behavior.
+- [ ] I updated endpoint listings if API surface changed.
+- [ ] I updated website docs if pages/JS flows changed.
+- [ ] I updated operations docs if setup/startup/deployment changed.
+- [ ] I verified old instructions were removed or corrected.
+- [ ] I included migration/compatibility notes when relevant.
+
+## 5. Monthly documentation review cadence
+
+Perform a repo-level documentation audit at least once per month:
+
+1. Compare `main.py` routes vs `docs/FEATURE_CATALOG.md`.
+2. Compare `static/` pages/modules vs `docs/WEBSITE_GUIDE.md`.
+3. Compare startup scripts/env handling vs `docs/OPERATIONS_RUNBOOK.md` and `README.md`.
+4. Verify troubleshooting entries match currently observed failure modes.
+5. Open follow-up issues for stale docs and label as `documentation-debt`.
+
+## 6. Release-time documentation gate
+
+Before a release tag/deployment:
+- Confirm no pending doc updates remain in open PR comments.
+- Confirm configuration examples are still valid for current environments.
+- Confirm monitor/tooling pages listed in docs still exist and are reachable.
+
+## 7. Quality standards for docs
+
+Documentation should be:
+- Accurate (matches current code behavior).
+- Actionable (contains specific commands/paths/endpoints).
+- Discoverable (linked from hub docs and top-level docs).
+- Concise but complete (enough for humans and AI agents to act safely).
+
+## 8. Handling breaking changes
+
+When a change is breaking:
+- Add an explicit “Breaking Change” section in updated docs.
+- Include migration steps and rollback notes.
+- Mark removed endpoints/pages/processes as deprecated then removed, where feasible.
+
+## 9. Fast stale-doc detection workflow
+
+Use these quick checks:
+- Route drift: scan `@app.<method>(...)` in `main.py` against feature catalog.
+- Static drift: compare `static/*.html` and `static/*.js` against website guide lists.
+- Script drift: compare startup/migration script behavior against runbook instructions.
+
+## 10. Non-compliance handling
+
+If PR behavior changes without doc updates:
+- Block merge.
+- Request explicit doc updates.
+- Require follow-up patch only if emergency change had to ship first.

--- a/docs/FEATURE_CATALOG.md
+++ b/docs/FEATURE_CATALOG.md
@@ -1,0 +1,222 @@
+# Feature Catalog
+
+This document inventories the implemented backend and platform features in this repository.
+
+## 1. Core platform responsibilities
+
+The application combines multiple capabilities under one FastAPI service:
+
+- Road-condition ingestion and roughness indexing.
+- Device lifecycle and nickname management.
+- Data browsing/export and maintenance tooling.
+- Debug and operational logging endpoints.
+- Website/content monitor scheduler and history.
+- Shared-link style records (`/api/shared`).
+- Memo management and optional transcription pipeline.
+- Audio/video tooling (noise reduction and media download/proxy features).
+
+## 2. Environment-aware boot behavior
+
+At startup, the application resolves configuration mode:
+
+- **Azure Web App mode**: uses app settings environment variables.
+- **GitHub Codespaces mode**: uses Codespaces environment variables.
+- **Local mode**: attempts to load `.env` via `python-dotenv`.
+
+Connectivity tests for SQL infrastructure are run during startup to fail fast with actionable diagnostics.
+
+## 3. Data ingestion and roughness pipeline
+
+### `POST /bike-data`
+Primary endpoint for measurement ingest.
+
+Core behavior:
+- Validates payload with GPS + motion data and Z-axis samples.
+- Computes average speed and applies a minimum speed threshold (`RCI_MIN_SPEED_KMH`, default 7 km/h).
+- Applies preprocessing/filtering to sensor stream and computes roughness metrics.
+- Stores standardized records in core tables.
+- Supports optional source sample persistence for research/analysis.
+
+Roughness pipeline characteristics:
+- Resampling to stable sampling interval.
+- Band-pass filtering approximately in the ride vibration range.
+- RMS-derived roughness with additional vibration metrics computed for future use.
+
+## 4. Logging, diagnostics, and observability
+
+### Logging ingestion + retrieval
+- `POST /log`: client log intake.
+- `GET /logs`: recent logs.
+- `GET /filteredlogs`: logs with filtering.
+
+### Debug visibility
+- `GET /debuglog`
+- `GET /debuglog/enhanced`
+- `GET /system_startup_log`
+- `GET /sql_operations_log`
+
+### Deep diagnostics
+- `GET /debug/db_test`
+- `GET /debug/db_stats`
+- `POST /debug/test_insert`
+- `GET /debug/data_flow_test`
+
+### Log lifecycle management
+- `GET /manage/debug_logs`
+- `DELETE /manage/debug_logs`
+- `POST /manage/log_config`
+- `GET /manage/log_config`
+- `POST /manage/archive_logs`
+
+## 5. Device and identity features
+
+- `GET /device_ids`: discover active/known devices.
+- `GET /device_stats`: aggregate metrics by device.
+- Nickname lifecycle:
+  - `POST /nickname`
+  - `GET /nickname`
+  - `DELETE /nickname`
+- `POST /manage/merge_device_ids`: merge duplicate device identities.
+- `DELETE /device_data`: targeted cleanup.
+
+## 6. Data browsing, editing, and maintenance APIs
+
+Data management endpoints under `/manage` include:
+
+- Discovery:
+  - `/manage/tables`
+  - `/manage/table_schema`
+  - `/manage/table_summary`
+  - `/manage/last_rows`
+- Row/query views:
+  - `/manage/table_rows`
+  - `/manage/table_range`
+  - `/manage/record`
+  - `/manage/filtered_records`
+- Write operations:
+  - `/manage/update_record`
+  - `/manage/delete_record`
+  - `/manage/delete_filtered_records`
+  - `/manage/delete_all`
+  - `/manage/insert_testdata`
+- Table lifecycle:
+  - `/manage/backup_table`
+  - `/manage/rename_table`
+  - `/manage/test_table`
+  - `/manage/repair_database`
+- Structural checks:
+  - `/manage/verify_tables`
+  - `/manage/verify_data`
+  - `/manage/verify_indexes`
+  - `/manage/verify_constraints`
+
+Security posture:
+- Table operations are constrained to project table naming conventions (`RCI_` prefixed), limiting accidental or malicious access to unrelated schema objects.
+
+## 7. Threshold and configuration endpoints
+
+- `GET /api/thresholds`
+- `POST /api/thresholds`
+
+Used for runtime threshold visibility/updates where enabled by the frontend workflow.
+
+## 8. Monitor subsystem
+
+Purpose: service, URL, and content monitoring with logs + history.
+
+### Metadata and CRUD
+- `GET /api/monitors/metadata`
+- `GET /api/monitors`
+- `POST /api/monitors`
+- `PUT /api/monitors/{monitor_id}`
+- `DELETE /api/monitors/{monitor_id}`
+- `GET /api/monitors/{monitor_id}`
+- `POST /api/monitors/{monitor_id}/toggle`
+
+### Execution and results
+- `POST /api/monitors/{monitor_id}/run`
+- `GET /api/monitors/{monitor_id}/logs`
+- `GET /api/monitors/{monitor_id}/history`
+
+Service types include HTTP/HTTPS, generic URL checks, TCP/UDP ports, DNS, SMTP/IMAP/POP3, FTP/SFTP/SSH, and ICMP ping.
+
+## 9. Shared records feature
+
+- `POST /api/shared`
+- `GET /api/shared`
+- `GET /api/shared/{shared_id}`
+- `PUT /api/shared/{shared_id}/note`
+- `DELETE /api/shared/{shared_id}`
+
+Supports persisted shared snippets/records with update + deletion lifecycle.
+
+## 10. Memo + transcription feature set
+
+- `POST /api/memos`
+- `GET /api/memos`
+- `PUT /api/memos/{memo_id}`
+- `DELETE /api/memos/{memo_id}`
+- `POST /api/memos/transcribe`
+
+The transcription flow is mediated by `transcription.py` service abstractions and explicit error classes for configuration and service/runtime failures.
+
+## 11. Media tooling
+
+### AV noise reduction
+- `POST /api/av/noise-reduction`
+- `GET /api/av/noise-reduction/{token}`
+
+Supports asynchronous/queued style processing semantics where a token can be used to retrieve output artifacts.
+
+### Video tooling + external media
+- `POST /tools/download_video`
+- Dumpert integrations:
+  - `GET /api/dumpert/toppers/{page}`
+  - `GET /api/dumpert/media-diagnostics`
+  - `GET /api/dumpert/media-proxy`
+
+## 12. Health/auth/navigation support endpoints
+
+- Auth/session support:
+  - `POST /login`
+  - `GET /auth_check`
+- Health:
+  - `GET /health`
+- Navigation/static entrypoints:
+  - `/`
+  - `/welcome.html`
+  - `/shared.html`
+  - plus direct static helper routes for assets/partials.
+
+## 13. Export and utility endpoints
+
+- `GET /gpx`: GPX export for ride data traces.
+- `GET /date_range`: date bounds for record browsing/filter forms.
+
+## 14. Data model highlights
+
+Core table families include:
+- Bike measurements and optional source samples.
+- Debug logs and archive logs.
+- Device nickname mapping and metadata.
+- User action trail.
+- Monitor entities and monitor run history/logs.
+- Shared and memo records.
+
+The schema is created/verified on startup via the database layer to reduce manual drift.
+
+## 15. Test suite landscape
+
+Test assets are grouped by depth/scope:
+- `tests/core`: foundational behavior and subsystem integrity.
+- `tests/extended`: larger-scope and connectivity-focused scenarios.
+- `tests/legacy`: compatibility/regression cases.
+- Top-level tests for connection string behavior and end-to-end style validations.
+
+## 16. Related files and where feature logic lives
+
+- API and app lifecycle: `main.py`
+- Database and table management: `database.py`
+- Logging utilities: `log_utils.py`
+- Transcription abstraction: `transcription.py`
+- SQL connectivity startup tests: `tests/sql_connectivity_tests.py`

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -1,0 +1,111 @@
+# Operations Runbook
+
+This runbook captures setup, startup, operation, and recovery workflows for this repository.
+
+## 1. Prerequisites
+
+- Python runtime compatible with repository dependencies.
+- Network access from runtime to Azure SQL (port 1433 unless customized).
+- Environment variables configured for database connectivity.
+
+## 2. Required environment variables
+
+Mandatory variables:
+
+- `AZURE_SQL_SERVER`
+- `AZURE_SQL_DATABASE`
+- `AZURE_SQL_USER`
+- `AZURE_SQL_PASSWORD`
+- `AZURE_SQL_PORT` (typically `1433`)
+
+Environment model:
+- **Local**: loaded from `.env` when available.
+- **Azure App Service**: set as App Settings.
+- **Codespaces**: set in environment/secrets for workspace.
+
+## 3. Installation workflow
+
+```bash
+pip install -r requirements.txt
+```
+
+Optional environment verification:
+
+```bash
+python setup_env.py
+```
+
+## 4. Startup workflow
+
+Local API startup example:
+
+```bash
+uvicorn main:app --reload --host 0.0.0.0
+```
+
+Startup behavior expectations:
+- Environment mode detection logs.
+- SQL connectivity checks execute.
+- Database layer verifies/creates required tables.
+- Static files become available under configured routes.
+
+## 5. Helper scripts
+
+- `startup.sh`: Linux startup helper.
+- `azure_startup.sh`: Azure-targeted startup helper.
+- `startup_local.ps1`: PowerShell local startup helper.
+- `validate-config.ps1`: config validation helper.
+- `migrate_db.py`: database migration/adjustment workflow.
+
+## 6. Routine operational workflows
+
+### 6.1 Verify service health
+- Call `GET /health`.
+- Review startup/system logs (`/system_startup_log`, `/sql_operations_log`).
+
+### 6.2 Validate DB visibility
+- Use maintenance endpoints (`/manage/tables`, `/manage/table_summary`, `/manage/last_rows`).
+- Confirm expected `RCI_` tables exist and are populated.
+
+### 6.3 Manage logs
+- Query logs via `/logs`, `/filteredlogs`, `/debuglog/enhanced`.
+- Archive/cleanup via `/manage/archive_logs` and debug log management endpoints.
+
+### 6.4 Operate monitors
+- Confirm metadata (`/api/monitors/metadata`).
+- Create/update/toggle monitors.
+- Trigger on-demand run (`/api/monitors/{id}/run`) during incident checks.
+
+### 6.5 Data repair and recovery
+- Run table verification endpoints (`verify_*`).
+- Use backup + repair endpoints.
+- Use row-level edit/delete endpoints only with explicit audit context.
+
+## 7. Security and safety constraints
+
+- Database table tooling is limited to application table prefixes for isolation.
+- Destructive endpoints exist; prefer backups before destructive operations.
+- Keep auth/session protections enforced for admin surfaces in production.
+
+## 8. Deployment and environment parity
+
+- Use `DEPLOYMENT.md` for platform-specific deployment details.
+- Keep local/test/prod config names aligned to reduce drift.
+- Validate schema and connectivity in each environment before releasing feature changes.
+
+## 9. Incident response quick flow
+
+1. Check `/health`.
+2. Inspect startup + SQL ops logs.
+3. Run DB diagnostics endpoints.
+4. Validate monitor subsystem behavior.
+5. Confirm core ingestion endpoint status (`/bike-data`) via controlled test payload.
+6. Capture findings in incident note and update troubleshooting docs.
+
+## 10. Operational documentation obligations
+
+Whenever operations-related behavior changes (startup, config, scripts, deployment, maintenance API semantics):
+
+- Update this runbook in the same PR.
+- Update top-level operational docs (`README.md`, `DEPLOYMENT.md`, `TROUBLESHOOTING.md`) as needed.
+- Add a changelog note in the PR description explaining operator impact.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+# Documentation Hub
+
+This `docs/` directory is the canonical guide for understanding, operating, and extending the Road Condition Indexer repository.
+
+## Who this documentation is for
+- Developers shipping code changes.
+- Operators deploying and maintaining environments.
+- QA contributors validating behavior.
+- AI agents that need complete project context quickly.
+
+## Document map
+
+1. **[AI Agent Context](./AI_AGENT_CONTEXT.md)**
+   - Fast orientation for autonomous agents.
+   - Architecture, conventions, and safe-change workflow.
+   - Where to look first for specific tasks.
+
+2. **[Feature Catalog](./FEATURE_CATALOG.md)**
+   - Comprehensive backend and data feature inventory.
+   - API surface grouped by domain.
+   - Data processing, logging, monitor services, memo/transcription, and media tooling.
+
+3. **[Website Guide](./WEBSITE_GUIDE.md)**
+   - All pages in the `static/` site and what they do.
+   - Key client-side modules and user journeys.
+   - Notes on partials and static asset routing.
+
+4. **[Operations Runbook](./OPERATIONS_RUNBOOK.md)**
+   - Local setup, environment model, startup scripts, and production operation.
+   - Database expectations, common workflows, and troubleshooting flow.
+
+5. **[Documentation Maintenance](./DOCUMENTATION_MAINTENANCE.md)**
+   - Required process to keep documentation updated.
+   - PR checklist and ownership expectations.
+   - Change-impact matrix for doc update triggers.
+
+## Existing top-level docs to continue using
+- `README.md`: high-level project overview.
+- `DEVELOPMENT.md`: engineering and test guidance.
+- `DEPLOYMENT.md`: deployment-specific workflow.
+- `TROUBLESHOOTING.md`: issue diagnosis and remediation.
+- `STATIC_FILES_GUIDE.md`: static file conventions and pitfalls.
+
+## Suggested reading order for onboarding
+1. `README.md`
+2. `docs/AI_AGENT_CONTEXT.md`
+3. `docs/FEATURE_CATALOG.md`
+4. `docs/WEBSITE_GUIDE.md`
+5. `docs/OPERATIONS_RUNBOOK.md`
+6. `docs/DOCUMENTATION_MAINTENANCE.md`
+
+## Maintenance policy
+Documentation in this folder is expected to be updated **in the same pull request** as the related code whenever behavior changes.
+
+See [Documentation Maintenance](./DOCUMENTATION_MAINTENANCE.md) for the required process.

--- a/docs/WEBSITE_GUIDE.md
+++ b/docs/WEBSITE_GUIDE.md
@@ -1,0 +1,94 @@
+# Website Guide
+
+This guide documents the web UI delivered from `static/` and mapped by FastAPI routes.
+
+## 1. Website architecture
+
+The website is server-hosted static content with API-driven dynamic behavior.
+
+- HTML pages live in `static/`.
+- Shared JS modules provide UI behavior and API calls.
+- FastAPI serves the pages directly via explicit routes and also mounts `static/` assets.
+- Feature pages call backend endpoints for data retrieval, updates, diagnostics, and tooling workflows.
+
+## 2. Primary pages and their purpose
+
+### Core experience
+- `static/index.html`: main interface for map/data workflows.
+- `static/map-partial.html`: map-focused content used as shared UI fragment.
+- `static/logs-partial.html`: log-viewing fragment.
+- `static/shared.html`: shared record rendering and interactions.
+
+### Authentication and access
+- `static/login.html`: sign-in page wired to `/login` and `/auth_check` behavior.
+
+### Operational/admin pages
+- `static/maintenance.html`: database + infrastructure management views.
+- `static/database.html`: data and schema-focused operations.
+- `static/device.html`: device-centric management and visibility.
+- `static/tools.html`: general-purpose utilities and operational helpers.
+
+### Feature-specific pages
+- `static/memo.html`: memo CRUD and transcription entrypoint UI.
+- `static/monitor.html`: monitor creation, toggling, execution, and history display.
+- `static/av-tools.html`: media/noise-reduction tooling UI.
+- `static/dumpert.html`: Dumpert content browsing.
+- `static/dumpert-player.html`: media playback/proxy consumption view.
+
+### Supporting/special pages
+- `static/solution.html`, `static/chris.html`, `static/timezone-test.html`: environment/support pages used for specific workflows or testing.
+
+## 3. Frontend JavaScript modules
+
+- `static/utils.js`: common helper utilities used across pages.
+- `static/map-components.js`: map rendering and map UI composition.
+- `static/memo.js`: memo page feature logic.
+- `static/monitor.js`: monitor UI and API interactions.
+- `static/av-tools.js`: media tool page API orchestration.
+
+## 4. Styling and assets
+
+- `static/site.css`: main project styling.
+- `static/leaflet.css`, `static/leaflet.js`: map dependency assets.
+- `static/logo.png`, `static/favicon.ico`: branding/icons.
+- `static/lib/`: additional local library resources.
+
+## 5. Navigation model
+
+Common user journeys:
+1. Login / auth check.
+2. Main map + logs for core road-condition data visibility.
+3. Device/database/maintenance views for administration.
+4. Feature-specific tools (monitor, memos, AV tools, Dumpert).
+
+## 6. Frontend-to-backend integration patterns
+
+Patterns used across pages:
+- JSON API requests via `fetch`.
+- Partial loading for composable UI sections (`map-partial`, `logs-partial`).
+- Polling/refresh for logs, monitor results, and long-running media tasks.
+- CRUD form patterns for records, nicknames, memos, and monitors.
+
+## 7. Static file conventions
+
+When adding/updating static resources:
+- Place new page/component files under `static/`.
+- Keep JavaScript modular and feature-focused.
+- Ensure route exposure in `main.py` if direct serving route is needed.
+- Follow `STATIC_FILES_GUIDE.md` to avoid MIME/CORB/caching pitfalls.
+
+## 8. Website change checklist
+
+For every perceptible UI or UX change:
+- Update this file’s page/module descriptions.
+- Update API dependencies in `docs/FEATURE_CATALOG.md` if endpoint usage changed.
+- Update `README.md` and/or `STATIC_FILES_GUIDE.md` when setup or static conventions change.
+- Include screenshots in PRs for visual changes (where tooling is available).
+
+## 9. Known integration dependencies
+
+- Login-dependent sections depend on auth endpoints and session behavior.
+- Map views depend on location + roughness data retrieval endpoints.
+- Maintenance/database pages depend on `/manage/*` APIs.
+- Monitor page depends on `/api/monitors/*` endpoints and service metadata.
+- Memo page depends on memo endpoints and optional transcription provider configuration.


### PR DESCRIPTION
### Motivation
- Provide a single, discoverable documentation hub to onboard developers, operators, and AI agents with a complete view of the repository and website behavior.
- Ensure documentation is maintained alongside code changes by introducing an explicit documentation maintenance policy and update contract.
- Reduce onboarding friction and stale-doc risk by enumerating features, routes, static site pages, and operational runbooks.

### Description
- Added a `docs/` folder with the following files: `docs/README.md`, `docs/AI_AGENT_CONTEXT.md`, `docs/FEATURE_CATALOG.md`, `docs/WEBSITE_GUIDE.md`, `docs/OPERATIONS_RUNBOOK.md`, and `docs/DOCUMENTATION_MAINTENANCE.md` to document features, site pages, runbook, and doc governance.
- Updated the top-level `README.md` to reference the new `docs/` hub and improve discoverability of the new guides.
- The new `docs/DOCUMENTATION_MAINTENANCE.md` defines the PR checklist, monthly review cadence, and rules that require documentation updates to ship with behavior changes.
- The `docs/AI_AGENT_CONTEXT.md` provides an agent-focused playbook with a safe-change workflow and a change-impact matrix for quick, context-aware edits.

### Testing
- No automated tests were executed because this is a documentation-only change and the repository policy instructs skipping tests for doc-only updates.
- Version control actions performed (`git add` / `git commit`) completed successfully as part of the change packaging step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ad3b06a083208038fe0132dc032e)