### PR TITLE
Dumpert: multi‑strategy background stream prewarm, diagnostics and enhanced logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1574,21 +1574,139 @@ async def dumpert_toppers_proxy(
     if page < 0 or page > 10:
         raise HTTPException(status_code=400, detail="Page must be between 0 and 10")
 
+    request_id = uuid.uuid4().hex[:8]
     url = f"https://api-live.dumpert.nl/mobile_api/json/toppers/{page}/"
     headers = {"origin": "Dumpert Top Loader"}
     if nsfw == "1":
         headers["x-dumpert-nsfw"] = "1"
 
+    log_info(
+        f"[Dumpert toppers:{request_id}] Fetching page={page} nsfw={nsfw or '0'} from upstream",
+        LogCategory.GENERAL,
+    )
+
     try:
+        started = time.perf_counter()
         resp = await run_in_threadpool(
             lambda: requests.get(url, headers=headers, timeout=10)
         )
         resp.raise_for_status()
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        try:
+            payload = resp.json()
+            item_count = len(payload.get("items") or [])
+        except ValueError:
+            item_count = -1
+        log_info(
+            f"[Dumpert toppers:{request_id}] Upstream ok status={resp.status_code} elapsed_ms={elapsed_ms} bytes={len(resp.content)} items={item_count}",
+            LogCategory.GENERAL,
+        )
         return Response(content=resp.content, media_type="application/json")
     except requests.exceptions.Timeout as exc:
+        log_warning(f"[Dumpert toppers:{request_id}] Timeout: {exc}", LogCategory.GENERAL)
         raise HTTPException(status_code=504, detail="Dumpert API timeout") from exc
     except requests.exceptions.RequestException as exc:
+        log_error(f"[Dumpert toppers:{request_id}] Request failed: {exc}", LogCategory.GENERAL)
         raise HTTPException(status_code=502, detail=f"Dumpert API error: {exc}") from exc
+
+
+def _extract_dumpert_media_urls(value: Any, bucket: List[str]) -> None:
+    if not value:
+        return
+    if isinstance(value, str):
+        if re.match(r"^https?://", value, flags=re.IGNORECASE):
+            bucket.append(value)
+        return
+    if isinstance(value, list):
+        for entry in value:
+            _extract_dumpert_media_urls(entry, bucket)
+        return
+    if isinstance(value, dict):
+        for entry in value.values():
+            _extract_dumpert_media_urls(entry, bucket)
+
+
+def _build_dumpert_stream_plan(item: Dict[str, Any]) -> Dict[str, Any]:
+    urls: List[str] = []
+    _extract_dumpert_media_urls(item, urls)
+    unique_urls = sorted(set(urls))
+
+    stream_sources: Dict[str, str] = {
+        "mp4": next((u for u in unique_urls if re.search(r"\.mp4(?:\?|$)", u, flags=re.IGNORECASE)), ""),
+        "webm": next((u for u in unique_urls if re.search(r"\.webm(?:\?|$)", u, flags=re.IGNORECASE)), ""),
+        "m3u8": next((u for u in unique_urls if re.search(r"\.m3u8(?:\?|$)", u, flags=re.IGNORECASE)), ""),
+    }
+
+    candidates: List[Dict[str, str]] = []
+    for kind in ("mp4", "webm", "m3u8"):
+        src = stream_sources.get(kind) or ""
+        if not src:
+            continue
+        candidates.append({"name": f"proxy-prewarm-{kind}", "url": _proxied_dumpert_url(src), "mode": "proxy_prewarm"})
+        candidates.append({"name": f"proxy-direct-{kind}", "url": _proxied_dumpert_url(src), "mode": "proxy_direct"})
+        candidates.append({"name": f"source-prewarm-{kind}", "url": src, "mode": "source_prewarm"})
+        candidates.append({"name": f"source-direct-{kind}", "url": src, "mode": "source_direct"})
+
+    preferred = stream_sources.get("mp4") or stream_sources.get("webm") or stream_sources.get("m3u8") or ""
+    ad_markers = ["ad", "advert", "vast", "preroll", "commercial"]
+    ad_hits = [u for u in unique_urls if any(marker in u.lower() for marker in ad_markers)]
+
+    return {
+        "item": {
+            "id": item.get("id"),
+            "title": item.get("title"),
+            "description": item.get("description"),
+        },
+        "stream_sources": stream_sources,
+        "preferred_stream": preferred,
+        "stream_candidates": candidates,
+        "ad_signals": {
+            "detected": bool(ad_hits),
+            "matches": ad_hits[:10],
+            "message": "Mogelijk advertentie-gerelateerde bron eerst geladen." if ad_hits else "",
+        },
+        "source_url_count": len(unique_urls),
+    }
+
+
+@app.get("/api/dumpert/bootstrap")
+async def dumpert_bootstrap(
+    request: Request,
+    page: int = Query(0, ge=0, le=10),
+    nsfw: Optional[str] = Query(None, pattern=r"^[01]$"),
+    item_id: Optional[str] = Query(None, min_length=3),
+):
+    """Load toppers, pick first/matching item and return stream extraction + fallback plan."""
+    request_id = uuid.uuid4().hex[:8]
+    client_ip = request.client.host if request and request.client else "unknown"
+    log_info(
+        f"[Dumpert bootstrap:{request_id}] Start page={page} nsfw={nsfw or '0'} item_id={item_id or '-'} ip={client_ip}",
+        LogCategory.GENERAL,
+    )
+
+    upstream = await dumpert_toppers_proxy(page=page, request=request, nsfw=nsfw)
+    payload = json.loads(upstream.body.decode("utf-8"))
+    items = payload.get("items") or []
+    if not items:
+        log_warning(f"[Dumpert bootstrap:{request_id}] No items returned", LogCategory.GENERAL)
+        raise HTTPException(status_code=404, detail="No Dumpert items available for requested page")
+
+    selected = items[0]
+    if item_id:
+        target = str(item_id).lower()
+        selected = next((entry for entry in items if str(entry.get("id") or "").lower() == target), selected)
+
+    plan = _build_dumpert_stream_plan(selected)
+    log_info(
+        f"[Dumpert bootstrap:{request_id}] Selected item={plan['item'].get('id')} candidates={len(plan['stream_candidates'])} ad_detected={plan['ad_signals']['detected']}",
+        LogCategory.GENERAL,
+    )
+    if not plan["preferred_stream"]:
+        log_warning(
+            f"[Dumpert bootstrap:{request_id}] No preferred stream found for item={plan['item'].get('id')}",
+            LogCategory.GENERAL,
+        )
+    return plan
 
 
 def _validate_dumpert_media_url(raw_url: str) -> str:
@@ -1643,6 +1761,8 @@ def _rewrite_m3u8_playlist(playlist_text: str, source_url: str) -> str:
 async def dumpert_media_diagnostics(url: str = Query(..., min_length=10)):
     """Return remote media response diagnostics (status/headers/sniff bytes)."""
     media_url = _validate_dumpert_media_url(url)
+    request_id = uuid.uuid4().hex[:8]
+    log_info(f"[Dumpert diagnostics:{request_id}] url={media_url}", LogCategory.GENERAL)
 
     def _fetch_diagnostics() -> Dict[str, Optional[str]]:
         session = requests.Session()
@@ -1672,8 +1792,13 @@ async def dumpert_media_diagnostics(url: str = Query(..., min_length=10)):
 
     try:
         payload = await run_in_threadpool(_fetch_diagnostics)
+        log_info(
+            f"[Dumpert diagnostics:{request_id}] status={payload.get('status')} type={payload.get('content_type')} len={payload.get('content_length')} range={payload.get('content_range')}",
+            LogCategory.GENERAL,
+        )
         return payload
     except requests.exceptions.RequestException as exc:
+        log_error(f"[Dumpert diagnostics:{request_id}] failed: {exc}", LogCategory.GENERAL)
         raise HTTPException(status_code=502, detail=f"Dumpert media diagnostics failed: {exc}") from exc
 
 
@@ -1685,6 +1810,7 @@ async def dumpert_media_proxy(
 ):
     """Stream Dumpert media through this backend to bypass browser CORS constraints."""
     media_url = _validate_dumpert_media_url(url)
+    request_id = uuid.uuid4().hex[:8]
     parsed = urlparse(media_url)
     pairs = [(k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=True) if k.lower() != "range_start"]
     clean_url = parsed._replace(query=urlencode(pairs)).geturl()
@@ -1696,16 +1822,31 @@ async def dumpert_media_proxy(
     request_headers = {"User-Agent": "RoadConditionIndexer-DumpertProxy/1.0"}
     if range_header:
         request_headers["Range"] = range_header
+    log_info(
+        f"[Dumpert proxy:{request_id}] start url={clean_url} range={range_header or '-'}",
+        LogCategory.GENERAL,
+    )
 
     try:
+        started = time.perf_counter()
         upstream = await run_in_threadpool(
             lambda: requests.get(clean_url, headers=request_headers, timeout=30, stream=True)
         )
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        log_info(
+            f"[Dumpert proxy:{request_id}] upstream status={upstream.status_code} elapsed_ms={elapsed_ms} type={upstream.headers.get('content-type', '-')}",
+            LogCategory.GENERAL,
+        )
     except requests.exceptions.RequestException as exc:
+        log_error(f"[Dumpert proxy:{request_id}] failed: {exc}", LogCategory.GENERAL)
         raise HTTPException(status_code=502, detail=f"Dumpert media proxy failed: {exc}") from exc
 
     if upstream.status_code >= 400:
         upstream.close()
+        log_warning(
+            f"[Dumpert proxy:{request_id}] upstream error status={upstream.status_code}",
+            LogCategory.GENERAL,
+        )
         raise HTTPException(status_code=upstream.status_code, detail="Dumpert media upstream returned error")
 
     content_type = (upstream.headers.get("content-type") or "").lower()
@@ -1714,6 +1855,10 @@ async def dumpert_media_proxy(
         playlist_content = upstream.text
         upstream.close()
         rewritten = _rewrite_m3u8_playlist(playlist_content, clean_url)
+        log_info(
+            f"[Dumpert proxy:{request_id}] rewritten playlist lines={len(rewritten.splitlines())}",
+            LogCategory.GENERAL,
+        )
         return Response(
             content=rewritten.encode("utf-8"),
             media_type="application/vnd.apple.mpegurl",

--- a/static/dumpert-player.html
+++ b/static/dumpert-player.html
@@ -55,7 +55,7 @@
         </div>
     </section>
 
-    <div class="status-note" id="status-note">De player doet eerst een achtergrond-check (diagnostics + byte-range prewarm) en start daarna met de beste streambron.</div>
+    <div class="status-note" id="status-note">De player doet een achtergrond-check (diagnostics + multi-strategy prewarm), probeert meerdere streamroutes en meldt advertentie-signalen vooraf.</div>
     <div id="error" class="status-message status-error" role="alert" aria-live="polite"></div>
 
     <video id="seamless-video" controls playsinline preload="auto"></video>
@@ -81,9 +81,10 @@
     let hlsInstance = null;
     let hlsScriptPromise = null;
 
-    function appendLog(message) {
+    function appendLog(message, context) {
         const stamp = new Date().toISOString();
-        logBox.value += `[${stamp}] ${message}\n`;
+        const ctx = context ? ` | ${JSON.stringify(context)}` : '';
+        logBox.value += `[${stamp}] ${message}${ctx}\n`;
         logBox.scrollTop = logBox.scrollHeight;
     }
 
@@ -201,18 +202,26 @@
         return payload.items;
     }
 
-    async function resolveItem() {
+    async function resolveItemWithStreamPlan() {
         const requestedId = parseItemId(itemIdInput.value);
-        const items = await fetchToppersPage(0, nsfwEl.value);
-        if (!items.length) throw new Error('Geen Dumpert items gevonden in toppers pagina 0.');
+        const query = new URLSearchParams({ page: '0' });
+        if (nsfwEl.value === '1') query.set('nsfw', '1');
+        if (requestedId) query.set('item_id', requestedId);
 
-        let chosen = items[0];
-        if (requestedId) {
-            const match = items.find((item) => String(item.id || '').toLowerCase() === requestedId.toLowerCase());
-            chosen = match || items[0];
-            if (!match) appendLog(`Item ${requestedId} niet gevonden op page0, fallback ${items[0].id}.`);
+        const response = await fetch(`/api/dumpert/bootstrap?${query.toString()}`);
+        if (!response.ok) {
+            const details = await response.text().catch(() => response.statusText);
+            throw new Error(`Bootstrap mislukt (${response.status}): ${details}`);
         }
-        return chosen;
+        const payload = await response.json();
+        if (!payload || !payload.item || !Array.isArray(payload.stream_candidates)) {
+            throw new Error('Onverwacht bootstrap formaat ontvangen.');
+        }
+        if (payload.ad_signals?.detected) {
+            statusNote.textContent = 'Let op: er zijn advertentie-signalen gevonden in de streambronnen.';
+            appendLog('Advertentie-signalen gevonden, gebruiker geïnformeerd.', payload.ad_signals);
+        }
+        return payload;
     }
 
     function proxiedUrl(url, rangeStart) {
@@ -245,6 +254,23 @@
         }
     }
 
+    function candidateToOriginalMediaUrl(candidateUrl) {
+        if (!candidateUrl.includes('/api/dumpert/media-proxy?url=')) return candidateUrl;
+        const encoded = candidateUrl.split('url=')[1]?.split('&')[0] || '';
+        return decodeURIComponent(encoded);
+    }
+
+    async function tryBackgroundLoad(candidate) {
+        const started = performance.now();
+        appendLog('Achtergrond poging gestart.', candidate);
+        if (candidate.mode.includes('prewarm')) {
+            await prewarmProxyStream(candidateToOriginalMediaUrl(candidate.url));
+        }
+        const elapsedMs = Math.round(performance.now() - started);
+        appendLog(`Achtergrond poging geslaagd in ${elapsedMs}ms`, candidate);
+        return true;
+    }
+
     async function playSeamless() {
         clearError();
         destroyHlsInstance();
@@ -252,35 +278,44 @@
         video.removeAttribute('src');
         video.load();
 
-        const item = await resolveItem();
-        itemIdInput.value = item.id || '';
-        const media = pickMediaUrls(item);
-        const preferred = media.mp4 || media.webm || media.m3u8;
+        const plan = await resolveItemWithStreamPlan();
+        const item = plan.item || {};
+        const media = plan.stream_sources || {};
+        const preferred = plan.preferred_stream;
         const usingHls = !media.mp4 && !media.webm && !!media.m3u8;
+        itemIdInput.value = item.id || '';
 
-        if (!preferred) throw new Error('Geen video URL (mp4/webm/m3u8) gevonden in payload.');
+        if (!preferred) throw new Error('Geen video URL (mp4/webm/m3u8) gevonden in bootstrap payload.');
 
         statusNote.textContent = `Item ${item.id || 'n/a'} wordt voorbereid voor seamless playback.`;
-        appendLog(`Gekozen item: ${item.id || 'onbekend'} - ${item.title || 'zonder titel'}`);
+        appendLog(`Gekozen item: ${item.id || 'onbekend'} - ${item.title || 'zonder titel'}`, { sourceUrlCount: plan.source_url_count || 0 });
         appendLog(`Bronnen: mp4=${media.mp4 || '-'} | webm=${media.webm || '-'} | m3u8=${media.m3u8 || '-'}`);
+        appendLog('Beschikbare laadstrategieën ontvangen.', { candidates: plan.stream_candidates.length });
 
         const diag = await fetchDiagnostics(preferred);
         appendLog(`Diagnostics: status=${diag.status} type=${diag.content_type || '-'} len=${diag.content_length || '-'} range=${diag.accept_ranges || '-'} sniff=${diag.sniff || '-'}`);
 
-        const proxySource = proxiedUrl(preferred);
-        try {
-            await prewarmProxyStream(preferred);
-            appendLog('Warmup geslaagd: eerste bytes op de achtergrond geladen via proxy.');
-            await setPlaybackSource(proxySource, usingHls);
-            statusNote.textContent = `Seamless playback via backend proxy voor item ${item.id || 'n/a'}.`;
-        } catch (error) {
-            appendLog(`Warmup/proxy fallback naar direct URL: ${error.message}`);
-            await setPlaybackSource(preferred, usingHls);
-            statusNote.textContent = `Fallback: directe streambron voor item ${item.id || 'n/a'}.`;
+        let lastError = null;
+        for (const candidate of plan.stream_candidates) {
+            try {
+                await tryBackgroundLoad(candidate);
+                await setPlaybackSource(candidate.url, usingHls);
+                statusNote.textContent = `Playback actief via strategie: ${candidate.name} (item ${item.id || 'n/a'}).`;
+                appendLog('Playback bron gekozen en naar front-end doorgezet.', candidate);
+                lastError = null;
+                break;
+            } catch (error) {
+                lastError = error;
+                appendLog(`Strategie mislukt: ${error.message}`, candidate);
+            }
+        }
+
+        if (lastError) {
+            throw new Error(`Geen enkele streamstrategie werkte: ${lastError.message}`);
         }
 
         video.load();
-        appendLog(`Playback bron ingesteld: ${usingHls ? '(HLS playlist geladen)' : video.src}`);
+        appendLog(`Playback bron ingesteld: ${usingHls ? '(HLS playlist geladen)' : video.src}`, { currentSrc: video.currentSrc || '-' });
     }
 
     ['loadstart', 'loadedmetadata', 'canplay', 'playing', 'stalled', 'waiting', 'error', 'ended'].forEach((evt) => {
@@ -297,10 +332,14 @@
     loadSampleBtn.addEventListener('click', async () => {
         clearError();
         try {
-            const items = await fetchToppersPage(0, nsfwEl.value);
-            if (!items.length) throw new Error('Geen items op toppers pagina 0.');
-            itemIdInput.value = items[0].id || '';
-            appendLog(`Sample geladen: ${items[0].id || 'onbekend'} - ${items[0].title || 'zonder titel'}`);
+            const plan = await resolveItemWithStreamPlan();
+            itemIdInput.value = plan.item?.id || '';
+            appendLog(`Sample geladen: ${plan.item?.id || 'onbekend'} - ${plan.item?.title || 'zonder titel'}`);
+            appendLog('Bootstrap data ontvangen en geparsed voor front-end.', {
+                hasPreferred: Boolean(plan.preferred_stream),
+                candidateCount: (plan.stream_candidates || []).length,
+                adSignals: Boolean(plan.ad_signals?.detected),
+            });
         } catch (error) {
             showError(error.message);
         }

--- a/tests/core/test_dumpert_bootstrap.py
+++ b/tests/core/test_dumpert_bootstrap.py
@@ -1,0 +1,100 @@
+"""Tests for Dumpert bootstrap stream extraction and background strategy payload."""
+
+import importlib
+import json
+import os
+
+import pytest
+from fastapi.dependencies import utils as fastapi_utils
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+REQUIRED_VARS = {
+    "AZURE_SQL_SERVER": "stub.server.local",
+    "AZURE_SQL_PORT": "1433",
+    "AZURE_SQL_USER": "test",
+    "AZURE_SQL_PASSWORD": "secret",
+    "AZURE_SQL_DATABASE": "testdb",
+}
+
+for key, value in REQUIRED_VARS.items():
+    os.environ.setdefault(key, value)
+
+
+def _load_main(monkeypatch):
+    monkeypatch.setattr(fastapi_utils, "ensure_multipart_is_installed", lambda: None)
+    return importlib.import_module("main")
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+        self.content = json.dumps(payload).encode("utf-8")
+        self.headers = {"content-type": "application/json"}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_bootstrap_returns_first_item_and_stream_candidates(monkeypatch):
+    main = _load_main(monkeypatch)
+    monkeypatch.setattr(main, "is_authenticated", lambda _request: True)
+
+    upstream_payload = {
+        "items": [
+            {
+                "id": "100_first",
+                "title": "First one",
+                "media": {
+                    "variants": {
+                        "mp4": "https://media.dumpert.nl/video/100_first.mp4",
+                        "hls": "https://media.dumpert.nl/video/100_first.m3u8",
+                    }
+                },
+            },
+            {"id": "200_second", "title": "Second one"},
+        ]
+    }
+    monkeypatch.setattr(main.requests, "get", lambda *_args, **_kwargs: _FakeResponse(upstream_payload))
+
+    client = TestClient(main.app)
+    response = client.get("/api/dumpert/bootstrap?page=0&nsfw=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["item"]["id"] == "100_first"
+    assert payload["preferred_stream"] == "https://media.dumpert.nl/video/100_first.mp4"
+    assert payload["stream_sources"]["m3u8"] == "https://media.dumpert.nl/video/100_first.m3u8"
+    assert payload["source_url_count"] >= 2
+    names = [entry["name"] for entry in payload["stream_candidates"]]
+    assert "proxy-prewarm-mp4" in names
+    assert "source-direct-m3u8" in names
+
+
+def test_bootstrap_detects_ad_signals(monkeypatch):
+    main = _load_main(monkeypatch)
+    monkeypatch.setattr(main, "is_authenticated", lambda _request: True)
+
+    upstream_payload = {
+        "items": [
+            {
+                "id": "ad_case",
+                "title": "Has ad marker",
+                "media": {"mp4": "https://media.dumpert.nl/vast/ad_preroll.mp4"},
+            }
+        ]
+    }
+    monkeypatch.setattr(main.requests, "get", lambda *_args, **_kwargs: _FakeResponse(upstream_payload))
+
+    client = TestClient(main.app)
+    response = client.get("/api/dumpert/bootstrap?page=0")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ad_signals"]["detected"] is True
+    assert payload["ad_signals"]["matches"]

--- a/tests/core/test_dumpert_pages.py
+++ b/tests/core/test_dumpert_pages.py
@@ -35,6 +35,8 @@ def test_dumpert_player_page_exposes_seamless_background_stream_flow(monkeypatch
 
     assert response.status_code == 200
     assert 'Seamless player' in response.text
-    assert 'achtergrond-check (diagnostics + byte-range prewarm)' in response.text
+    assert 'achtergrond-check (diagnostics + multi-strategy prewarm)' in response.text
+    assert 'meerdere streamroutes' in response.text
+    assert 'advertentie-signalen' in response.text
     assert 'Seamless afspelen' in response.text
     assert 'Start alle 10 oplossingen' not in response.text


### PR DESCRIPTION
### Motivation

- Improve the Dumpert player so the frontend can obtain video streams via multiple background-loading strategies and pick the best source automatically.  
- Surface advertisement-like sources to the user early so they are informed if ads appear to be loaded first.  
- Provide richer, request‑scoped logging and diagnostics to make debugging and analysis of streaming failures straightforward.  

### Description

- Add a new endpoint `GET /api/dumpert/bootstrap` that fetches toppers, selects the first (or matching) item, extracts all media URLs, builds a multi‑candidate stream plan (proxy/direct + prewarm variants) and flags ad signals.  
- Extend backend Dumpert logging across toppers, diagnostics and media proxy routes to include short `request_id`s, timings (`elapsed_ms`), response metadata (status, bytes, headers), and playlist rewrite details for improved observability.  
- Update `static/dumpert-player.html` to consume the bootstrap payload, inform the user about ad signals, attempt multiple background loading strategies (prewarm + direct/proxy variants), and emit structured debug logs for each step including candidate attempts and playback handoff.  
- Add automated tests in `tests/core/test_dumpert_bootstrap.py` and update `tests/core/test_dumpert_pages.py` to validate the new UI messaging and bootstrap payload shape, while keeping existing media proxy tests intact.  

### Testing

- Ran the focused test suite with `pytest -q tests/core/test_dumpert_pages.py tests/core/test_dumpert_media_proxy.py tests/core/test_dumpert_bootstrap.py`.  
- Result: `4 passed` (tests completed successfully).  
- The new tests verify that the bootstrap endpoint returns the first item, extracts stream candidates (including proxy/prewarm variants), and detects ad signals in the payload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ed55f12483208996967d03170da9)