### PR TITLE
Restructure site navigation around Maintenance Hub

### DIFF
--- a/static/av-tools.html
+++ b/static/av-tools.html
@@ -10,14 +10,9 @@
 </head>
 <body>
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="monitor.html">Monitor</a>
-    <a href="tools.html">Tools</a>
-    <a href="shared.html">Shared</a>
-    <a href="memo.html">Memo's</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/static/chris.html
+++ b/static/chris.html
@@ -10,12 +10,9 @@
 </head>
 <body>
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="shared.html">Shared</a>
-    <a href="tools.html">Tools</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 <h1 class="mb-1"><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Chris</h1>

--- a/static/database.html
+++ b/static/database.html
@@ -9,7 +9,15 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <script src="/static/utils.js"></script>
     <script src="map-components.js"></script>
-    
+</head>
+<body>
+<nav id="page-links" class="page-links mb-1">
+    <a href="/">Road Condition Indexer</a>
+    <a href="device.html">Device View</a>
+    <a href="maintenance.html">Maintenance Hub</a>
+    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
+</nav>
+<h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Database Maintenance</h1>
 
 <!-- Delete Confirmation -->
 <div id="delete-confirmation" class="confirmation-box danger">

--- a/static/dumpert.html
+++ b/static/dumpert.html
@@ -190,15 +190,9 @@
 </head>
 <body>
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="monitor.html">Monitor</a>
-    <a href="tools.html">Tools</a>
-    <a href="shared.html">Shared</a>
-    <a href="memo.html">Memo's</a>
-    <a href="dumpert.html" aria-current="page">Dumpert</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -237,13 +237,44 @@
 </head>
 <body>
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="tools.html">Tools</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
-<h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Maintenance</h1>
+<h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Maintenance Hub</h1>
+
+<section class="maintenance-hub rci-card" aria-labelledby="maintenance-hub-title">
+    <div class="maintenance-hub-header">
+        <h2 id="maintenance-hub-title">Hidden tools and support pages</h2>
+        <p class="rci-muted">The public Road Condition Indexer experience stays focused on the main map and Device View. Use this hub to access maintenance, media, memo, and technical utilities.</p>
+    </div>
+    <div class="maintenance-hub-grid">
+        <article class="maintenance-hub-group">
+            <h3>RCI Tools</h3>
+            <a href="database.html">Database Maintenance</a>
+            <a href="maintenance.html" aria-current="page">Maintenance</a>
+        </article>
+        <article class="maintenance-hub-group">
+            <h3>Audio/Video Tools</h3>
+            <a href="av-tools.html">Audio/Video Tools</a>
+        </article>
+        <article class="maintenance-hub-group">
+            <h3>Technical Tools</h3>
+            <a href="tools.html">Tools</a>
+            <a href="monitor.html">Monitor</a>
+        </article>
+        <article class="maintenance-hub-group">
+            <h3>Memos/Shared</h3>
+            <a href="memo.html">Memo's</a>
+            <a href="shared.html">Shared Objects</a>
+        </article>
+        <article class="maintenance-hub-group">
+            <h3>Dumpert</h3>
+            <a href="dumpert.html">Dumpert Top Loader</a>
+        </article>
+    </div>
+</section>
 
 <!-- Database Log Viewer (collapsible section) -->
 <div class="section">

--- a/static/memo.html
+++ b/static/memo.html
@@ -12,12 +12,9 @@
 <body>
 
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="tools.html">Tools</a>
-    <a href="memo.html" aria-current="page">Memo's</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/static/monitor.html
+++ b/static/monitor.html
@@ -13,14 +13,9 @@
 <body>
 
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="tools.html">Tools</a>
-    <a href="monitor.html" aria-current="page">Monitor</a>
-    <a href="shared.html">Shared</a>
-    <a href="memo.html">Memo's</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/static/shared.html
+++ b/static/shared.html
@@ -14,11 +14,9 @@
 <body>
 
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="tools.html">Tools</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/static/site.css
+++ b/static/site.css
@@ -771,3 +771,16 @@ body.memo-camera-overlay-fullscreen { overflow:hidden; }
 [data-theme="dark"] .monitor-log-panel { background:#1f2a33; border:1px solid #2f3d47; }
 [data-theme="dark"] .monitor-log-change { background:#23303a; border-color:#2f3d47; }
 [data-theme="dark"] .monitor-graph-empty { color:#9fb3c8; }
+
+/* Maintenance hub navigation */
+.maintenance-hub { margin:1rem 0 1.5rem; }
+.maintenance-hub-header { margin-bottom:1rem; }
+.maintenance-hub-header h2 { margin:0 0 .35rem; }
+.maintenance-hub-header p { margin:0; }
+.maintenance-hub-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:1rem; }
+.maintenance-hub-group { border:1px solid var(--rci-border); border-radius:8px; padding:1rem; background:var(--rci-surface); box-shadow:var(--rci-shadow); }
+.maintenance-hub-group h3 { margin:0 0 .75rem; color:var(--rci-primary); font-size:1rem; }
+.maintenance-hub-group a { display:block; padding:.45rem .55rem; margin:.25rem 0; border-radius:6px; color:var(--rci-link); text-decoration:none; background:var(--rci-bg-alt); }
+.maintenance-hub-group a:hover,
+.maintenance-hub-group a:focus { background:var(--rci-surface-alt); text-decoration:underline; outline:none; }
+.maintenance-hub-group a[aria-current="page"] { font-weight:700; color:var(--rci-text); border:1px solid var(--rci-primary-accent); }

--- a/static/solution.html
+++ b/static/solution.html
@@ -10,12 +10,9 @@
 </head>
 <body>
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="shared.html">Shared</a>
-    <a href="tools.html">Tools</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 <h1 class="mb-1"><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Solution</h1>

--- a/static/timezone-test.html
+++ b/static/timezone-test.html
@@ -10,12 +10,9 @@
 </head>
 <body>
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="shared.html">Shared</a>
-    <a href="tools.html">Tools</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 

--- a/static/tools.html
+++ b/static/tools.html
@@ -21,15 +21,9 @@
 <body>
 
 <nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
+    <a href="/">Road Condition Indexer</a>
     <a href="device.html">Device View</a>
-    <a href="database.html">Database Management</a>
-    <a href="maintenance.html">Maintenance</a>
-    <a href="monitor.html">Monitor</a>
-    <a href="shared.html">Shared</a>
-    <a href="memo.html">Memo's</a>
-    <a href="av-tools.html">Audio/Video Tools</a>
-    <a href="dumpert.html">Dumpert</a>
+    <a href="maintenance.html">Maintenance Hub</a>
     <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
 </nav>
 


### PR DESCRIPTION
### Motivation

- Keep the public experience focused on the main Road Condition Indexer map and Device View while moving secondary/administrative pages behind a single maintenance entrypoint. 
- Group related hidden pages (database maintenance, audio/video, technical tools, memos/shared, Dumpert) so they are discoverable but not prominent in every page nav. 
- Make the Database Maintenance page presentable under the new hub so it fits the same navigation affordance as other maintenance tools. 

### Description

- Added a new Maintenance Hub section to `static/maintenance.html` that organizes hidden pages into: RCI Tools, Audio/Video Tools, Technical Tools, Memos/Shared, and Dumpert. 
- Simplified header navigation across secondary pages so non-main pages link back to the hub instead of listing every tool (updated many `static/*.html` files to use the new hub nav). 
- Restored a standard page shell (nav + heading) for `static/database.html` and adjusted `static/site.css` with responsive hub card styles (`.maintenance-hub*` rules). 
- Minor wording and title adjustments to ensure the main site title reads `Road Condition Indexer` and the hub pages present the grouped links consistently. 

### Testing

- No automated tests were executed because this is a layout/navigation-only change (per project instructions). 
- A screenshot verification attempt was made but Playwright/browser tooling was not available in the environment, so no render snapshot was generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda0e812348320809f18af9fb4653d)