### PR TITLE
Add role-based user management with per-user passwords and admin-protected maintenance

### DIFF
--- a/database.py
+++ b/database.py
@@ -66,6 +66,7 @@ TABLE_MEMOS = "RCI_memos"
 TABLE_MEMO_ARCHIVE = "memo_archive"
 TABLE_MONITORS = "RCI_monitors"
 TABLE_MONITOR_RESULTS = "RCI_monitor_results"
+TABLE_USERS = "RCI_users"
 
 # Base directory for the application
 BASE_DIR = Path(__file__).resolve().parent
@@ -327,6 +328,64 @@ class DatabaseManager:
 
     def _create_sqlserver_tables(self, conn):
         """Create tables for SQL Server."""
+        # Create users table for role-based authentication
+        conn.execute(
+            text(f"""
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.tables WHERE name = '{TABLE_USERS}'
+            )
+            BEGIN
+                CREATE TABLE {TABLE_USERS} (
+                    id INT IDENTITY PRIMARY KEY,
+                    username NVARCHAR(100) NOT NULL UNIQUE,
+                    role NVARCHAR(20) NOT NULL,
+                    password_hash NVARCHAR(512) NULL,
+                    created_at DATETIME2 DEFAULT SYSUTCDATETIME(),
+                    updated_at DATETIME2 DEFAULT SYSUTCDATETIME(),
+                    last_login_at DATETIME2 NULL,
+                    CONSTRAINT CK_RCI_users_role CHECK (role IN ('User', 'Admin'))
+                )
+            END
+            """)
+        )
+
+        # Add user-management columns when upgrading an existing table
+        for column_name, column_definition in (
+            ("password_hash", "NVARCHAR(512) NULL"),
+            ("created_at", "DATETIME2 DEFAULT SYSUTCDATETIME()"),
+            ("updated_at", "DATETIME2 DEFAULT SYSUTCDATETIME()"),
+            ("last_login_at", "DATETIME2 NULL"),
+        ):
+            conn.execute(
+                text(f"""
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.columns
+                    WHERE object_id = OBJECT_ID('{TABLE_USERS}') AND name = '{column_name}'
+                )
+                BEGIN
+                    ALTER TABLE {TABLE_USERS} ADD {column_name} {column_definition}
+                END
+                """)
+            )
+
+        # Ensure the initial application users exist without passwords. Passwords
+        # are set by the users during their first successful sign-in flow.
+        conn.execute(text(f"""
+            IF NOT EXISTS (SELECT 1 FROM {TABLE_USERS} WHERE username = 'Fiets')
+            BEGIN
+                INSERT INTO {TABLE_USERS} (username, role, password_hash)
+                VALUES ('Fiets', 'User', NULL)
+            END
+        """))
+        conn.execute(text(f"""
+            IF NOT EXISTS (SELECT 1 FROM {TABLE_USERS} WHERE username = 'Techno')
+            BEGIN
+                INSERT INTO {TABLE_USERS} (username, role, password_hash)
+                VALUES ('Techno', 'Admin', NULL)
+            END
+        """))
+
         # Create bike data table
         conn.execute(
             text(f"""
@@ -1433,7 +1492,49 @@ class DatabaseManager:
             # Return defaults if there's any error
             return 0.0, None
 
-    def execute_query(self, query: str, params: Optional[Tuple] = None) -> List[Dict[str, Any]]:
+    def get_user_by_username(self, username: str) -> Optional[Dict[str, Any]]:
+        """Return a user record for a case-insensitive username lookup."""
+        rows = self.execute_query(
+            f"""
+            SELECT TOP 1 id, username, role, password_hash, created_at, updated_at, last_login_at
+            FROM {TABLE_USERS}
+            WHERE LOWER(username) = LOWER(:username)
+            """,
+            {"username": username},
+        )
+        return rows[0] if rows else None
+
+    def get_user_by_id(self, user_id: int) -> Optional[Dict[str, Any]]:
+        """Return a user record by id."""
+        rows = self.execute_query(
+            f"""
+            SELECT TOP 1 id, username, role, password_hash, created_at, updated_at, last_login_at
+            FROM {TABLE_USERS}
+            WHERE id = :user_id
+            """,
+            {"user_id": user_id},
+        )
+        return rows[0] if rows else None
+
+    def set_user_password_hash(self, user_id: int, password_hash: str) -> None:
+        """Persist a password hash for a user."""
+        self.execute_non_query(
+            f"""
+            UPDATE {TABLE_USERS}
+            SET password_hash = :password_hash, updated_at = SYSUTCDATETIME()
+            WHERE id = :user_id
+            """,
+            {"password_hash": password_hash, "user_id": user_id},
+        )
+
+    def record_user_login(self, user_id: int) -> None:
+        """Record the latest successful login timestamp for a user."""
+        self.execute_non_query(
+            f"UPDATE {TABLE_USERS} SET last_login_at = SYSUTCDATETIME() WHERE id = :user_id",
+            {"user_id": user_id},
+        )
+
+    def execute_query(self, query: str, params: Optional[Union[Tuple, Dict]] = None) -> List[Dict[str, Any]]:
         """Execute a query and return results as a list of dictionaries."""
         query_short = query[:100] + "..." if len(query) > 100 else query
         self.log_debug(f"Executing query: {query_short}", LogLevel.DEBUG, LogCategory.QUERY)
@@ -1484,7 +1585,7 @@ class DatabaseManager:
                           LogLevel.ERROR, LogCategory.QUERY, include_stack=True)
             raise
 
-    def execute_scalar(self, query: str, params: Optional[Tuple] = None) -> Any:
+    def execute_scalar(self, query: str, params: Optional[Union[Tuple, Dict]] = None) -> Any:
         """Execute a query and return a single scalar value."""
         query_short = query[:100] + "..." if len(query) > 100 else query
         self.log_debug(f"Executing scalar query: {query_short}", LogLevel.DEBUG, LogCategory.QUERY)

--- a/main.py
+++ b/main.py
@@ -37,13 +37,16 @@ def load_environment_config():
 load_environment_config()
 import asyncio
 import difflib
+import base64
 import hashlib
+import hmac
 import json
 import math
 import re
+import secrets
 import tempfile
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from html import unescape
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Literal
@@ -1223,13 +1226,41 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Road Condition Indexer", lifespan=lifespan)
 
 
-# Serve all static files automatically (public, no auth)
-from fastapi.staticfiles import StaticFiles
+class RoleProtectedStaticFiles(StaticFiles):
+    """Serve static assets while enforcing auth for directly requested HTML pages."""
 
-app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
+    async def get_response(self, path: str, scope):
+        requested_name = Path(path).name
+        if requested_name.endswith(".html") and requested_name not in PUBLIC_STATIC_HTML:
+            required_role = ROLE_ADMIN if requested_name in MAINTENANCE_PAGES else ROLE_USER
+            user = get_current_user_from_scope(scope)
+            if user is None:
+                return RedirectResponse(url=f"/static/login.html?next=/static/{path}")
+            if required_role == ROLE_ADMIN and user.get("role") != ROLE_ADMIN:
+                return Response(status_code=403, content="Forbidden")
+        return await super().get_response(path, scope)
 
-# MD5 hash for the default password
-PASSWORD_HASH = "08457aa99f426e5e8410798acd74c23b"
+
+app.mount("/static", RoleProtectedStaticFiles(directory=BASE_DIR / "static"), name="static")
+
+SESSION_COOKIE_NAME = "rci_session"
+SESSION_TTL_SECONDS = int(os.getenv("RCI_SESSION_TTL_SECONDS", str(12 * 60 * 60)))
+SESSION_SECRET = os.getenv("RCI_SESSION_SECRET") or os.getenv("SECRET_KEY") or "rci-development-session-secret"
+ROLE_USER = "User"
+ROLE_ADMIN = "Admin"
+PASSWORD_HASH_ITERATIONS = 260_000
+
+MAINTENANCE_PAGES = {
+    "maintenance.html",
+    "database.html",
+    "tools.html",
+    "av-tools.html",
+    "memo.html",
+    "monitor.html",
+    "comprehensive-logs.html",
+    "dumpert.html",
+}
+PUBLIC_STATIC_HTML = {"login.html"}
 
 # Thresholds for log filtering
 MAX_INTERVAL_SEC = float(os.getenv("RCI_MAX_INTERVAL_SEC", "15"))
@@ -1324,56 +1355,192 @@ def get_sql_client():
         return None
     return SqlManagementClient(cred, subscription)
 
-def verify_password(pw: str) -> bool:
-    """Return True if the MD5 hash of ``pw`` matches PASSWORD_HASH."""
-    return hashlib.md5(pw.encode()).hexdigest() == PASSWORD_HASH
+def hash_password(password: str) -> str:
+    """Hash a password with PBKDF2-HMAC-SHA256 and a per-password salt."""
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        PASSWORD_HASH_ITERATIONS,
+    )
+    return "pbkdf2_sha256${iterations}${salt}${digest}".format(
+        iterations=PASSWORD_HASH_ITERATIONS,
+        salt=base64.urlsafe_b64encode(salt).decode("ascii"),
+        digest=base64.urlsafe_b64encode(digest).decode("ascii"),
+    )
+
+
+def verify_password(password: str, stored_hash: Optional[str]) -> bool:
+    """Return True when a plaintext password matches the stored password hash."""
+    if not stored_hash:
+        return password == ""
+
+    try:
+        algorithm, iterations, salt_b64, digest_b64 = stored_hash.split("$", 3)
+        if algorithm != "pbkdf2_sha256":
+            return False
+        expected = base64.urlsafe_b64decode(digest_b64.encode("ascii"))
+        actual = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode("utf-8"),
+            base64.urlsafe_b64decode(salt_b64.encode("ascii")),
+            int(iterations),
+        )
+        return hmac.compare_digest(actual, expected)
+    except Exception:
+        return False
+
+
+def _session_signature(payload: str) -> str:
+    return hmac.new(SESSION_SECRET.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def create_session_token(user: Dict[str, Any]) -> str:
+    """Create a signed, time-limited session token for a user."""
+    expires_at = int(time.time()) + SESSION_TTL_SECONDS
+    payload = "|".join([str(user["id"]), str(user["username"]), str(user["role"]), str(expires_at)])
+    token = f"{payload}|{_session_signature(payload)}"
+    return base64.urlsafe_b64encode(token.encode("utf-8")).decode("ascii")
+
+
+def decode_session_token(token: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Validate a session cookie and return its user payload."""
+    if not token:
+        return None
+    try:
+        decoded = base64.urlsafe_b64decode(token.encode("ascii")).decode("utf-8")
+        user_id, username, role, expires_at, signature = decoded.rsplit("|", 4)
+        payload = "|".join([user_id, username, role, expires_at])
+        if not hmac.compare_digest(signature, _session_signature(payload)):
+            return None
+        if int(expires_at) < int(time.time()):
+            return None
+        return {"id": int(user_id), "username": username, "role": role}
+    except Exception:
+        return None
+
+
+def get_current_user_from_scope(scope) -> Optional[Dict[str, Any]]:
+    headers = dict(scope.get("headers") or [])
+    cookie_header = headers.get(b"cookie", b"").decode("latin-1")
+    cookies = {}
+    for part in cookie_header.split(";"):
+        if "=" in part:
+            key, value = part.strip().split("=", 1)
+            cookies[key] = value
+    return decode_session_token(cookies.get(SESSION_COOKIE_NAME))
+
+
+def get_current_user(request: Request) -> Optional[Dict[str, Any]]:
+    """Return the authenticated user from the signed session cookie, if any."""
+    return decode_session_token(request.cookies.get(SESSION_COOKIE_NAME))
+
 
 def is_authenticated(request: Request) -> bool:
-    """Return True if request has valid auth cookie."""
-    return request.cookies.get("auth") == PASSWORD_HASH
+    """Return True if request has a valid user session."""
+    return get_current_user(request) is not None
+
+
+def require_role(request: Request, required_role: str = ROLE_USER) -> Dict[str, Any]:
+    """Require an authenticated user and, optionally, the Admin role."""
+    user = get_current_user(request)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if required_role == ROLE_ADMIN and user.get("role") != ROLE_ADMIN:
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return user
+
 
 def password_dependency(request: Request) -> None:
-    """Authenticate using cookie or optional ``pw`` query parameter."""
-    cookie = request.cookies.get("auth")
-    if cookie == PASSWORD_HASH:
-        return
-    pw = request.query_params.get("pw")
-    if pw and verify_password(pw):
-        return
-    raise HTTPException(status_code=401, detail="Unauthorized")
+    """Require any authenticated application user."""
+    require_role(request, ROLE_USER)
+
+
+def admin_dependency(request: Request) -> None:
+    """Require an authenticated Admin user."""
+    require_role(request, ROLE_ADMIN)
 
 
 class LoginRequest(BaseModel):
-    password: str = Field(..., min_length=1)
+    username: str = Field(..., min_length=1)
+    password: str = ""
+    new_password: Optional[str] = Field(None, min_length=1)
 
 
 @app.post("/login")
 def login(req: LoginRequest, request: Request):
-    """Set auth cookie if password is correct."""
+    """Authenticate a named user, setting an initial password when needed."""
     client_ip = get_client_ip(request)
-    user_agent = request.headers.get("user-agent", "Unknown")
-    
-    if verify_password(req.password):
-        # Successful login
-        resp = Response(status_code=204)
-        resp.set_cookie("auth", PASSWORD_HASH, httponly=True, path="/")
-        
-        log_info(f"Successful login from IP: {client_ip}", LogCategory.USER_ACTION)
-        return resp
-    else:
-        # Failed login
-        log_warning(f"Failed login attempt from IP: {client_ip}", LogCategory.USER_ACTION)
+    username = req.username.strip()
+    if not username:
+        raise HTTPException(status_code=400, detail="Username is required")
+
+    if hasattr(db_manager, "init_tables"):
+        db_manager.init_tables()
+
+    user = db_manager.get_user_by_username(username)
+    if not user:
+        log_warning(f"Failed login attempt for unknown user '{username}' from IP: {client_ip}", LogCategory.USER_ACTION)
         raise HTTPException(status_code=401, detail="Unauthorized")
 
-@app.get("/auth_check")
-def auth_check(request: Request):
-    """Return 204 if auth cookie valid else 401."""
-    if is_authenticated(request):
-        return Response(status_code=204)
-    else:
-        client_ip = get_client_ip(request)
-        log_warning(f"Authentication check failed from IP: {client_ip}", LogCategory.USER_ACTION)
+    password_hash = user.get("password_hash")
+    password_needs_setup = not password_hash
+    if password_needs_setup:
+        if req.password != "":
+            raise HTTPException(status_code=401, detail="Initial password is blank")
+        if not req.new_password:
+            raise HTTPException(status_code=409, detail="Password setup required")
+        db_manager.set_user_password_hash(int(user["id"]), hash_password(req.new_password))
+    elif not verify_password(req.password, password_hash):
+        log_warning(f"Failed login attempt for user '{user['username']}' from IP: {client_ip}", LogCategory.USER_ACTION)
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+    db_manager.record_user_login(int(user["id"]))
+    resp = Response(status_code=204)
+    resp.set_cookie(
+        SESSION_COOKIE_NAME,
+        create_session_token(user),
+        httponly=True,
+        path="/",
+        samesite="lax",
+    )
+    log_info(f"Successful login for user '{user['username']}' ({user['role']}) from IP: {client_ip}", LogCategory.USER_ACTION)
+    return resp
+
+
+@app.post("/logout")
+def logout():
+    """Clear the signed session cookie."""
+    resp = Response(status_code=204)
+    resp.delete_cookie(SESSION_COOKIE_NAME, path="/")
+    return resp
+
+
+@app.get("/auth_check")
+def auth_check(request: Request, role: str = Query(ROLE_USER)):
+    """Return 204 if the current session has the requested role."""
+    required_role = ROLE_ADMIN if role == ROLE_ADMIN else ROLE_USER
+    require_role(request, required_role)
+    return Response(status_code=204)
+
+
+@app.get("/api/me")
+def get_me(request: Request):
+    """Return the current authenticated user."""
+    return require_role(request, ROLE_USER)
+
+
+
+
+def serve_protected_html(request: Request, filename: str, required_role: str = ROLE_USER):
+    """Serve an HTML page after enforcing the requested role."""
+    user = get_current_user(request)
+    if user is None:
+        return RedirectResponse(url=f"/static/login.html?next=/{filename}")
+    if required_role == ROLE_ADMIN and user.get("role") != ROLE_ADMIN:
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return FileResponse(BASE_DIR / "static" / filename)
 
 @app.get("/health")
 def health_check():
@@ -1447,6 +1614,11 @@ def get_login_page():
     """Serve the login page - this should be accessible without authentication."""
     return FileResponse(BASE_DIR / "static" / "login.html")
 
+@app.get("/login.html")
+def get_login_page_alias():
+    """Serve the login page alias for older redirects."""
+    return FileResponse(BASE_DIR / "static" / "login.html")
+
 
 @app.get("/static/logs-partial.html")
 def get_logs_partial():
@@ -1469,65 +1641,49 @@ def get_map_components_js():
 @app.get("/welcome.html")
 def read_welcome(request: Request):
     """Serve the welcome page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/welcome.html")
-    return FileResponse(BASE_DIR / "static" / "welcome.html")
+    return serve_protected_html(request, "welcome.html")
 
 
 @app.get("/device.html")
 def read_device(request: Request):
     """Serve the device filter page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/device.html")
-    return FileResponse(BASE_DIR / "static" / "device.html")
+    return serve_protected_html(request, "device.html")
 
 
 @app.get("/maintenance.html")
 def read_maintenance(request: Request):
     """Serve the maintenance page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/maintenance.html")
-    return FileResponse(BASE_DIR / "static" / "maintenance.html")
+    return serve_protected_html(request, "maintenance.html", ROLE_ADMIN)
 
 
 @app.get("/database.html")
 def read_database(request: Request):
     """Serve the database management page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/database.html")
-    return FileResponse(BASE_DIR / "static" / "database.html")
+    return serve_protected_html(request, "database.html", ROLE_ADMIN)
 
 
 @app.get("/tools.html")
 def read_tools(request: Request):
     """Serve the tools page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/tools.html")
-    return FileResponse(BASE_DIR / "static" / "tools.html")
+    return serve_protected_html(request, "tools.html", ROLE_ADMIN)
 
 
 @app.get("/av-tools.html")
 def read_av_tools(request: Request):
     """Serve the audio and video tools page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/av-tools.html")
-    return FileResponse(BASE_DIR / "static" / "av-tools.html")
+    return serve_protected_html(request, "av-tools.html", ROLE_ADMIN)
 
 
 @app.get("/memo.html")
 def read_memo_page(request: Request):
     """Serve the memo management page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/memo.html")
-    return FileResponse(BASE_DIR / "static" / "memo.html")
+    return serve_protected_html(request, "memo.html", ROLE_ADMIN)
 
 
 @app.get("/monitor.html")
 def read_monitor_page(request: Request):
     """Serve the monitor management page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/monitor.html")
-    return FileResponse(BASE_DIR / "static" / "monitor.html")
+    return serve_protected_html(request, "monitor.html", ROLE_ADMIN)
 
 
 @app.get("/logs-partial.html")
@@ -1539,23 +1695,20 @@ def read_logs_partial(request: Request):
 @app.get("/comprehensive-logs.html")
 def read_comprehensive_logs(request: Request):
     """Serve the comprehensive logs page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/comprehensive-logs.html")
-    return FileResponse(BASE_DIR / "static" / "comprehensive-logs.html")
+    return serve_protected_html(request, "comprehensive-logs.html", ROLE_ADMIN)
 
 
 @app.get("/dumpert.html")
 def read_dumpert_page(request: Request):
     """Serve the Dumpert Top Loader page."""
-    if not is_authenticated(request):
-        return RedirectResponse(url="/static/login.html?next=/dumpert.html")
-    return FileResponse(BASE_DIR / "static" / "dumpert.html")
+    return serve_protected_html(request, "dumpert.html", ROLE_ADMIN)
 
 
 @app.get("/api/dumpert/toppers/{page}")
 async def dumpert_toppers_proxy(
     page: int,
     request: Request,
+    dep: None = Depends(admin_dependency),
     nsfw: Optional[str] = Query(None, pattern=r"^[01]$"),
 ):
     """Proxy the Dumpert toppers API to work around CORS restrictions.
@@ -1664,6 +1817,7 @@ def _build_dumpert_stream_plan(item: Dict[str, Any]) -> Dict[str, Any]:
 @app.get("/api/dumpert/bootstrap")
 async def dumpert_bootstrap(
     request: Request,
+    dep: None = Depends(admin_dependency),
     page: int = Query(0, ge=0, le=10),
     nsfw: Optional[str] = Query(None, pattern=r"^[01]$"),
     item_id: Optional[str] = Query(None, min_length=3),
@@ -2444,7 +2598,7 @@ class MonitorToggleRequest(BaseModel):
 
 
 @app.delete("/nickname")
-def delete_device_nickname(entry: DeviceDeletionEntry, dep: None = Depends(password_dependency)):
+def delete_device_nickname(entry: DeviceDeletionEntry, dep: None = Depends(admin_dependency)):
     """Delete a device nickname/registration."""
     try:
         db_manager.delete_device_nickname(entry.device_id)
@@ -2455,7 +2609,7 @@ def delete_device_nickname(entry: DeviceDeletionEntry, dep: None = Depends(passw
 
 
 @app.delete("/device_data")
-def delete_device_data(entry: DeviceDeletionEntry, dep: None = Depends(password_dependency)):
+def delete_device_data(entry: DeviceDeletionEntry, dep: None = Depends(admin_dependency)):
     """Delete device data including bike_data and source_data records."""
     try:
         deleted_counts = db_manager.delete_device_data(entry.device_id, entry.delete_data)
@@ -2878,7 +3032,7 @@ async def download_video(entry: VideoDownloadRequest):
 
 
 @app.get("/debuglog")
-def get_debuglog(dep: None = Depends(password_dependency)):
+def get_debuglog(dep: None = Depends(admin_dependency)):
     """Get in-memory debug log for compatibility."""
     return {"log": DEBUG_LOG}
 
@@ -2888,7 +3042,8 @@ def get_enhanced_debuglog(
     level: Optional[str] = Query(None, description="Minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"),
     category: Optional[str] = Query(None, description="Log category filter"),
     device_id: Optional[str] = Query(None, description="Device ID filter"),
-    limit: Optional[int] = Query(100, description="Maximum number of logs to return")
+    limit: Optional[int] = Query(100, description="Maximum number of logs to return"),
+    dep: None = Depends(admin_dependency),
 ):
     """Get enhanced debug logs with filtering capabilities."""
     try:
@@ -3368,7 +3523,7 @@ def get_manage_debug_logs(
     category_filter: Optional[str] = Query(None, description="Log category filter"),
     device_id_filter: Optional[str] = Query(None, description="Device ID filter"),
     limit: Optional[int] = Query(100, description="Maximum number of logs to return"),
-    dep: None = Depends(password_dependency)
+    dep: None = Depends(admin_dependency)
 ):
     """Get debug logs from database with filtering - requires authentication."""
     try:
@@ -3422,7 +3577,7 @@ def get_manage_debug_logs(
 
 
 @app.post("/manage/repair_database")
-def repair_database(dep: None = Depends(password_dependency)):
+def repair_database(dep: None = Depends(admin_dependency)):
     """Repair database integrity issues - requires authentication."""
     try:
         log_debug("Starting manual database repair")
@@ -3457,7 +3612,7 @@ def repair_database(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/tables")
-def manage_tables(dep: None = Depends(password_dependency)):
+def manage_tables(dep: None = Depends(admin_dependency)):
     """Return table contents for management page."""
     try:
         names = db_manager.execute_query("SELECT name FROM sys.tables")
@@ -3476,7 +3631,7 @@ def manage_tables(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/table_rows")
-def get_table_rows(table: str, dep: None = Depends(password_dependency)):
+def get_table_rows(table: str, dep: None = Depends(admin_dependency)):
     """Return all rows from the specified table."""
     name_re = re.compile(r"^[A-Za-z0-9_]+$")
     if not name_re.match(table):
@@ -3491,7 +3646,7 @@ def get_table_rows(table: str, dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/table_range")
-def get_table_range(table: str, dep: None = Depends(password_dependency)):
+def get_table_range(table: str, dep: None = Depends(admin_dependency)):
     """Return min and max timestamp for a table."""
     name_re = re.compile(r"^[A-Za-z0-9_]+$")
     if not name_re.match(table):
@@ -3520,7 +3675,7 @@ class TestdataRequest(BaseModel):
 
 
 @app.post("/manage/insert_testdata")
-def insert_testdata(req: TestdataRequest, dep: None = Depends(password_dependency)):
+def insert_testdata(req: TestdataRequest, dep: None = Depends(admin_dependency)):
     """Insert a simple test record into a table."""
     try:
         if req.table == TABLE_BIKE_DATA:
@@ -3552,7 +3707,7 @@ def insert_testdata(req: TestdataRequest, dep: None = Depends(password_dependenc
 
 
 @app.post("/manage/test_table")
-def test_table(req: TestdataRequest, dep: None = Depends(password_dependency)):
+def test_table(req: TestdataRequest, dep: None = Depends(admin_dependency)):
     """Insert, read and delete two test rows for a table."""
     try:
         rows = db_manager.test_table_operations(req.table)
@@ -3566,7 +3721,7 @@ def test_table(req: TestdataRequest, dep: None = Depends(password_dependency)):
 
 
 @app.delete("/manage/delete_all")
-def delete_all(table: str, dep: None = Depends(password_dependency)):
+def delete_all(table: str, dep: None = Depends(admin_dependency)):
     """Delete all rows from the specified table."""
     if table not in (TABLE_BIKE_DATA, TABLE_DEBUG_LOG, TABLE_DEVICE_NICKNAMES):
         raise HTTPException(status_code=400, detail="Unknown table")
@@ -3584,7 +3739,7 @@ class BackupRequest(BaseModel):
 
 
 @app.post("/manage/backup_table")
-def backup_table(req: BackupRequest, dep: None = Depends(password_dependency)):
+def backup_table(req: BackupRequest, dep: None = Depends(admin_dependency)):
     """Create a backup copy of the given table."""
     name_re = re.compile(r"^[A-Za-z0-9_]+$")
     if not name_re.match(req.table):
@@ -3607,7 +3762,7 @@ class RenameRequest(BaseModel):
 
 
 @app.post("/manage/rename_table")
-def rename_table(req: RenameRequest, dep: None = Depends(password_dependency)):
+def rename_table(req: RenameRequest, dep: None = Depends(admin_dependency)):
     """Rename a table."""
     name_re = re.compile(r"^[A-Za-z0-9_]+$")
     if not name_re.match(req.old_name) or not name_re.match(req.new_name):
@@ -3655,7 +3810,7 @@ class SetSkuRequest(BaseModel):
 
 
 @app.get("/manage/record")
-def get_record(record_id: int, dep: None = Depends(password_dependency)):
+def get_record(record_id: int, dep: None = Depends(admin_dependency)):
     """Return a single RCI_bike_data record by id."""
     try:
         result = db_manager.execute_query(
@@ -3675,7 +3830,7 @@ def get_record(record_id: int, dep: None = Depends(password_dependency)):
 
 
 @app.put("/manage/update_record")
-def update_record(update: RecordUpdate, dep: None = Depends(password_dependency)):
+def update_record(update: RecordUpdate, dep: None = Depends(admin_dependency)):
     """Update fields of a RCI_bike_data row."""
     fields = []
     params = []
@@ -3714,7 +3869,7 @@ def update_record(update: RecordUpdate, dep: None = Depends(password_dependency)
 
 
 @app.delete("/manage/delete_record")
-def delete_record(record_id: int, dep: None = Depends(password_dependency)):
+def delete_record(record_id: int, dep: None = Depends(admin_dependency)):
     """Delete a RCI_bike_data row by id."""
     try:
         affected_rows = db_manager.execute_non_query(
@@ -3734,7 +3889,7 @@ def delete_record(record_id: int, dep: None = Depends(password_dependency)):
 
 
 @app.post("/manage/merge_device_ids")
-def merge_device_ids(req: MergeDeviceRequest, dep: None = Depends(password_dependency)):
+def merge_device_ids(req: MergeDeviceRequest, dep: None = Depends(admin_dependency)):
     """Merge records from old device id into new id."""
     if req.old_id == req.new_id:
         raise HTTPException(status_code=400, detail="IDs must be different")
@@ -3789,7 +3944,7 @@ def get_filtered_records(
     ids: Optional[List[int]] = Query(None),
     start_id: Optional[int] = Query(None),
     end_id: Optional[int] = Query(None),
-    dep: None = Depends(password_dependency),
+    dep: None = Depends(admin_dependency),
 ):
     """Return RCI_bike_data rows filtered by id, device and time."""
     try:
@@ -3834,7 +3989,7 @@ def delete_filtered_records(
     ids: Optional[List[int]] = Query(None),
     start_id: Optional[int] = Query(None),
     end_id: Optional[int] = Query(None),
-    dep: None = Depends(password_dependency),
+    dep: None = Depends(admin_dependency),
 ):
     """Delete RCI_bike_data rows matching the given filters."""
     try:
@@ -3872,7 +4027,7 @@ def delete_filtered_records(
 
 
 @app.get("/manage/db_size")
-def get_db_size(dep: None = Depends(password_dependency)):
+def get_db_size(dep: None = Depends(admin_dependency)):
     """Return current database size and max size in GB."""
     try:
         size_mb, max_gb = db_manager.get_database_size()
@@ -3884,7 +4039,7 @@ def get_db_size(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/db_sku")
-def get_db_sku(dep: None = Depends(password_dependency)):
+def get_db_sku(dep: None = Depends(admin_dependency)):
     """Return current DB SKU and available options."""
     client = get_sql_client()
     group = os.getenv("AZURE_RESOURCE_GROUP")
@@ -3909,7 +4064,7 @@ def get_db_sku(dep: None = Depends(password_dependency)):
 
 
 @app.post("/manage/set_db_sku")
-def set_db_sku(req: SetSkuRequest, dep: None = Depends(password_dependency)):
+def set_db_sku(req: SetSkuRequest, dep: None = Depends(admin_dependency)):
     """Change the database SKU."""
     client = get_sql_client()
     group = os.getenv("AZURE_RESOURCE_GROUP")
@@ -3932,7 +4087,7 @@ def set_db_sku(req: SetSkuRequest, dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/app_plan")
-def get_app_plan(dep: None = Depends(password_dependency)):
+def get_app_plan(dep: None = Depends(admin_dependency)):
     """Return info about the App Service plan if configured."""
     client = get_web_client()
     group = os.getenv("AZURE_RESOURCE_GROUP")
@@ -3952,7 +4107,7 @@ def get_app_plan(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/app_plan_skus")
-def get_app_plan_skus(dep: None = Depends(password_dependency)):
+def get_app_plan_skus(dep: None = Depends(admin_dependency)):
     """Return selectable SKUs for the current App Service plan."""
     client = get_web_client()
     group = os.getenv("AZURE_RESOURCE_GROUP")
@@ -3974,7 +4129,7 @@ def get_app_plan_skus(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/table_summary")
-def get_table_summary(dep: None = Depends(password_dependency)):
+def get_table_summary(dep: None = Depends(admin_dependency)):
     """Return record count and last update for all tables."""
     try:
         tables = db_manager.get_table_summary()
@@ -3986,7 +4141,7 @@ def get_table_summary(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/last_rows")
-def get_last_rows(table: str, limit: int = Query(10, ge=1, le=100), dep: None = Depends(password_dependency)):
+def get_last_rows(table: str, limit: int = Query(10, ge=1, le=100), dep: None = Depends(admin_dependency)):
     """Return the latest rows from a table."""
     try:
         rows = db_manager.get_last_table_rows(table, limit)
@@ -4006,7 +4161,7 @@ class LogConfigRequest(BaseModel):
 
 
 @app.post("/manage/log_config")
-def set_log_config(config: LogConfigRequest, dep: None = Depends(password_dependency)):
+def set_log_config(config: LogConfigRequest, dep: None = Depends(admin_dependency)):
     """Set logging configuration."""
     try:
         # Set log level
@@ -4033,7 +4188,7 @@ def set_log_config(config: LogConfigRequest, dep: None = Depends(password_depend
 
 
 @app.get("/manage/log_config")
-def get_log_config(dep: None = Depends(password_dependency)):
+def get_log_config(dep: None = Depends(admin_dependency)):
     """Get current logging configuration."""
     try:
         return {
@@ -4048,7 +4203,7 @@ def get_log_config(dep: None = Depends(password_dependency)):
 
 
 @app.delete("/manage/debug_logs")
-def clear_debug_logs(dep: None = Depends(password_dependency)):
+def clear_debug_logs(dep: None = Depends(admin_dependency)):
     """Clear all debug logs from the database."""
     try:
         count = db_manager.execute_non_query(f"DELETE FROM {TABLE_DEBUG_LOG}")
@@ -4060,7 +4215,7 @@ def clear_debug_logs(dep: None = Depends(password_dependency)):
 
 
 @app.post("/manage/archive_logs")
-def archive_logs(dep: None = Depends(password_dependency)):
+def archive_logs(dep: None = Depends(admin_dependency)):
     """Archive all current logs to the archive table and clear the main logs table."""
     try:
         result = db_manager.archive_logs()
@@ -4072,7 +4227,7 @@ def archive_logs(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/table_schema")
-def get_table_schema(table: str, dep: None = Depends(password_dependency)):
+def get_table_schema(table: str, dep: None = Depends(admin_dependency)):
     """Get detailed schema information for a table."""
     try:
         schema = db_manager.get_table_schema(table)
@@ -4087,7 +4242,7 @@ def get_table_schema(table: str, dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/verify_tables")
-def verify_tables(dep: None = Depends(password_dependency)):
+def verify_tables(dep: None = Depends(admin_dependency)):
     """Verify table integrity and structure."""
     try:
         result = db_manager.verify_tables()
@@ -4099,7 +4254,7 @@ def verify_tables(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/verify_data")
-def verify_data(dep: None = Depends(password_dependency)):
+def verify_data(dep: None = Depends(admin_dependency)):
     """Verify data consistency and integrity."""
     try:
         result = db_manager.verify_data()
@@ -4111,7 +4266,7 @@ def verify_data(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/verify_indexes")
-def verify_indexes(dep: None = Depends(password_dependency)):
+def verify_indexes(dep: None = Depends(admin_dependency)):
     """Verify database indexes and performance."""
     try:
         result = db_manager.verify_indexes()
@@ -4123,7 +4278,7 @@ def verify_indexes(dep: None = Depends(password_dependency)):
 
 
 @app.get("/manage/verify_constraints")
-def verify_constraints(dep: None = Depends(password_dependency)):
+def verify_constraints(dep: None = Depends(admin_dependency)):
     """Verify foreign key constraints and referential integrity."""
     try:
         result = db_manager.verify_constraints()
@@ -4143,13 +4298,13 @@ class ThresholdSettings(BaseModel):
 
 
 @app.get("/api/thresholds")
-def get_thresholds(dep: None = Depends(password_dependency)):
+def get_thresholds(dep: None = Depends(admin_dependency)):
     """Get current threshold settings."""
     return current_thresholds
 
 
 @app.post("/api/thresholds")
-def set_thresholds(settings: ThresholdSettings, dep: None = Depends(password_dependency)):
+def set_thresholds(settings: ThresholdSettings, dep: None = Depends(admin_dependency)):
     """Update threshold settings."""
     # Validate frequency range
     if settings.freq_min >= settings.freq_max:
@@ -4169,7 +4324,7 @@ def set_thresholds(settings: ThresholdSettings, dep: None = Depends(password_dep
 
 
 @app.get("/api/monitors/metadata")
-def get_monitor_metadata(dep: None = Depends(password_dependency)):
+def get_monitor_metadata(dep: None = Depends(admin_dependency)):
     """Return metadata to initialize the monitor UI."""
     return {
         "status": "ok",
@@ -4183,7 +4338,7 @@ def get_monitor_metadata(dep: None = Depends(password_dependency)):
 def list_monitors(
     include_history: bool = Query(False, description="Include recent results"),
     history_limit: int = Query(20, ge=1, le=200, description="Number of historical records"),
-    dep: None = Depends(password_dependency),
+    dep: None = Depends(admin_dependency),
 ):
     """Return configured monitors."""
     try:
@@ -4238,7 +4393,7 @@ def _prepare_monitor_payload(request: MonitorRequest) -> Dict[str, Any]:
 
 
 @app.post("/api/monitors")
-def create_monitor_endpoint(request: MonitorRequest, dep: None = Depends(password_dependency)):
+def create_monitor_endpoint(request: MonitorRequest, dep: None = Depends(admin_dependency)):
     payload = _prepare_monitor_payload(request)
 
     try:
@@ -4255,7 +4410,7 @@ def create_monitor_endpoint(request: MonitorRequest, dep: None = Depends(passwor
 def update_monitor_endpoint(
     monitor_id: int,
     request: MonitorRequest,
-    dep: None = Depends(password_dependency),
+    dep: None = Depends(admin_dependency),
 ):
     payload = _prepare_monitor_payload(request)
 
@@ -4275,7 +4430,7 @@ def update_monitor_endpoint(
 def toggle_monitor_endpoint(
     monitor_id: int,
     request: MonitorToggleRequest,
-    dep: None = Depends(password_dependency),
+    dep: None = Depends(admin_dependency),
 ):
     try:
         monitor = db_manager.set_monitor_enabled(monitor_id, request.is_enabled)
@@ -4290,7 +4445,7 @@ def toggle_monitor_endpoint(
 
 
 @app.delete("/api/monitors/{monitor_id}")
-def delete_monitor_endpoint(monitor_id: int, dep: None = Depends(password_dependency)):
+def delete_monitor_endpoint(monitor_id: int, dep: None = Depends(admin_dependency)):
     try:
         deleted = db_manager.delete_monitor(monitor_id)
         if not deleted:
@@ -4304,7 +4459,7 @@ def delete_monitor_endpoint(monitor_id: int, dep: None = Depends(password_depend
 
 
 @app.get("/api/monitors/{monitor_id}")
-def get_monitor_endpoint(monitor_id: int, dep: None = Depends(password_dependency)):
+def get_monitor_endpoint(monitor_id: int, dep: None = Depends(admin_dependency)):
     try:
         monitor = db_manager.get_monitor(monitor_id)
         if monitor is None:
@@ -4321,7 +4476,7 @@ def get_monitor_endpoint(monitor_id: int, dep: None = Depends(password_dependenc
 def get_monitor_logs(
     monitor_id: int,
     limit: int = Query(100, ge=1, le=500),
-    dep: None = Depends(password_dependency),
+    dep: None = Depends(admin_dependency),
 ):
     try:
         monitor = db_manager.get_monitor(monitor_id)
@@ -4341,7 +4496,7 @@ def get_monitor_logs(
 
 
 @app.get("/api/monitors/{monitor_id}/history")
-def get_monitor_history(monitor_id: int, dep: None = Depends(password_dependency)):
+def get_monitor_history(monitor_id: int, dep: None = Depends(admin_dependency)):
     try:
         monitor = db_manager.get_monitor(monitor_id)
         if monitor is None:
@@ -4360,7 +4515,7 @@ def get_monitor_history(monitor_id: int, dep: None = Depends(password_dependency
 
 
 @app.post("/api/monitors/{monitor_id}/run")
-def run_monitor_now(monitor_id: int, dep: None = Depends(password_dependency)):
+def run_monitor_now(monitor_id: int, dep: None = Depends(admin_dependency)):
     try:
         monitor = db_manager.get_monitor(monitor_id)
         if monitor is None:
@@ -4603,7 +4758,7 @@ def get_shared_object(shared_id: int):
 
 
 @app.put("/api/shared/{shared_id}/note")
-def update_shared_object_note(shared_id: int, request: SharedObjectNoteUpdate, dep: None = Depends(password_dependency)):
+def update_shared_object_note(shared_id: int, request: SharedObjectNoteUpdate, dep: None = Depends(admin_dependency)):
     """Update the note for a shared object."""
     try:
         # Check if object exists
@@ -4622,7 +4777,7 @@ def update_shared_object_note(shared_id: int, request: SharedObjectNoteUpdate, d
 
 
 @app.delete("/api/shared/{shared_id}")
-def delete_shared_object(shared_id: int, dep: None = Depends(password_dependency)):
+def delete_shared_object(shared_id: int, dep: None = Depends(admin_dependency)):
     """Delete a shared object."""
     try:
         # Check if object exists
@@ -4643,6 +4798,7 @@ def delete_shared_object(shared_id: int, dep: None = Depends(password_dependency
 # Memo management endpoints
 @app.post("/api/memos/transcribe")
 async def transcribe_memo(
+    dep: None = Depends(admin_dependency),
     media: Optional[UploadFile] = File(
         None, description="Audio- of videobestand voor transcriptie"
     ),
@@ -4720,7 +4876,7 @@ async def transcribe_memo(
 
 
 @app.post("/api/memos")
-def create_memo(request: MemoCreateRequest):
+def create_memo(request: MemoCreateRequest, dep: None = Depends(admin_dependency)):
     """Create a new memo entry."""
     content = request.content.strip()
     if not content:
@@ -4735,7 +4891,10 @@ def create_memo(request: MemoCreateRequest):
 
 
 @app.get("/api/memos")
-def list_memos(limit: Optional[int] = Query(None, ge=1, le=200, description="Maximum number of memos")):
+def list_memos(
+    limit: Optional[int] = Query(None, ge=1, le=200, description="Maximum number of memos"),
+    dep: None = Depends(admin_dependency),
+):
     """Return stored memos in reverse chronological order."""
     try:
         memos = db_manager.get_memos(limit)
@@ -4746,7 +4905,7 @@ def list_memos(limit: Optional[int] = Query(None, ge=1, le=200, description="Max
 
 
 @app.put("/api/memos/{memo_id}")
-def update_memo(memo_id: int, request: MemoUpdateRequest):
+def update_memo(memo_id: int, request: MemoUpdateRequest, dep: None = Depends(admin_dependency)):
     """Update an existing memo."""
     content = request.content.strip()
     if not content:
@@ -4765,7 +4924,7 @@ def update_memo(memo_id: int, request: MemoUpdateRequest):
 
 
 @app.delete("/api/memos/{memo_id}")
-def delete_memo(memo_id: int):
+def delete_memo(memo_id: int, dep: None = Depends(admin_dependency)):
     """Archive an existing memo instead of deleting it permanently."""
     try:
         archived = db_manager.archive_memo(memo_id)
@@ -4782,4 +4941,4 @@ def delete_memo(memo_id: int):
 @app.get("/shared.html")
 def read_shared(request: Request):
     """Serve the shared objects page."""
-    return FileResponse(BASE_DIR / "static" / "shared.html")
+    return serve_protected_html(request, "shared.html")

--- a/static/database.html
+++ b/static/database.html
@@ -931,17 +931,10 @@ function viewDeviceData(deviceId) {
 }
 
 async function authFetch(url, options) {
-    let res = await fetch(url, options);
-    if (res.status === 401) {
-        const pw = prompt('Password:');
-        if (!pw) throw new Error('Password required');
-        const loginRes = await fetch('/login', {
-            method: 'POST',
-            headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({password: pw})
-        });
-        if (!loginRes.ok) throw new Error('Login failed');
-        res = await fetch(url, options);
+    const res = await fetch(url, options);
+    if (res.status === 401 || res.status === 403) {
+        window.location.href = '/static/login.html?next=' + encodeURIComponent(window.location.pathname);
+        throw new Error('Authentication required');
     }
     return res;
 }

--- a/static/device.html
+++ b/static/device.html
@@ -1118,16 +1118,9 @@ window.addEventListener('beforeunload', () => {
 // Authentication wrapper function
 async function authFetch(url, options) {
     let res = await fetch(url, options);
-    if (res.status === 401) {
-        const pw = prompt('Password:');
-        if (!pw) throw new Error('Password required');
-        const loginRes = await fetch('/login', {
-            method: 'POST',
-            headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({password: pw})
-        });
-        if (!loginRes.ok) throw new Error('Login failed');
-        res = await fetch(url, options);
+    if (res.status === 401 || res.status === 403) {
+        window.location.href = '/static/login.html?next=' + encodeURIComponent(window.location.pathname);
+        throw new Error('Authentication required');
     }
     
     // Check for server errors

--- a/static/login.html
+++ b/static/login.html
@@ -1,136 +1,87 @@
-    <link rel="stylesheet" href="/static/site.css">
-    <script src="/static/utils.js"></script>
-</head>
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login</title>
+    <title>Login - Road Condition Indexer</title>
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <link rel="stylesheet" href="/static/site.css">
     <script src="/static/utils.js"></script>
     <style>
-        body { 
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-            margin: 0; 
+        body.auth-screen {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
             padding: 0;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
             display: flex;
             align-items: center;
             justify-content: center;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         }
-        
-        .login-container {
-            background: white;
+        .auth-card {
+            background: var(--rci-card-bg, #fff);
+            color: var(--rci-text, #1f2937);
+            width: min(92vw, 430px);
             padding: 2rem;
-            border-radius: 10px;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-            max-width: 400px;
-            width: 90%;
-            text-align: center;
+            border-radius: 14px;
+            box-shadow: 0 20px 45px rgba(0, 0, 0, 0.25);
         }
-        
-        .logo-title {
+        .auth-logo-title {
             display: flex;
             align-items: center;
             justify-content: center;
-            margin-bottom: 2rem;
-            color: #333;
-        }
-        
-        .logo-title img {
-            height: 3em;
-            margin-right: 0.5em;
-        }
-        
-        .logo-title h1 {
-            margin: 0;
-            font-size: 1.8rem;
-            font-weight: 300;
-        }
-        
-        .login-form {
-            margin-top: 1.5rem;
-        }
-        
-        .login-form h2 {
-            color: #555;
+            gap: 0.75rem;
             margin-bottom: 1.5rem;
-            font-weight: 400;
+            text-align: center;
         }
-        
-        .form-group {
-            margin-bottom: 1.5rem;
-            text-align: left;
+        .auth-logo-title img { height: 3rem; }
+        .auth-logo-title h1 { margin: 0; font-size: 1.65rem; font-weight: 600; }
+        .auth-form h2 { margin: 0 0 0.75rem; text-align: center; }
+        .auth-helper {
+            margin: 0 0 1.25rem;
+            color: var(--rci-muted, #64748b);
+            font-size: 0.95rem;
+            line-height: 1.45;
+            text-align: center;
         }
-        
-        .form-group label {
-            display: block;
-            margin-bottom: 0.5rem;
-            color: #555;
-            font-weight: 500;
-        }
-        
+        .form-group { margin-bottom: 1rem; text-align: left; }
+        .form-group label { display: block; margin-bottom: 0.4rem; font-weight: 600; }
+        .form-group small { display: block; margin-top: 0.35rem; color: var(--rci-muted, #64748b); }
         .form-group input {
             width: 100%;
             padding: 0.75rem;
-            border: 2px solid #e1e5e9;
-            border-radius: 5px;
+            border: 2px solid #d8dee9;
+            border-radius: 8px;
             font-size: 1rem;
-            transition: border-color 0.3s ease;
             box-sizing: border-box;
         }
-        
         .form-group input:focus {
             outline: none;
             border-color: #667eea;
-            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
         }
-        
-        .login-button {
+        .btn-auth-primary {
             width: 100%;
-            padding: 0.75rem;
+            padding: 0.85rem;
+            margin-top: 0.5rem;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            border: none;
-            border-radius: 5px;
+            color: #fff;
+            border: 0;
+            border-radius: 8px;
             font-size: 1rem;
-            font-weight: 500;
+            font-weight: 700;
             cursor: pointer;
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
-        
-        .login-button:hover:not(:disabled) {
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
-        }
-        
-        .login-button:disabled {
-            opacity: 0.7;
-            cursor: not-allowed;
-            transform: none;
-        }
-        
-        .error-message {
-            color: #e74c3c;
+        .btn-auth-primary:disabled { opacity: 0.7; cursor: not-allowed; }
+        .auth-message {
+            display: none;
             margin-top: 1rem;
             padding: 0.75rem;
-            background: #ffeaea;
-            border: 1px solid #f5c6cb;
-            border-radius: 5px;
-            display: none;
+            border-radius: 8px;
+            line-height: 1.4;
         }
-        
-        .success-message {
-            color: #27ae60;
-            margin-top: 1rem;
-            padding: 0.75rem;
-            background: #eafaf1;
-            border: 1px solid #c3e6cb;
-            border-radius: 5px;
-            display: none;
-        }
+        .auth-message.error { color: #991b1b; background: #fee2e2; border: 1px solid #fecaca; }
+        .auth-message.success { color: #166534; background: #dcfce7; border: 1px solid #bbf7d0; }
     </style>
 </head>
 <body class="auth-screen" data-page="login">
@@ -142,9 +93,19 @@
     </div>
     <form id="login-form" class="auth-form" onsubmit="event.preventDefault(); doLogin();" novalidate>
         <h2>Sign In</h2>
+        <p class="auth-helper">Sign in as <strong>Fiets</strong> (User) or <strong>Techno</strong> (Admin). First-time users leave the current password blank and choose a new password.</p>
         <div class="form-group">
-            <label for="pw">Password</label>
-            <input type="password" id="pw" autocomplete="current-password" required aria-required="true" />
+            <label for="username">Username</label>
+            <input type="text" id="username" autocomplete="username" required aria-required="true">
+        </div>
+        <div class="form-group">
+            <label for="pw">Current password</label>
+            <input type="password" id="pw" autocomplete="current-password" aria-describedby="first-login-help">
+            <small id="first-login-help">Leave blank only when setting your initial password.</small>
+        </div>
+        <div class="form-group">
+            <label for="new-pw">New password for first sign-in</label>
+            <input type="password" id="new-pw" autocomplete="new-password">
         </div>
         <button type="submit" class="btn-auth-primary" id="login-submit">Sign In</button>
         <div id="error-message" class="auth-message error" aria-live="polite"></div>
@@ -155,84 +116,80 @@
 function showMessage(message, isError = false) {
     const errorDiv = document.getElementById('error-message');
     const successDiv = document.getElementById('success-message');
-    
-    // Hide both messages first
     errorDiv.style.display = 'none';
     successDiv.style.display = 'none';
-    
     if (isError) {
         errorDiv.textContent = message;
         errorDiv.style.display = 'block';
-    } else {
+    } else if (message) {
         successDiv.textContent = message;
         successDiv.style.display = 'block';
     }
 }
 
 async function doLogin() {
+    const username = document.getElementById('username').value.trim();
     const pw = document.getElementById('pw').value;
+    const newPw = document.getElementById('new-pw').value;
     const submitButton = document.getElementById('login-submit');
-    
-    // Hide any previous messages
-    document.getElementById('error-message').style.display = 'none';
-    document.getElementById('success-message').style.display = 'none';
-    
-    // Disable button and show loading state
+
+    if (!username) {
+        showMessage('Enter your username.', true);
+        document.getElementById('username').focus();
+        return;
+    }
+
     submitButton.disabled = true;
     submitButton.textContent = 'Signing in...';
-    
+    showMessage('', false);
+
     try {
+        const payload = { username, password: pw };
+        if (newPw) payload.new_password = newPw;
         const res = await fetch('/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password: pw })
+            body: JSON.stringify(payload)
         });
-        
+
         if (res.ok) {
             const params = new URLSearchParams(location.search);
             const next = params.get('next') || '/';
             showMessage('Login successful! Redirecting...', false);
-            
-            // Small delay to show success message
-            setTimeout(() => {
-                location.href = next;
-            }, 1000);
+            setTimeout(() => { location.href = next; }, 500);
         } else {
-            // Handle different error types
             let errorMessage = 'Login failed';
-            if (res.status === 401) {
-                errorMessage = 'Invalid password. Please try again.';
+            if (res.status === 409) {
+                errorMessage = 'This account has no password yet. Leave current password blank, enter a new password, and sign in again.';
+                document.getElementById('new-pw').focus();
+            } else if (res.status === 401) {
+                errorMessage = 'Invalid username or password.';
+                document.getElementById('pw').value = '';
+                document.getElementById('pw').focus();
+            } else if (res.status === 403) {
+                errorMessage = 'Your account cannot access the requested page.';
             } else if (res.status >= 500) {
                 errorMessage = 'Server error. Please try again later.';
             }
-            
             showMessage(errorMessage, true);
-            document.getElementById('pw').value = '';
-            document.getElementById('pw').focus();
         }
     } catch (error) {
-        // Handle network errors
         console.error('Login error:', error);
         showMessage('Network error. Please check your connection and try again.', true);
-        document.getElementById('pw').focus();
     } finally {
-        // Re-enable button
         submitButton.disabled = false;
-    submitButton.textContent = 'Sign In';
+        submitButton.textContent = 'Sign In';
     }
 }
 
-// Add Enter key support for password field
 document.addEventListener('DOMContentLoaded', () => {
-    const pwField = document.getElementById('pw');
-    pwField.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') {
-            doLogin();
-        }
+    const usernameField = document.getElementById('username');
+    ['username', 'pw', 'new-pw'].forEach((id) => {
+        document.getElementById(id).addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') doLogin();
+        });
     });
-    
-    // Focus on password field when page loads
-    pwField.focus();
+    usernameField.focus();
 });
 </script>
 </body>

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -638,16 +638,9 @@ function debounce(func, wait) {
 
 async function authFetch(url, options) {
     let res = await fetch(url, options);
-    if (res.status === 401) {
-        const pw = prompt('Password:');
-        if (!pw) throw new Error('Password required');
-        const loginRes = await fetch('/login', {
-            method: 'POST',
-            headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({password: pw})
-        });
-        if (!loginRes.ok) throw new Error('Login failed');
-        res = await fetch(url, options);
+    if (res.status === 401 || res.status === 403) {
+        window.location.href = '/static/login.html?next=' + encodeURIComponent(window.location.pathname);
+        throw new Error('Authentication required');
     }
     return res;
 }
@@ -938,11 +931,11 @@ document.getElementById('fastapi-test-btn').addEventListener('click', async func
     resultDiv.textContent = '';
     try {
         // Use a simple endpoint for health check, e.g. /auth_check or /logs
-        const response = await fetch('/auth_check');
+        const response = await fetch('/auth_check?role=Admin');
         if (response.status === 204) {
             resultDiv.textContent = '✅ FastAPI server is running and responded with 204 (No Content)';
             resultDiv.style.color = '#2e7d32';
-        } else if (response.status === 401) {
+        } else if (response.status === 401 || response.status === 403) {
             resultDiv.textContent = '⚠️ FastAPI server is running but authentication is required (401)';
             resultDiv.style.color = '#f57c00';
         } else {

--- a/static/utils.js
+++ b/static/utils.js
@@ -439,9 +439,9 @@ async function authFetch(url, options = {}) {
         credentials: 'include'
     });
     
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
         const currentUrl = encodeURIComponent(window.location.href);
-        window.location.href = `/login.html?next=${currentUrl}`;
+        window.location.href = `/static/login.html?next=${currentUrl}`;
         return;
     }
     

--- a/tests/core/test_dumpert_bootstrap.py
+++ b/tests/core/test_dumpert_bootstrap.py
@@ -43,7 +43,7 @@ class _FakeResponse:
 
 def test_bootstrap_returns_first_item_and_stream_candidates(monkeypatch):
     main = _load_main(monkeypatch)
-    monkeypatch.setattr(main, "is_authenticated", lambda _request: True)
+    main.app.dependency_overrides[main.admin_dependency] = lambda: None
 
     upstream_payload = {
         "items": [
@@ -78,7 +78,7 @@ def test_bootstrap_returns_first_item_and_stream_candidates(monkeypatch):
 
 def test_bootstrap_detects_ad_signals(monkeypatch):
     main = _load_main(monkeypatch)
-    monkeypatch.setattr(main, "is_authenticated", lambda _request: True)
+    main.app.dependency_overrides[main.admin_dependency] = lambda: None
 
     upstream_payload = {
         "items": [

--- a/tests/core/test_user_auth.py
+++ b/tests/core/test_user_auth.py
@@ -1,0 +1,81 @@
+"""User-management authentication tests."""
+
+import importlib
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+REQUIRED_VARS = {
+    "AZURE_SQL_SERVER": "stub.server.local",
+    "AZURE_SQL_PORT": "1433",
+    "AZURE_SQL_USER": "test",
+    "AZURE_SQL_PASSWORD": "secret",
+    "AZURE_SQL_DATABASE": "testdb",
+}
+
+for key, value in REQUIRED_VARS.items():
+    os.environ.setdefault(key, value)
+
+
+class FakeUserStore:
+    def __init__(self, main):
+        self.main = main
+        self.users = {
+            "fiets": {"id": 1, "username": "Fiets", "role": main.ROLE_USER, "password_hash": None},
+            "techno": {"id": 2, "username": "Techno", "role": main.ROLE_ADMIN, "password_hash": None},
+        }
+
+    def get_user_by_username(self, username):
+        user = self.users.get(username.lower())
+        return dict(user) if user else None
+
+    def set_user_password_hash(self, user_id, password_hash):
+        for user in self.users.values():
+            if user["id"] == user_id:
+                user["password_hash"] = password_hash
+                return
+
+    def record_user_login(self, user_id):
+        return None
+
+
+def load_main(monkeypatch):
+    main = importlib.import_module("main")
+    fake_store = FakeUserStore(main)
+    monkeypatch.setattr(main, "db_manager", fake_store)
+    return main, fake_store
+
+
+def test_initial_user_sets_password_and_accesses_main_page(monkeypatch):
+    main, store = load_main(monkeypatch)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/login",
+        json={"username": "Fiets", "password": "", "new_password": "fiets-secret"},
+    )
+
+    assert response.status_code == 204
+    assert store.users["fiets"]["password_hash"].startswith("pbkdf2_sha256$")
+    assert client.get("/auth_check").status_code == 204
+
+
+def test_user_cannot_access_admin_role(monkeypatch):
+    main, _store = load_main(monkeypatch)
+    client = TestClient(main.app)
+    client.post("/login", json={"username": "Fiets", "password": "", "new_password": "fiets-secret"})
+
+    response = client.get("/auth_check?role=Admin")
+
+    assert response.status_code == 403
+
+
+def test_admin_can_access_admin_role(monkeypatch):
+    main, _store = load_main(monkeypatch)
+    client = TestClient(main.app)
+    client.post("/login", json={"username": "Techno", "password": "", "new_password": "techno-secret"})
+
+    response = client.get("/auth_check?role=Admin")
+
+    assert response.status_code == 204


### PR DESCRIPTION
### Motivation
- Introduce proper user management so the app can distinguish regular users from administrators and enforce access to maintenance pages and APIs.
- Replace the single shared password with per-user credentials that can be set on first sign-in for better security and auditability.

### Description
- Database: add `RCI_users` table and ensure it is created/altered at startup with seeded users `Fiets` (role `User`) and `Techno` (role `Admin`), and add helpers `get_user_by_username`, `set_user_password_hash`, `record_user_login`, and `get_user_by_id` to `DatabaseManager`.
- Authentication: remove the single MD5 shared password and implement per-user PBKDF2-HMAC-SHA256 password hashing with per-password salt, plus first-login password setup semantics; introduce signed, time-limited session tokens stored in a cookie and helper functions to create/validate them.
- Authorization: add `ROLE_USER` / `ROLE_ADMIN`, `password_dependency` and `admin_dependency` helpers, protect main app pages for authenticated users and restrict maintenance pages and many management/monitoring APIs to Admins, and enforce authorization for direct `/static/*.html` requests via `RoleProtectedStaticFiles` and `serve_protected_html`.
- UI & client: update `static/login.html` to collect `username`, `current password`, and optional `new_password` for first-login setup, and update client auth wrappers in `static/utils.js`, `static/database.html`, `static/device.html`, and `static/maintenance.html` to redirect on 401/403 instead of prompting for the removed shared password.
- Tests: add `tests/core/test_user_auth.py` to cover first-login password setup and role checks, and update Dumpert bootstrap tests to bypass admin dependency during testing.

### Testing
- Compiled modules to assert syntax: `python -m py_compile main.py database.py` (succeeded).
- Ran unit tests: `pytest -q` (includes new `tests/core/test_user_auth.py` and core suite), result: all tests passed (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda306e6c88320811db4017c1eea9e)