### PR TITLE
Add maintenance user management

### DIFF
--- a/database.py
+++ b/database.py
@@ -1534,6 +1534,62 @@ class DatabaseManager:
             {"user_id": user_id},
         )
 
+    def list_users(self) -> List[Dict[str, Any]]:
+        """Return users for the maintenance user-management screen."""
+        return self.execute_query(
+            f"""
+            SELECT id, username, role,
+                   CASE WHEN password_hash IS NULL OR password_hash = '' THEN CAST(0 AS bit) ELSE CAST(1 AS bit) END AS password_set,
+                   created_at, updated_at, last_login_at
+            FROM {TABLE_USERS}
+            ORDER BY username
+            """
+        )
+
+    def create_user(self, username: str, role: str, password_hash: Optional[str] = None) -> Dict[str, Any]:
+        """Create a user and return the saved record."""
+        self.execute_non_query(
+            f"""
+            INSERT INTO {TABLE_USERS} (username, role, password_hash)
+            VALUES (:username, :role, :password_hash)
+            """,
+            {"username": username, "role": role, "password_hash": password_hash},
+        )
+        created = self.get_user_by_username(username)
+        if created is None:
+            raise RuntimeError("Created user could not be loaded")
+        return created
+
+    def update_user(self, user_id: int, username: str, role: str) -> Optional[Dict[str, Any]]:
+        """Update username and role for a user, returning the updated record when found."""
+        self.execute_non_query(
+            f"""
+            UPDATE {TABLE_USERS}
+            SET username = :username, role = :role, updated_at = SYSUTCDATETIME()
+            WHERE id = :user_id
+            """,
+            {"username": username, "role": role, "user_id": user_id},
+        )
+        return self.get_user_by_id(user_id)
+
+    def clear_user_password(self, user_id: int) -> None:
+        """Clear a user's password so they can set a new one during their next sign-in."""
+        self.execute_non_query(
+            f"""
+            UPDATE {TABLE_USERS}
+            SET password_hash = NULL, updated_at = SYSUTCDATETIME()
+            WHERE id = :user_id
+            """,
+            {"user_id": user_id},
+        )
+
+    def delete_user(self, user_id: int) -> None:
+        """Delete a user account."""
+        self.execute_non_query(
+            f"DELETE FROM {TABLE_USERS} WHERE id = :user_id",
+            {"user_id": user_id},
+        )
+
     def execute_query(self, query: str, params: Optional[Union[Tuple, Dict]] = None) -> List[Dict[str, Any]]:
         """Execute a query and return results as a list of dictionaries."""
         query_short = query[:100] + "..." if len(query) > 100 else query

--- a/main.py
+++ b/main.py
@@ -1531,6 +1531,153 @@ def get_me(request: Request):
     return require_role(request, ROLE_USER)
 
 
+class UserCreateRequest(BaseModel):
+    username: str = Field(..., min_length=1, max_length=100)
+    role: str = Field(ROLE_USER)
+    password: Optional[str] = Field(None, min_length=1)
+
+
+class UserUpdateRequest(BaseModel):
+    username: str = Field(..., min_length=1, max_length=100)
+    role: str = Field(ROLE_USER)
+
+
+class UserPasswordRequest(BaseModel):
+    password: Optional[str] = Field(None, min_length=1)
+
+
+def normalize_user_role(role: str) -> str:
+    """Return a canonical role value or reject unsupported roles."""
+    normalized = role.strip().lower()
+    if normalized == ROLE_USER.lower():
+        return ROLE_USER
+    if normalized == ROLE_ADMIN.lower():
+        return ROLE_ADMIN
+    raise HTTPException(status_code=400, detail="Role must be User or Admin")
+
+
+def sanitize_username(username: str) -> str:
+    """Validate and normalize a username supplied from user management."""
+    sanitized = username.strip()
+    if not sanitized:
+        raise HTTPException(status_code=400, detail="Username is required")
+    if len(sanitized) > 100:
+        raise HTTPException(status_code=400, detail="Username must be 100 characters or fewer")
+    return sanitized
+
+
+def public_user_record(user: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a user record safe for API responses."""
+    return {
+        "id": user.get("id"),
+        "username": user.get("username"),
+        "role": user.get("role"),
+        "password_set": bool(user.get("password_set") or user.get("password_hash")),
+        "created_at": user.get("created_at"),
+        "updated_at": user.get("updated_at"),
+        "last_login_at": user.get("last_login_at"),
+    }
+
+
+@app.get("/manage/users")
+def manage_list_users(dep: None = Depends(admin_dependency)):
+    """List application users for the maintenance page."""
+    try:
+        users = db_manager.list_users()
+        return {"users": [public_user_record(user) for user in users], "roles": [ROLE_USER, ROLE_ADMIN]}
+    except Exception as exc:
+        log_error(f"Failed to list users: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to list users") from exc
+
+
+@app.post("/manage/users", status_code=201)
+def manage_create_user(req: UserCreateRequest, dep: None = Depends(admin_dependency)):
+    """Create an application user."""
+    username = sanitize_username(req.username)
+    role = normalize_user_role(req.role)
+    password_hash = hash_password(req.password) if req.password else None
+    try:
+        existing = db_manager.get_user_by_username(username)
+        if existing:
+            raise HTTPException(status_code=409, detail="Username already exists")
+        user = db_manager.create_user(username, role, password_hash)
+        log_info(f"Created user '{username}' with role '{role}'", LogCategory.USER_ACTION)
+        return {"user": public_user_record(user)}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_error(f"Failed to create user '{username}': {exc}")
+        raise HTTPException(status_code=500, detail="Failed to create user") from exc
+
+
+@app.put("/manage/users/{user_id}")
+def manage_update_user(user_id: int, req: UserUpdateRequest, request: Request, dep: None = Depends(admin_dependency)):
+    """Update an application user's username or role."""
+    username = sanitize_username(req.username)
+    role = normalize_user_role(req.role)
+    current_user = require_role(request, ROLE_ADMIN)
+    try:
+        existing = db_manager.get_user_by_id(user_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="User not found")
+        duplicate = db_manager.get_user_by_username(username)
+        if duplicate and int(duplicate["id"]) != user_id:
+            raise HTTPException(status_code=409, detail="Username already exists")
+        if int(current_user["id"]) == user_id and existing.get("role") == ROLE_ADMIN and role != ROLE_ADMIN:
+            raise HTTPException(status_code=400, detail="You cannot remove your own Admin role")
+        user = db_manager.update_user(user_id, username, role)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        log_info(f"Updated user id {user_id} to '{username}' with role '{role}'", LogCategory.USER_ACTION)
+        return {"user": public_user_record(user)}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_error(f"Failed to update user id {user_id}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to update user") from exc
+
+
+@app.post("/manage/users/{user_id}/password")
+def manage_set_user_password(user_id: int, req: UserPasswordRequest, dep: None = Depends(admin_dependency)):
+    """Set or reset a user's password."""
+    try:
+        user = db_manager.get_user_by_id(user_id)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        if req.password:
+            db_manager.set_user_password_hash(user_id, hash_password(req.password))
+            message = "Password updated"
+        else:
+            db_manager.clear_user_password(user_id)
+            message = "Password reset; user must set a password on next sign-in"
+        log_info(f"Password state changed for user id {user_id}", LogCategory.USER_ACTION)
+        updated = db_manager.get_user_by_id(user_id) or user
+        return {"status": "ok", "message": message, "user": public_user_record(updated)}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_error(f"Failed to update password for user id {user_id}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to update password") from exc
+
+
+@app.delete("/manage/users/{user_id}")
+def manage_delete_user(user_id: int, request: Request, dep: None = Depends(admin_dependency)):
+    """Delete an application user."""
+    current_user = require_role(request, ROLE_ADMIN)
+    if int(current_user["id"]) == user_id:
+        raise HTTPException(status_code=400, detail="You cannot delete your own user account")
+    try:
+        existing = db_manager.get_user_by_id(user_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="User not found")
+        db_manager.delete_user(user_id)
+        log_warning(f"Deleted user '{existing.get('username')}' (id {user_id})", LogCategory.USER_ACTION)
+        return {"status": "ok"}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_error(f"Failed to delete user id {user_id}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to delete user") from exc
 
 
 def serve_protected_html(request: Request, filename: str, required_role: str = ROLE_USER):

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -233,6 +233,60 @@
             color: #fff !important;
             font-weight: bold;
         }
+
+        .user-management-grid {
+            display: grid;
+            grid-template-columns: minmax(260px, 360px) 1fr;
+            gap: 1rem;
+            align-items: start;
+        }
+        .user-management-form, .user-management-list {
+            background: white;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 1rem;
+        }
+        .user-management-form input, .user-management-form select {
+            width: 100%;
+            box-sizing: border-box;
+            padding: 0.45rem;
+            border: 1px solid #ccc;
+            border-radius: 3px;
+        }
+        .user-management-actions {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            margin-top: 0.75rem;
+        }
+        .user-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.95rem;
+        }
+        .user-table th, .user-table td {
+            border: 1px solid #e5e5e5;
+            padding: 0.5rem;
+            text-align: left;
+            vertical-align: top;
+        }
+        .user-table th { background: #f0f0f0; }
+        .user-table button { margin: 0 0.25rem 0.25rem 0; }
+        .role-badge, .password-badge {
+            display: inline-block;
+            border-radius: 999px;
+            padding: 0.15rem 0.55rem;
+            font-size: 0.8rem;
+            font-weight: bold;
+        }
+        .role-badge-admin { background: #fee2e2; color: #991b1b; }
+        .role-badge-user { background: #dbeafe; color: #1e40af; }
+        .password-badge-set { background: #dcfce7; color: #166534; }
+        .password-badge-empty { background: #fef3c7; color: #92400e; }
+        #user-management-message { margin-top: 0.75rem; min-height: 1.4rem; }
+        @media (max-width: 850px) {
+            .user-management-grid { grid-template-columns: 1fr; }
+        }
     </style>
 </head>
 <body>
@@ -275,6 +329,44 @@
         </article>
     </div>
 </section>
+
+<!-- User Management (collapsible section) -->
+<div class="section">
+    <div class="section-header" onclick="toggleSection('user-management')">
+        <span>👥 User Management</span>
+        <span class="section-toggle" id="user-management-toggle">▶</span>
+    </div>
+    <div class="section-content" id="user-management-content">
+        <p class="rci-muted">Create users, assign roles, reset passwords, and remove accounts. Empty passwords require users to set their password on their next sign-in.</p>
+        <div class="user-management-grid">
+            <form id="user-form" class="user-management-form" onsubmit="event.preventDefault(); saveUser();">
+                <h3 id="user-form-title">Create user</h3>
+                <input type="hidden" id="user-id">
+                <label for="user-username">Username</label>
+                <input type="text" id="user-username" maxlength="100" required>
+                <label for="user-role">Role</label>
+                <select id="user-role">
+                    <option value="User">User</option>
+                    <option value="Admin">Admin</option>
+                </select>
+                <label for="user-password">Password</label>
+                <input type="password" id="user-password" autocomplete="new-password" placeholder="Optional for new users">
+                <small>Leave blank when editing to keep the current password. Use “Clear password” to force first-sign-in setup.</small>
+                <div class="user-management-actions">
+                    <button type="submit" id="save-user-btn">Create User</button>
+                    <button type="button" onclick="resetUserForm()">Cancel</button>
+                </div>
+                <div id="user-management-message" aria-live="polite"></div>
+            </form>
+            <div class="user-management-list">
+                <div class="control-group">
+                    <button type="button" onclick="loadUsers()">Refresh Users</button>
+                </div>
+                <div id="user-list">Loading users...</div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- Database Log Viewer (collapsible section) -->
 <div class="section">
@@ -598,7 +690,7 @@ async function archiveLogs() {
 // Load logs on page load
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize all sections as collapsed by default
-    ['log-viewer', 'tables', 'fastapi-health'].forEach(sectionId => {
+    ['user-management', 'log-viewer', 'tables', 'fastapi-health'].forEach(sectionId => {
         const content = document.getElementById(sectionId + '-content');
         const toggle = document.getElementById(sectionId + '-toggle');
         if (content && toggle) {
@@ -608,6 +700,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     
     loadDatabaseLogs();
+    loadUsers();
     
     // Enable auto-refresh by default
     const autoRefreshBtn = document.getElementById('auto-refresh-btn');
@@ -643,6 +736,176 @@ async function authFetch(url, options) {
         throw new Error('Authentication required');
     }
     return res;
+}
+
+function formatUserDate(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return String(value);
+    return date.toLocaleString();
+}
+
+function setUserMessage(message, isError = false) {
+    const el = document.getElementById('user-management-message');
+    if (!el) return;
+    el.textContent = message || '';
+    el.style.color = isError ? '#b91c1c' : '#166534';
+}
+
+async function parseApiError(response) {
+    try {
+        const data = await response.json();
+        return data.detail || response.statusText;
+    } catch (_error) {
+        return response.statusText;
+    }
+}
+
+async function loadUsers() {
+    const container = document.getElementById('user-list');
+    if (!container) return;
+    container.textContent = 'Loading users...';
+    try {
+        const res = await authFetch('/manage/users');
+        if (!res.ok) throw new Error(await parseApiError(res));
+        const data = await res.json();
+        const users = data.users || [];
+        if (users.length === 0) {
+            container.textContent = 'No users found.';
+            return;
+        }
+        const table = document.createElement('table');
+        table.className = 'user-table';
+        const thead = document.createElement('thead');
+        thead.innerHTML = '<tr><th>Username</th><th>Role</th><th>Password</th><th>Last Login</th><th>Actions</th></tr>';
+        table.appendChild(thead);
+        const tbody = document.createElement('tbody');
+        users.forEach(user => {
+            const tr = document.createElement('tr');
+            const roleClass = user.role === 'Admin' ? 'role-badge-admin' : 'role-badge-user';
+            const passwordClass = user.password_set ? 'password-badge-set' : 'password-badge-empty';
+            const passwordText = user.password_set ? 'Set' : 'Needs setup';
+            tr.innerHTML = `
+                <td><strong>${escapeHtml(user.username)}</strong><br><small>ID ${user.id}</small></td>
+                <td><span class="role-badge ${roleClass}">${escapeHtml(user.role)}</span></td>
+                <td><span class="password-badge ${passwordClass}">${passwordText}</span></td>
+                <td>${escapeHtml(formatUserDate(user.last_login_at))}</td>
+                <td></td>
+            `;
+            const actions = tr.querySelector('td:last-child');
+            const editBtn = document.createElement('button');
+            editBtn.type = 'button';
+            editBtn.textContent = 'Edit';
+            editBtn.onclick = () => editUser(user);
+            actions.appendChild(editBtn);
+            const resetBtn = document.createElement('button');
+            resetBtn.type = 'button';
+            resetBtn.textContent = 'Clear password';
+            resetBtn.onclick = () => clearUserPassword(user.id, user.username);
+            actions.appendChild(resetBtn);
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.textContent = 'Delete';
+            deleteBtn.className = 'btn-red';
+            deleteBtn.onclick = () => deleteUser(user.id, user.username);
+            actions.appendChild(deleteBtn);
+            tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        container.innerHTML = '';
+        container.appendChild(table);
+    } catch (error) {
+        container.textContent = `Failed to load users: ${error.message}`;
+    }
+}
+
+function resetUserForm() {
+    document.getElementById('user-id').value = '';
+    document.getElementById('user-username').value = '';
+    document.getElementById('user-role').value = 'User';
+    document.getElementById('user-password').value = '';
+    document.getElementById('user-form-title').textContent = 'Create user';
+    document.getElementById('save-user-btn').textContent = 'Create User';
+    setUserMessage('');
+}
+
+function editUser(user) {
+    document.getElementById('user-id').value = user.id;
+    document.getElementById('user-username').value = user.username;
+    document.getElementById('user-role').value = user.role;
+    document.getElementById('user-password').value = '';
+    document.getElementById('user-form-title').textContent = `Edit ${user.username}`;
+    document.getElementById('save-user-btn').textContent = 'Save User';
+    setUserMessage('Leave password blank to keep the existing password.');
+    const content = document.getElementById('user-management-content');
+    const toggle = document.getElementById('user-management-toggle');
+    if (content && toggle && content.style.display !== 'block') {
+        content.style.display = 'block';
+        toggle.textContent = '▼';
+    }
+}
+
+async function saveUser() {
+    const id = document.getElementById('user-id').value;
+    const username = document.getElementById('user-username').value.trim();
+    const role = document.getElementById('user-role').value;
+    const password = document.getElementById('user-password').value;
+    const payload = { username, role };
+    if (!id && password) payload.password = password;
+    const btn = document.getElementById('save-user-btn');
+    btn.disabled = true;
+    try {
+        const res = await authFetch(id ? `/manage/users/${encodeURIComponent(id)}` : '/manage/users', {
+            method: id ? 'PUT' : 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(payload),
+        });
+        if (!res.ok) throw new Error(await parseApiError(res));
+        if (id && password) {
+            const passRes = await authFetch(`/manage/users/${encodeURIComponent(id)}/password`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({password}),
+            });
+            if (!passRes.ok) throw new Error(await parseApiError(passRes));
+        }
+        resetUserForm();
+        setUserMessage(id ? 'User updated.' : 'User created.');
+        await loadUsers();
+    } catch (error) {
+        setUserMessage(error.message, true);
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+async function clearUserPassword(id, username) {
+    if (!confirm(`Clear the password for ${username}? They will need to set a new password on next sign-in.`)) return;
+    try {
+        const res = await authFetch(`/manage/users/${encodeURIComponent(id)}/password`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({}),
+        });
+        if (!res.ok) throw new Error(await parseApiError(res));
+        setUserMessage(`Password cleared for ${username}.`);
+        await loadUsers();
+    } catch (error) {
+        setUserMessage(error.message, true);
+    }
+}
+
+async function deleteUser(id, username) {
+    if (!confirm(`Delete user ${username}? This cannot be undone.`)) return;
+    try {
+        const res = await authFetch(`/manage/users/${encodeURIComponent(id)}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error(await parseApiError(res));
+        resetUserForm();
+        setUserMessage(`Deleted ${username}.`);
+        await loadUsers();
+    } catch (error) {
+        setUserMessage(error.message, true);
+    }
 }
 
 async function loadSummary() {

--- a/tests/core/test_user_auth.py
+++ b/tests/core/test_user_auth.py
@@ -39,6 +39,46 @@ class FakeUserStore:
     def record_user_login(self, user_id):
         return None
 
+    def list_users(self):
+        return [
+            {**user, "password_set": bool(user.get("password_hash"))}
+            for user in sorted(self.users.values(), key=lambda row: row["username"].lower())
+        ]
+
+    def get_user_by_id(self, user_id):
+        for user in self.users.values():
+            if user["id"] == user_id:
+                return dict(user)
+        return None
+
+    def create_user(self, username, role, password_hash=None):
+        user_id = max(user["id"] for user in self.users.values()) + 1
+        user = {"id": user_id, "username": username, "role": role, "password_hash": password_hash}
+        self.users[username.lower()] = user
+        return dict(user)
+
+    def update_user(self, user_id, username, role):
+        old_key = None
+        for key, user in self.users.items():
+            if user["id"] == user_id:
+                old_key = key
+                break
+        if old_key is None:
+            return None
+        user = self.users.pop(old_key)
+        user["username"] = username
+        user["role"] = role
+        self.users[username.lower()] = user
+        return dict(user)
+
+    def clear_user_password(self, user_id):
+        self.set_user_password_hash(user_id, None)
+
+    def delete_user(self, user_id):
+        for key, user in list(self.users.items()):
+            if user["id"] == user_id:
+                del self.users[key]
+
 
 def load_main(monkeypatch):
     main = importlib.import_module("main")
@@ -79,3 +119,47 @@ def test_admin_can_access_admin_role(monkeypatch):
     response = client.get("/auth_check?role=Admin")
 
     assert response.status_code == 204
+
+
+def test_admin_can_manage_users(monkeypatch):
+    main, store = load_main(monkeypatch)
+    client = TestClient(main.app)
+    client.post("/login", json={"username": "Techno", "password": "", "new_password": "techno-secret"})
+
+    create_response = client.post(
+        "/manage/users",
+        json={"username": "Alex", "role": "User", "password": "alex-secret"},
+    )
+
+    assert create_response.status_code == 201
+    created = create_response.json()["user"]
+    assert created["username"] == "Alex"
+    assert created["password_set"] is True
+
+    update_response = client.put(
+        f"/manage/users/{created['id']}",
+        json={"username": "Alex Admin", "role": "Admin"},
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["user"]["role"] == "Admin"
+
+    reset_response = client.post(f"/manage/users/{created['id']}/password", json={})
+
+    assert reset_response.status_code == 200
+    assert store.users["alex admin"]["password_hash"] is None
+
+    delete_response = client.delete(f"/manage/users/{created['id']}")
+
+    assert delete_response.status_code == 200
+    assert "alex admin" not in store.users
+
+
+def test_admin_cannot_delete_own_user(monkeypatch):
+    main, _store = load_main(monkeypatch)
+    client = TestClient(main.app)
+    client.post("/login", json={"username": "Techno", "password": "", "new_password": "techno-secret"})
+
+    response = client.delete("/manage/users/2")
+
+    assert response.status_code == 400


### PR DESCRIPTION
### Motivation
- Provide administrators with an in-app UI and API to manage application users from the Maintenance pages. 
- Support full lifecycle operations (list/create/update/reset password/delete) and prevent unsafe self-demotion/self-deletion. 

### Description
- Add database helper methods to `DatabaseManager` for user CRUD operations: `list_users`, `create_user`, `update_user`, `clear_user_password`, and `delete_user` (in `database.py`).
- Add admin-only FastAPI endpoints under `/manage/users` in `main.py` for listing, creating, updating, setting/resetting passwords, and deleting users with validation and self-protection checks.
- Extend maintenance UI: add a collapsible "User Management" panel to `static/maintenance.html` with a create/edit form, user list table, and client-side JavaScript to call the new APIs (`loadUsers`, `saveUser`, `editUser`, `clearUserPassword`, `deleteUser`, plus helpers and UI messages).
- Update tests by extending `tests/core/test_user_auth.py` with a fake user store supporting the new DB methods and adding coverage for create/update/reset/delete flows and self-delete protection.

### Testing
- Ran `python -m pytest tests/core/test_user_auth.py` and all tests passed (5 passed). 
- Verified Python syntax for modified modules with `python -m py_compile main.py database.py` which succeeded.
- Manual static checks: inserted UI JS/CSS and verified the maintenance page scripts compile in-place (no runtime browser automation was executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc3233fa08320b0f04fb5a4b19fe8)