### PR TITLE
Add centralized top navigation (shared renderer + styles)

### DIFF
--- a/static/av-tools.html
+++ b/static/av-tools.html
@@ -9,12 +9,7 @@
     <link rel="stylesheet" href="/static/site.css">
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
 <h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Audio &amp; Video Tools</h1>
 

--- a/static/chris.html
+++ b/static/chris.html
@@ -9,12 +9,7 @@
     <link rel="stylesheet" href="/static/site.css">
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 <h1 class="mb-1"><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Chris</h1>
 <p>LVGL (Light and Versatile Graphics Library) is an open-source graphics library designed for embedded systems. In the context of MicroPython, it enables rich graphical user interfaces on microcontrollers.</p>
 <p>The example below demonstrates initializing LVGL and displaying a label:</p>

--- a/static/database.html
+++ b/static/database.html
@@ -11,12 +11,7 @@
     <script src="map-components.js"></script>
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 <h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Database Maintenance</h1>
 
 <!-- Delete Confirmation -->

--- a/static/device.html
+++ b/static/device.html
@@ -12,10 +12,7 @@
     <!-- Inlined styles removed; migrated into site.css utilities or to be added if missing -->
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Main</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 <h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Device Records</h1>
 <!-- Hidden maintenance link as a square at bottom right -->
 <a href="maintenance.html" id="maintenance-link" class="maintenance-link" title="Maintenance">🛠️</a>

--- a/static/dumpert.html
+++ b/static/dumpert.html
@@ -189,12 +189,7 @@
     </style>
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
 <main>
     <div class="dumpert-hero">

--- a/static/index.html
+++ b/static/index.html
@@ -11,10 +11,7 @@
     <script src="map-components.js"></script>
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="device.html">Device View</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 <h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Road Condition Indexer</h1>
 
 <!-- Status indicators in top right -->

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -290,12 +290,7 @@
     </style>
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 <h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Maintenance Hub</h1>
 
 <section class="maintenance-hub rci-card" aria-labelledby="maintenance-hub-title">

--- a/static/memo.html
+++ b/static/memo.html
@@ -11,12 +11,7 @@
 </head>
 <body>
 
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
 <h1 id="memo-page-title">
     <img src="/static/logo.png" alt="Road Condition Indexer" class="rci-logo">

--- a/static/monitor.html
+++ b/static/monitor.html
@@ -12,12 +12,7 @@
 </head>
 <body>
 
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
 <header class="monitor-page-header">
     <h1 id="monitor-title" class="monitor-title">

--- a/static/shared.html
+++ b/static/shared.html
@@ -13,12 +13,7 @@
 </head>
 <body>
 
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
 <h1>
     <img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">

--- a/static/site.css
+++ b/static/site.css
@@ -458,10 +458,79 @@ body.memo-camera-overlay-fullscreen { overflow:hidden; }
 .min-h-32 { min-height:32px; }
 .json-editor-container { height:420px; border:1px solid var(--rci-border); border-radius:4px; background:var(--rci-surface); }
 
-/* Theme panel integrated into page links */
-.page-links { display:flex; gap:1rem; align-items:center; flex-wrap:wrap; }
-.page-links a { text-decoration:none; color:var(--rci-link); }
-.page-links a:hover { text-decoration:underline; }
+/* Shared top navigation */
+.page-links,
+.rci-top-nav {
+  display:flex;
+  align-items:stretch;
+  gap:1rem;
+  flex-wrap:wrap;
+  padding:.75rem;
+  border:1px solid var(--rci-border);
+  border-radius:var(--rci-radius);
+  background:var(--rci-surface);
+  box-shadow:var(--rci-shadow);
+}
+.rci-top-nav a { text-decoration:none; color:var(--rci-link); }
+.rci-top-nav a:hover { text-decoration:none; }
+.rci-nav-brand {
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+  padding:.45rem .6rem;
+  border-radius:999px;
+  color:var(--rci-text);
+  font-weight:700;
+  white-space:nowrap;
+}
+.rci-nav-logo { width:1.5rem; height:1.5rem; object-fit:contain; }
+.rci-nav-groups {
+  display:flex;
+  align-items:stretch;
+  gap:.75rem;
+  flex:1 1 560px;
+  flex-wrap:wrap;
+}
+.rci-nav-group {
+  display:flex;
+  flex-direction:column;
+  gap:.35rem;
+  min-width:0;
+}
+.rci-nav-group-label {
+  color:var(--rci-text-muted);
+  font-size:.72rem;
+  font-weight:700;
+  letter-spacing:.06em;
+  line-height:1;
+  text-transform:uppercase;
+}
+.rci-nav-group-links { display:flex; align-items:center; gap:.35rem; flex-wrap:wrap; }
+.rci-nav-link {
+  display:inline-flex;
+  align-items:center;
+  min-height:32px;
+  padding:.35rem .55rem;
+  border:1px solid transparent;
+  border-radius:999px;
+  color:var(--rci-link);
+  line-height:1.1;
+  white-space:nowrap;
+}
+.rci-nav-link:hover,
+.rci-nav-brand:hover { background:var(--rci-surface-alt); }
+.rci-nav-link[aria-current="page"],
+.rci-nav-brand[aria-current="page"] {
+  background:var(--rci-primary);
+  border-color:var(--rci-primary-accent);
+  color:#fff;
+}
+.rci-nav-actions { display:flex; align-items:center; margin-left:auto; }
+@media (max-width:760px){
+  .rci-top-nav { flex-direction:column; align-items:stretch; }
+  .rci-nav-groups { flex:1 1 auto; }
+  .rci-nav-actions { margin-left:0; }
+}
 
 /* Time range slider (database view) */
 .time-range-container { position:relative; margin:1rem 0; }

--- a/static/solution.html
+++ b/static/solution.html
@@ -9,12 +9,7 @@
     <link rel="stylesheet" href="/static/site.css">
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 <h1 class="mb-1"><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Solution</h1>
 <p>Solving the system of equations:</p>
 <pre class="text-md">

--- a/static/timezone-test.html
+++ b/static/timezone-test.html
@@ -9,12 +9,7 @@
     <link rel="stylesheet" href="/static/site.css">
 </head>
 <body>
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
     <h1 class="mb-1"><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Timezone Conversion Test</h1>
     

--- a/static/tools.html
+++ b/static/tools.html
@@ -20,12 +20,7 @@
 </head>
 <body>
 
-<nav id="page-links" class="page-links mb-1">
-    <a href="/">Road Condition Indexer</a>
-    <a href="device.html">Device View</a>
-    <a href="maintenance.html">Maintenance Hub</a>
-    <button type="button" data-role="theme-toggle" class="theme-toggle focus-ring" aria-label="Toggle dark mode">🌙 Dark</button>
-</nav>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
 
 <h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Tools</h1>
 

--- a/static/utils.js
+++ b/static/utils.js
@@ -669,6 +669,116 @@ function toggleSettings() {
     togglePanel('settings-content', 'settings-toggle');
 }
 
+
+// ============================================================================
+// NAVIGATION UTILITIES
+// ============================================================================
+
+const RCI_NAV_GROUPS = [
+    {
+        label: 'Main',
+        items: [
+            { label: 'Device View', href: '/static/device.html', paths: ['/static/device.html'] },
+            { label: 'Memo\'s', href: '/static/memo.html', paths: ['/static/memo.html'] }
+        ]
+    },
+    {
+        label: 'Tools',
+        items: [
+            { label: 'Tools', href: '/static/tools.html', paths: ['/static/tools.html'] },
+            { label: 'Audio & Video', href: '/static/av-tools.html', paths: ['/static/av-tools.html'] },
+            { label: 'Shared Objects', href: '/static/shared.html', paths: ['/static/shared.html'] },
+            { label: 'Monitor', href: '/static/monitor.html', paths: ['/static/monitor.html'] }
+        ]
+    },
+    {
+        label: 'Maintenance',
+        items: [
+            { label: 'Database', href: '/static/database.html', paths: ['/static/database.html'] },
+            { label: 'Maintenance Hub', href: '/static/maintenance.html', paths: ['/static/maintenance.html'] }
+        ]
+    },
+    {
+        label: 'Labs',
+        items: [
+            { label: 'Dumpert', href: '/static/dumpert.html', paths: ['/static/dumpert.html'] },
+            { label: 'Solution', href: '/static/solution.html', paths: ['/static/solution.html'] },
+            { label: 'Chris', href: '/static/chris.html', paths: ['/static/chris.html'] },
+            { label: 'Timezone Test', href: '/static/timezone-test.html', paths: ['/static/timezone-test.html'] }
+        ]
+    }
+];
+
+function normalizeNavPath(pathname) {
+    if (!pathname || pathname === '/static/') return '/';
+    return pathname.endsWith('/') && pathname !== '/' ? pathname.slice(0, -1) : pathname;
+}
+
+function isCurrentNavItem(item, currentPath) {
+    return item.paths.some(path => normalizeNavPath(path) === currentPath);
+}
+
+function createNavLink(item, currentPath) {
+    const link = document.createElement('a');
+    link.href = item.href;
+    link.textContent = item.label;
+    link.className = 'rci-nav-link focus-ring';
+    if (isCurrentNavItem(item, currentPath)) {
+        link.setAttribute('aria-current', 'page');
+    }
+    return link;
+}
+
+function renderRciNavigation() {
+    const nav = document.querySelector('[data-rci-navigation]');
+    if (!nav) return;
+
+    const currentPath = normalizeNavPath(window.location.pathname);
+    nav.classList.add('rci-top-nav');
+    nav.innerHTML = '';
+
+    const brand = document.createElement('a');
+    brand.href = '/';
+    brand.className = 'rci-nav-brand focus-ring';
+    brand.innerHTML = '<img src="/static/logo.png" alt="" class="rci-nav-logo"> <span>Road Condition Indexer</span>';
+    if (currentPath === '/' || currentPath === '/index.html' || currentPath === '/static/index.html') {
+        brand.setAttribute('aria-current', 'page');
+    }
+    nav.appendChild(brand);
+
+    const groupsWrapper = document.createElement('div');
+    groupsWrapper.className = 'rci-nav-groups';
+
+    RCI_NAV_GROUPS.forEach(group => {
+        const groupElement = document.createElement('div');
+        groupElement.className = 'rci-nav-group';
+
+        const label = document.createElement('span');
+        label.className = 'rci-nav-group-label';
+        label.textContent = group.label;
+        groupElement.appendChild(label);
+
+        const links = document.createElement('div');
+        links.className = 'rci-nav-group-links';
+        group.items.forEach(item => links.appendChild(createNavLink(item, currentPath)));
+        groupElement.appendChild(links);
+        groupsWrapper.appendChild(groupElement);
+    });
+
+    nav.appendChild(groupsWrapper);
+
+    const actions = document.createElement('div');
+    actions.className = 'rci-nav-actions';
+    const themeButton = document.createElement('button');
+    themeButton.type = 'button';
+    themeButton.dataset.role = 'theme-toggle';
+    themeButton.className = 'theme-toggle focus-ring';
+    themeButton.setAttribute('aria-label', 'Toggle dark mode');
+    themeButton.textContent = '🌙 Dark';
+    actions.appendChild(themeButton);
+    nav.appendChild(actions);
+}
+
 // ============================================================================
 // INITIALIZATION
 // ============================================================================
@@ -676,6 +786,7 @@ function toggleSettings() {
 // Initialize device ID when script loads
 document.addEventListener('DOMContentLoaded', function() {
     initializeDeviceId();
+    renderRciNavigation();
 });
 
 // Theme toggling logic


### PR DESCRIPTION
### Motivation
- Replace ad-hoc per-page top links with a single, structured navigation system for consistent header and easier maintenance.
- Provide grouped navigation, clear active-state handling and a stable place for the theme toggle and brand link across pages.

### Description
- Added a navigation config and renderer in `static/utils.js` (`RCI_NAV_GROUPS`, `renderRciNavigation()`, `createNavLink()` and helpers) and invoked `renderRciNavigation()` on `DOMContentLoaded`.
- Replaced per-page hard-coded nav markup with a placeholder `<nav id="page-links" data-rci-navigation aria-label="Primary navigation"></nav>` in the static HTML files so the common renderer populates the header.
- Introduced responsive grouped top-navigation styling in `static/site.css` (`.rci-top-nav`, `.rci-nav-group`, `.rci-nav-link`, `.rci-nav-brand`, etc.) including `aria-current` active-state styles.
- Ensured the theme toggle button is produced by the renderer (`data-role="theme-toggle"`) to keep theme behavior intact and centralized.

### Testing
- No automated tests were executed for this change because it is a layout/navigation-only update and tests were skipped per the repository guidance for UI/layout changes.
- A local static server start was attempted for visual verification but no browser binary was available in the environment, so no screenshot or end-to-end visual test could be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc95da91883208c0cdfe5c6f99f5a)