### PR TITLE
Add Playwright-based development browser installer and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ static/vendor/
 # Allow specific lib files but ignore others
 static/lib/*
 !static/lib/README.md
+# Local browser binaries and screenshot artifacts
+.cache/
+.browser.env
+screenshots/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,6 +76,18 @@ AZURE_SQL_PORT=1433
 pip install -r requirements.txt
 ```
 
+For local browser-based development tools, such as screenshot capture, install the
+optional development dependencies and managed Chromium binary:
+```bash
+pip install -r requirements-dev.txt
+bin/install_browser.sh
+source .browser.env
+```
+
+The browser binary is stored under `.cache/ms-playwright/` by default and is
+ignored by Git. Override `PLAYWRIGHT_BROWSERS_PATH` before running the installer
+if you want to keep the binary in a different location.
+
 ### 3. Run Development Server
 ```bash
 python -m uvicorn main:app --host 0.0.0.0 --port 8000 --reload

--- a/bin/install_browser.sh
+++ b/bin/install_browser.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install a repo-local Playwright Chromium browser binary for development tools
+# that need to capture screenshots.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BROWSER_CACHE_DIR="${PLAYWRIGHT_BROWSERS_PATH:-$REPO_ROOT/.cache/ms-playwright}"
+ENV_FILE="$REPO_ROOT/.browser.env"
+
+export PLAYWRIGHT_BROWSERS_PATH="$BROWSER_CACHE_DIR"
+
+echo "🔎 Checking Python Playwright package..."
+if ! python -c "import playwright" >/dev/null 2>&1; then
+    echo "📦 Installing development dependencies from requirements-dev.txt..."
+    python -m pip install -r "$REPO_ROOT/requirements-dev.txt"
+fi
+
+echo "🌐 Installing Chromium browser binary into $PLAYWRIGHT_BROWSERS_PATH..."
+if [ "$(uname -s)" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then
+    echo "🧩 Installing Chromium runtime libraries for Linux screenshot capture..."
+    if [ "$(id -u)" -eq 0 ]; then
+        python -m playwright install --with-deps chromium
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo env PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" python -m playwright install --with-deps chromium
+    else
+        echo "⚠️  sudo is unavailable; installing Chromium without OS runtime libraries."
+        echo "   If launch fails, run: python -m playwright install-deps chromium"
+        python -m playwright install chromium
+    fi
+else
+    python -m playwright install chromium
+fi
+
+BROWSER_BINARY="$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f \( -name chrome -o -name chromium -o -name chromium-browser \) | head -n 1 || true)"
+if [ -z "$BROWSER_BINARY" ]; then
+    echo "❌ Chromium installed, but no browser executable was found under $PLAYWRIGHT_BROWSERS_PATH" >&2
+    exit 1
+fi
+
+cat > "$ENV_FILE" <<ENVEOF
+# Source this file to expose the local browser binary to screenshot tooling.
+export PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH"
+export RCI_BROWSER_BINARY_PATH="$BROWSER_BINARY"
+ENVEOF
+
+echo "✅ Chromium ready: $BROWSER_BINARY"
+echo "💡 Run 'source .browser.env' to expose RCI_BROWSER_BINARY_PATH in your shell."

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development dependencies for local tooling.
+# Install with: pip install -r requirements-dev.txt
+-r requirements.txt
+
+# Provides a managed Chromium browser binary for local screenshot capture.
+playwright>=1.44.0


### PR DESCRIPTION
### Motivation
- Provide a reproducible local browser binary for developers to capture screenshots without adding browser binaries to production requirements. 
- Keep browser tooling optional and documented so development workflows remain lightweight for CI and production.

### Description
- Add `requirements-dev.txt` to declare optional development dependencies including `playwright`. 
- Add `bin/install_browser.sh` which installs Playwright if missing, downloads a repo-local Chromium binary, installs OS runtime libraries on Debian/Ubuntu when available, and writes `.browser.env` exposing `PLAYWRIGHT_BROWSERS_PATH` and `RCI_BROWSER_BINARY_PATH` for tooling. 
- Update `DEVELOPMENT.md` with local browser setup instructions and update `.gitignore` to ignore browser caches, `.browser.env`, and `screenshots/` artifacts. 

### Testing
- Linted and executed the installer with `bash -n bin/install_browser.sh && bin/install_browser.sh`, which completed successfully in the test environment. 
- Performed a Playwright smoke test by sourcing `.browser.env` and running a small script that launches Chromium, renders a simple page and writes a screenshot to `screenshots/browser-check.png`, which succeeded. 
- Verified that the installer handles missing system libraries on Linux by installing runtime dependencies via `apt-get` when available, allowing the headless Chromium launch to succeed in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde12a630483208b8692ad124a2be1)