### PR TITLE
Add AI Features page and Omi MCP configuration (UI, JS, nav, CSS)

### DIFF
--- a/static/ai-features.html
+++ b/static/ai-features.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Features</title>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <link rel="stylesheet" href="/static/site.css">
+    <script src="/static/utils.js"></script>
+    <script src="/static/ai-features.js" defer></script>
+</head>
+<body>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
+<h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">AI Features</h1>
+
+<section class="rci-card ai-hero" aria-labelledby="ai-features-title">
+    <div>
+        <p class="eyebrow">External agents, MCP servers, and assistant workflows</p>
+        <h2 id="ai-features-title">Configure AI integrations from one place</h2>
+        <p class="rci-muted">Use this page to plan AI functionality, manage connection details for external assistants, and prepare MCP server configuration snippets. The first available integration is Omi MCP.</p>
+    </div>
+    <div class="ai-hero-status" aria-label="Configured AI feature areas">
+        <span>🤖 Agents</span>
+        <span>🔌 MCP Servers</span>
+        <span>⚙️ Functionality</span>
+    </div>
+</section>
+
+<section class="ai-feature-grid" aria-label="AI feature areas">
+    <article class="rci-card ai-feature-card">
+        <h2>External Agents</h2>
+        <p>Reserve connection profiles for assistants such as desktop IDE agents, hosted copilots, and local workflow runners.</p>
+        <ul>
+            <li>Provider and agent name</li>
+            <li>Allowed tools and scopes</li>
+            <li>Default prompt or handoff notes</li>
+        </ul>
+        <span class="pill muted">Planned</span>
+    </article>
+    <article class="rci-card ai-feature-card ai-feature-card-active">
+        <h2>MCP Servers</h2>
+        <p>Configure Model Context Protocol servers that agents can use for memories, conversation search, or other context tools.</p>
+        <ul>
+            <li>Server URL and transport</li>
+            <li>Bearer token authorization</li>
+            <li>Client-ready config snippets</li>
+        </ul>
+        <span class="pill success">Omi available</span>
+    </article>
+    <article class="rci-card ai-feature-card">
+        <h2>Functionality</h2>
+        <p>Track higher-level AI capabilities you may enable later, such as summarization, road-condition insights, and memo workflows.</p>
+        <ul>
+            <li>Feature toggles</li>
+            <li>Task templates</li>
+            <li>Safety and privacy notes</li>
+        </ul>
+        <span class="pill muted">Planned</span>
+    </article>
+</section>
+
+<div class="section ai-section">
+    <div class="section-header" onclick="toggleSection('omi-mcp')">
+        <span>🔌 Omi MCP Server</span>
+        <span class="section-toggle" id="omi-mcp-toggle">▶</span>
+    </div>
+    <div class="section-content" id="omi-mcp-content">
+        <div class="ai-two-column">
+            <form id="omi-mcp-form" class="ai-config-form" autocomplete="off">
+                <div class="ai-form-header">
+                    <div>
+                        <h2>Connection settings</h2>
+                        <p class="rci-muted">Store Omi MCP connection details in this browser so you can generate client configuration snippets without retyping them.</p>
+                    </div>
+                    <label class="toggle-row">
+                        <input type="checkbox" id="omi-enabled">
+                        <span>Enabled</span>
+                    </label>
+                </div>
+
+                <div class="ai-form-grid">
+                    <label>
+                        <span>Display name</span>
+                        <input type="text" id="omi-display-name" value="Omi" maxlength="80">
+                    </label>
+                    <label>
+                        <span>Server key</span>
+                        <input type="text" id="omi-server-key" value="omi" maxlength="40" pattern="[a-zA-Z0-9_-]+">
+                    </label>
+                    <label class="full-width">
+                        <span>MCP URL</span>
+                        <input type="url" id="omi-url" value="https://api.omi.me/v1/mcp/sse" required>
+                    </label>
+                    <label>
+                        <span>VS Code server type</span>
+                        <select id="omi-vscode-type">
+                            <option value="sse" selected>SSE</option>
+                            <option value="http">HTTP</option>
+                        </select>
+                    </label>
+                    <label>
+                        <span>SDK transport</span>
+                        <select id="omi-transport">
+                            <option value="streamable_http" selected>Streamable HTTP</option>
+                            <option value="sse">SSE</option>
+                        </select>
+                    </label>
+                    <label class="full-width">
+                        <span>Bearer token</span>
+                        <div class="secret-input-row">
+                            <input type="password" id="omi-token" placeholder="omi_mcp_..." pattern="omi_mcp_.+" aria-describedby="omi-token-help">
+                            <button type="button" id="omi-toggle-token" class="secondary-button">Show</button>
+                        </div>
+                        <small id="omi-token-help">Create the key in the Omi app under Settings → Developer → MCP. Token values remain in browser local storage only.</small>
+                    </label>
+                    <label class="full-width">
+                        <span>Notes</span>
+                        <textarea id="omi-notes" rows="3" placeholder="Usage notes, owner, or scope restrictions"></textarea>
+                    </label>
+                </div>
+
+                <div class="ai-form-actions">
+                    <button type="submit" class="focus-ring">Save Omi MCP settings</button>
+                    <button type="button" id="omi-reset" class="secondary-button focus-ring">Reset defaults</button>
+                    <button type="button" id="omi-clear" class="secondary-button focus-ring">Clear saved settings</button>
+                </div>
+                <div id="omi-status" class="status-message" role="status" aria-live="polite"></div>
+            </form>
+
+            <aside class="ai-reference rci-card" aria-labelledby="omi-reference-title">
+                <h2 id="omi-reference-title">Omi quick reference</h2>
+                <dl>
+                    <dt>Website</dt>
+                    <dd><a href="https://omi.me" target="_blank" rel="noopener">omi.me</a></dd>
+                    <dt>Docs</dt>
+                    <dd><a href="https://docs.omi.me" target="_blank" rel="noopener">docs.omi.me</a></dd>
+                    <dt>Auth</dt>
+                    <dd>Bearer token in the <code>Authorization</code> header</dd>
+                    <dt>Key format</dt>
+                    <dd><code>omi_mcp_...</code></dd>
+                    <dt>Tools</dt>
+                    <dd>Memories and conversations: list, semantic search, create/edit/delete memories, and transcript lookup.</dd>
+                </dl>
+                <details>
+                    <summary>Error codes</summary>
+                    <ul>
+                        <li><code>-32602</code>: invalid parameters</li>
+                        <li><code>-32001</code>: resource not found</li>
+                        <li><code>-32002</code>: locked content</li>
+                        <li><code>-32601</code>: unknown tool name</li>
+                    </ul>
+                </details>
+            </aside>
+        </div>
+
+        <div class="ai-snippet-toolbar">
+            <label><input type="checkbox" id="omi-include-token"> Include saved token in snippets</label>
+            <button type="button" id="omi-copy-vscode" class="secondary-button focus-ring">Copy VS Code config</button>
+            <button type="button" id="omi-copy-python" class="secondary-button focus-ring">Copy Python SDK example</button>
+        </div>
+
+        <div class="compare-grid ai-snippet-grid">
+            <div class="json-col">
+                <h4>VS Code <code>.vscode/mcp.json</code></h4>
+                <pre id="omi-vscode-snippet" class="result-box ai-code-block" tabindex="0"></pre>
+            </div>
+            <div class="json-col">
+                <h4>Python SDK example</h4>
+                <pre id="omi-python-snippet" class="result-box ai-code-block" tabindex="0"></pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/static/ai-features.js
+++ b/static/ai-features.js
@@ -1,0 +1,223 @@
+(function () {
+    const STORAGE_KEY = 'rci.ai.omiMcpConfig';
+    const DEFAULT_CONFIG = {
+        enabled: false,
+        displayName: 'Omi',
+        serverKey: 'omi',
+        url: 'https://api.omi.me/v1/mcp/sse',
+        vscodeType: 'sse',
+        transport: 'streamable_http',
+        token: '',
+        notes: ''
+    };
+
+    const elements = {};
+
+    function getElement(id) {
+        return document.getElementById(id);
+    }
+
+    function loadSavedConfig() {
+        let raw = '';
+        try {
+            raw = localStorage.getItem(STORAGE_KEY);
+        } catch (error) {
+            console.warn('Unable to read saved Omi MCP config. Falling back to defaults.', error);
+            return { ...DEFAULT_CONFIG };
+        }
+        if (!raw) return { ...DEFAULT_CONFIG };
+        try {
+            const parsed = JSON.parse(raw);
+            return { ...DEFAULT_CONFIG, ...parsed };
+        } catch (error) {
+            console.warn('Invalid saved Omi MCP config. Falling back to defaults.', error);
+            return { ...DEFAULT_CONFIG };
+        }
+    }
+
+    function readFormConfig() {
+        return {
+            enabled: elements.enabled.checked,
+            displayName: elements.displayName.value.trim() || DEFAULT_CONFIG.displayName,
+            serverKey: elements.serverKey.value.trim() || DEFAULT_CONFIG.serverKey,
+            url: elements.url.value.trim() || DEFAULT_CONFIG.url,
+            vscodeType: elements.vscodeType.value,
+            transport: elements.transport.value,
+            token: elements.token.value.trim(),
+            notes: elements.notes.value.trim()
+        };
+    }
+
+    function applyConfig(config) {
+        elements.enabled.checked = Boolean(config.enabled);
+        elements.displayName.value = config.displayName;
+        elements.serverKey.value = config.serverKey;
+        elements.url.value = config.url;
+        elements.vscodeType.value = config.vscodeType;
+        elements.transport.value = config.transport;
+        elements.token.value = config.token;
+        elements.notes.value = config.notes;
+        renderSnippets();
+    }
+
+    function getSnippetToken(config) {
+        if (elements.includeToken.checked && config.token) {
+            return config.token;
+        }
+        return '<key>';
+    }
+
+    function buildVsCodeSnippet(config) {
+        const token = getSnippetToken(config);
+        const serverKey = config.serverKey || DEFAULT_CONFIG.serverKey;
+        return JSON.stringify({
+            servers: {
+                [serverKey]: {
+                    type: config.vscodeType,
+                    url: config.url,
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    }
+                }
+            }
+        }, null, 2);
+    }
+
+    function buildPythonSnippet(config) {
+        const token = getSnippetToken(config) === '<key>' ? 'omi_mcp_YOUR_KEY' : config.token;
+        const serverKey = config.serverKey || DEFAULT_CONFIG.serverKey;
+        return `from langchain_mcp_adapters.client import MultiServerMCPClient\n\nasync with MultiServerMCPClient({\n    "${serverKey}": {\n        "url": "${config.url}",\n        "transport": "${config.transport}",\n        "headers": {"Authorization": "Bearer ${token}"},\n    }\n}) as client:\n    tools = client.get_tools()\n    result = await client.call_tool("${serverKey}", "search_memories", {\n        "query": "morning routine",\n        "limit": 5,\n    })`;
+    }
+
+    function renderSnippets() {
+        const config = readFormConfig();
+        elements.vscodeSnippet.textContent = buildVsCodeSnippet(config);
+        elements.pythonSnippet.textContent = buildPythonSnippet(config);
+    }
+
+    function showStatus(message, type) {
+        elements.status.textContent = message;
+        elements.status.className = `status-message ${type || ''}`.trim();
+    }
+
+    function validateConfig(config) {
+        if (!config.url.startsWith('https://')) {
+            return 'MCP URL should use HTTPS.';
+        }
+        if (config.token && !config.token.startsWith('omi_mcp_')) {
+            return 'Omi MCP tokens should start with omi_mcp_.';
+        }
+        if (!/^[a-zA-Z0-9_-]+$/.test(config.serverKey)) {
+            return 'Server key can contain letters, numbers, underscores, and hyphens only.';
+        }
+        return '';
+    }
+
+    function saveConfig(event) {
+        event.preventDefault();
+        const config = readFormConfig();
+        const validationError = validateConfig(config);
+        if (validationError) {
+            showStatus(validationError, 'error');
+            return;
+        }
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+        } catch (error) {
+            console.warn('Unable to save Omi MCP config.', error);
+            showStatus('Unable to save settings in this browser.', 'error');
+            return;
+        }
+        renderSnippets();
+        showStatus('Omi MCP settings saved in this browser.', 'success');
+    }
+
+    function resetDefaults() {
+        applyConfig({ ...DEFAULT_CONFIG });
+        showStatus('Omi MCP settings reset to defaults. Save to keep these values.', 'warning');
+    }
+
+    function clearSavedConfig() {
+        try {
+            localStorage.removeItem(STORAGE_KEY);
+        } catch (error) {
+            console.warn('Unable to clear saved Omi MCP config.', error);
+            showStatus('Unable to clear saved settings in this browser.', 'error');
+            return;
+        }
+        applyConfig({ ...DEFAULT_CONFIG });
+        showStatus('Saved Omi MCP settings cleared from this browser.', 'success');
+    }
+
+    async function copyText(text, successMessage) {
+        if (!navigator.clipboard) {
+            showStatus('Clipboard access is not available in this browser.', 'error');
+            return;
+        }
+        try {
+            await navigator.clipboard.writeText(text);
+            showStatus(successMessage, 'success');
+        } catch (error) {
+            console.warn('Unable to copy AI config snippet.', error);
+            showStatus('Unable to copy snippet to the clipboard.', 'error');
+        }
+    }
+
+    function toggleTokenVisibility() {
+        const showing = elements.token.type === 'text';
+        elements.token.type = showing ? 'password' : 'text';
+        elements.toggleToken.textContent = showing ? 'Show' : 'Hide';
+    }
+
+    function bindElements() {
+        elements.form = getElement('omi-mcp-form');
+        elements.enabled = getElement('omi-enabled');
+        elements.displayName = getElement('omi-display-name');
+        elements.serverKey = getElement('omi-server-key');
+        elements.url = getElement('omi-url');
+        elements.vscodeType = getElement('omi-vscode-type');
+        elements.transport = getElement('omi-transport');
+        elements.token = getElement('omi-token');
+        elements.notes = getElement('omi-notes');
+        elements.status = getElement('omi-status');
+        elements.reset = getElement('omi-reset');
+        elements.clear = getElement('omi-clear');
+        elements.includeToken = getElement('omi-include-token');
+        elements.vscodeSnippet = getElement('omi-vscode-snippet');
+        elements.pythonSnippet = getElement('omi-python-snippet');
+        elements.copyVsCode = getElement('omi-copy-vscode');
+        elements.copyPython = getElement('omi-copy-python');
+        elements.toggleToken = getElement('omi-toggle-token');
+    }
+
+    function bindEvents() {
+        elements.form.addEventListener('submit', saveConfig);
+        elements.reset.addEventListener('click', resetDefaults);
+        elements.clear.addEventListener('click', clearSavedConfig);
+        elements.toggleToken.addEventListener('click', toggleTokenVisibility);
+        elements.includeToken.addEventListener('change', renderSnippets);
+
+        [
+            elements.enabled,
+            elements.displayName,
+            elements.serverKey,
+            elements.url,
+            elements.vscodeType,
+            elements.transport,
+            elements.token,
+            elements.notes
+        ].forEach(element => {
+            element.addEventListener('input', renderSnippets);
+            element.addEventListener('change', renderSnippets);
+        });
+
+        elements.copyVsCode.addEventListener('click', () => copyText(elements.vscodeSnippet.textContent, 'VS Code MCP config copied.'));
+        elements.copyPython.addEventListener('click', () => copyText(elements.pythonSnippet.textContent, 'Python SDK example copied.'));
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        bindElements();
+        bindEvents();
+        applyConfig(loadSavedConfig());
+    });
+})();

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -31,6 +31,7 @@
             <h3>Technical Tools</h3>
             <a href="tools.html">Tools</a>
             <a href="monitor.html">Monitor</a>
+            <a href="ai-features.html">AI Features</a>
         </article>
         <article class="maintenance-hub-group">
             <h3>Memos/Shared</h3>

--- a/static/site.css
+++ b/static/site.css
@@ -943,3 +943,64 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
 [data-theme="dark"] .password-badge-empty { background:#4a350a; color:#ffd666; }
 [data-theme="dark"] .maintenance-message--warning,
 [data-theme="dark"] .maintenance-check--warning { color:#ffd666; }
+
+/* AI Features page */
+.ai-hero {
+  display:flex;
+  justify-content:space-between;
+  gap:1rem;
+  align-items:center;
+  margin-bottom:1rem;
+}
+.ai-hero h2 { margin:.2rem 0 .35rem; }
+.eyebrow { margin:0; color:var(--rci-primary); font-size:.75rem; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+.ai-hero-status { display:flex; flex-wrap:wrap; gap:.5rem; justify-content:flex-end; }
+.ai-hero-status span,
+.pill { display:inline-flex; align-items:center; gap:.25rem; border:1px solid var(--rci-border); border-radius:999px; padding:.3rem .65rem; background:var(--rci-surface-alt); font-size:.8rem; font-weight:600; white-space:nowrap; }
+.pill.success { color:#1b7f3a; background:rgba(46, 125, 50, .12); border-color:rgba(46, 125, 50, .35); }
+.pill.muted { color:var(--rci-text-muted); }
+.ai-feature-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr)); gap:1rem; margin-bottom:1rem; }
+.ai-feature-card { display:flex; flex-direction:column; gap:.5rem; }
+.ai-feature-card h2 { margin:0; font-size:1.1rem; }
+.ai-feature-card p { margin:0; color:var(--rci-text-muted); }
+.ai-feature-card ul { margin:.25rem 0; padding-left:1.2rem; }
+.ai-feature-card-active { border-color:var(--rci-primary); }
+.ai-section .section-content { display:block; }
+.ai-two-column { display:grid; grid-template-columns:minmax(0, 1.6fr) minmax(260px, .8fr); gap:1rem; align-items:start; }
+.ai-config-form { border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:1rem; background:var(--rci-surface); box-shadow:var(--rci-shadow); }
+.ai-form-header { display:flex; justify-content:space-between; gap:1rem; align-items:flex-start; margin-bottom:1rem; }
+.ai-form-header h2,
+.ai-reference h2 { margin:0 0 .25rem; }
+.toggle-row { display:flex; align-items:center; gap:.4rem; font-weight:600; white-space:nowrap; }
+.ai-form-grid { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:.75rem; }
+.ai-form-grid label { display:flex; flex-direction:column; gap:.25rem; font-weight:600; }
+.ai-form-grid label span { font-size:.78rem; color:var(--rci-text-muted); letter-spacing:.04em; text-transform:uppercase; }
+.ai-form-grid input,
+.ai-form-grid select,
+.ai-form-grid textarea { width:100%; box-sizing:border-box; padding:.45rem .55rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); color:var(--rci-text); font:inherit; }
+.ai-form-grid textarea { resize:vertical; }
+.ai-form-grid small { color:var(--rci-text-muted); font-weight:400; }
+.full-width { grid-column:1 / -1; }
+.secret-input-row { display:flex; gap:.4rem; }
+.secret-input-row input { flex:1; }
+.ai-form-actions,
+.ai-snippet-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; margin-top:1rem; }
+.ai-reference dl { display:grid; grid-template-columns:max-content minmax(0, 1fr); gap:.4rem .75rem; margin:0 0 1rem; }
+.ai-reference dt { font-weight:700; color:var(--rci-text-muted); }
+.ai-reference dd { margin:0; min-width:0; overflow-wrap:anywhere; }
+.ai-reference details { border-top:1px solid var(--rci-border); padding-top:.75rem; }
+.ai-snippet-grid { margin-top:.75rem; }
+.ai-code-block { white-space:pre; font-family:monospace; font-size:.85rem; line-height:1.45; max-height:360px; }
+.status-message.success { color:#1b7f3a; }
+.status-message.warning { color:#a86400; }
+.status-message.error { color:var(--rci-danger, #c0392b); }
+[data-theme="dark"] .pill.success,
+[data-theme="dark"] .status-message.success { color:#78d98b; }
+[data-theme="dark"] .status-message.warning { color:#ffd166; }
+@media (max-width:768px){
+  .ai-hero,
+  .ai-form-header { flex-direction:column; align-items:flex-start; }
+  .ai-hero-status { justify-content:flex-start; }
+  .ai-two-column,
+  .ai-form-grid { grid-template-columns:1fr; }
+}

--- a/static/utils.js
+++ b/static/utils.js
@@ -688,7 +688,8 @@ const RCI_NAV_GROUPS = [
             { label: 'Tools', href: '/static/tools.html', paths: ['/static/tools.html'] },
             { label: 'Audio & Video', href: '/static/av-tools.html', paths: ['/static/av-tools.html'] },
             { label: 'Shared Objects', href: '/static/shared.html', paths: ['/static/shared.html'] },
-            { label: 'Monitor', href: '/static/monitor.html', paths: ['/static/monitor.html'] }
+            { label: 'Monitor', href: '/static/monitor.html', paths: ['/static/monitor.html'] },
+            { label: 'AI Features', href: '/static/ai-features.html', paths: ['/static/ai-features.html'] }
         ]
     },
     {


### PR DESCRIPTION
### Motivation
- Provide a central place to configure AI integration surfaces (external agents, MCP servers, and planned AI functionality) and to make it easy to generate client-ready snippets for integrations.
- Start with support for a custom MCP server integration for Omi so agents can be configured to use Omi's MCP endpoint for memories and conversations.

### Description
- Add a new static page `static/ai-features.html` that provides overview cards for Agents / MCP Servers / Functionality and a detailed Omi MCP configuration panel with form fields and snippet viewers.  
- Implement `static/ai-features.js` to persist Omi MCP settings to browser `localStorage`, validate inputs, toggle token visibility, generate VS Code (`.vscode/mcp.json`) and Python SDK snippets, and copy snippets to the clipboard with graceful error handling.  
- Wire the page into the UI by adding an "AI Features" link to the top navigation in `static/utils.js` and adding an entry in the Maintenance Hub (`static/maintenance.html`).  
- Add responsive styles and component styling for the new page in `static/site.css` and harden client-side behaviors (safe `localStorage` access and clipboard fallbacks). 

### Testing
- Ran `node --check static/ai-features.js` to validate the new JavaScript and it succeeded.  
- Ran `python3 -m compileall -q main.py database.py` to ensure no Python syntax errors in the server code and it succeeded.  
- Ran `git diff --check` to spot whitespace or diff issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fded9f0df4832081513fe7f9060578)