### PR TITLE
Add MCP tools/functions tester to AI Features (admin-only proxy + UI)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2728,6 +2728,138 @@ class VideoDownloadRequest(BaseModel):
     url: str
 
 
+class McpToolTestRequest(BaseModel):
+    url: str = Field(..., max_length=2000)
+    token: Optional[str] = Field(default=None, max_length=4000)
+    transport: Optional[Literal["streamable_http", "sse", "http"]] = "streamable_http"
+    method: Literal["initialize", "tools/list", "prompts/list", "resources/list", "tools/call"] = "tools/list"
+    tool_name: Optional[str] = Field(default=None, max_length=200)
+    arguments: Optional[Dict[str, Any]] = None
+    timeout_seconds: int = Field(default=20, ge=1, le=60)
+
+
+def _mcp_extract_json_response(response: requests.Response) -> Any:
+    """Return a JSON-RPC payload from JSON or SSE-style MCP responses."""
+    content_type = response.headers.get("Content-Type", "")
+    if "application/json" in content_type.lower():
+        return response.json()
+
+    text = response.text.strip()
+    if not text:
+        return {}
+
+    # Some MCP servers stream JSON-RPC responses as Server-Sent Events. Prefer
+    # the last JSON data frame, which is commonly the completed result.
+    json_candidates: List[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            payload = line[5:].strip()
+            if payload and payload != "[DONE]":
+                json_candidates.append(payload)
+    json_candidates.append(text)
+
+    for candidate in reversed(json_candidates):
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+
+    return {"raw": text}
+
+
+def _mcp_json_rpc_payload(method: str, request: McpToolTestRequest, request_id: Union[int, str]) -> Dict[str, Any]:
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "road-condition-indexer", "version": "1.0"},
+            },
+        }
+    if method == "tools/call":
+        if not request.tool_name:
+            raise HTTPException(status_code=400, detail="tool_name is required for tools/call")
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": request.tool_name, "arguments": request.arguments or {}},
+        }
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": {}}
+
+
+def _post_mcp_json_rpc(
+    request: McpToolTestRequest,
+    method: str,
+    request_id: Union[int, str],
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Tuple[Any, Dict[str, str]]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2024-11-05",
+    }
+    if request.token:
+        headers["Authorization"] = f"Bearer {request.token}"
+    if extra_headers:
+        headers.update({key: value for key, value in extra_headers.items() if value})
+
+    payload = _mcp_json_rpc_payload(method, request, request_id)
+    response = requests.post(request.url, json=payload, headers=headers, timeout=request.timeout_seconds)
+    response.raise_for_status()
+    return _mcp_extract_json_response(response), dict(response.headers)
+
+
+def _header_value(headers: Dict[str, str], name: str) -> str:
+    for key, value in headers.items():
+        if key.lower() == name.lower():
+            return value
+    return ""
+
+
+@app.post("/ai/mcp/test")
+def test_mcp_tool(request: McpToolTestRequest, dep: None = Depends(admin_dependency)):
+    """Proxy a small MCP JSON-RPC request for the AI Features test console."""
+    parsed_url = urlparse(request.url)
+    if parsed_url.scheme != "https" or not parsed_url.netloc:
+        raise HTTPException(status_code=400, detail="MCP URL must be a valid HTTPS URL")
+
+    try:
+        initialize_response = None
+        initialize_headers: Dict[str, str] = {}
+        if request.method != "initialize":
+            try:
+                initialize_response, initialize_headers = _post_mcp_json_rpc(request, "initialize", "init")
+            except requests.RequestException as exc:
+                initialize_response = {
+                    "warning": f"Initialize request failed; attempted {request.method} anyway.",
+                    "detail": str(exc),
+                }
+
+        session_id = _header_value(initialize_headers, "mcp-session-id")
+        session_headers = {"Mcp-Session-Id": session_id} if session_id else None
+        result, response_headers = _post_mcp_json_rpc(request, request.method, "test", session_headers)
+    except requests.RequestException as exc:
+        detail = str(exc)
+        if getattr(exc, "response", None) is not None and exc.response is not None:
+            detail = f"{detail}: {exc.response.text[:500]}"
+        raise HTTPException(status_code=502, detail=detail) from exc
+
+    return {
+        "status": "ok",
+        "transport": request.transport,
+        "method": request.method,
+        "initialize": initialize_response,
+        "initialize_headers": {"mcp-session-id": _header_value(initialize_headers, "mcp-session-id")},
+        "result": result,
+        "response_headers": {"content-type": response_headers.get("Content-Type", "")},
+    }
+
+
 class MonitorRequest(BaseModel):
     name: str = Field(..., max_length=150)
     service_type: str = Field(..., max_length=50)

--- a/static/ai-features.html
+++ b/static/ai-features.html
@@ -169,6 +169,60 @@
                 <pre id="omi-python-snippet" class="result-box ai-code-block" tabindex="0"></pre>
             </div>
         </div>
+
+        <section class="rci-card ai-mcp-console" aria-labelledby="omi-mcp-console-title">
+            <div class="ai-console-header">
+                <div>
+                    <h2 id="omi-mcp-console-title">MCP tools and function tester</h2>
+                    <p class="rci-muted">List the tools exposed by the configured MCP server, inspect their schemas, and run a small test call through the Road Condition Indexer admin proxy.</p>
+                </div>
+                <span id="omi-tool-count" class="pill muted">No tools loaded</span>
+            </div>
+
+            <div class="ai-form-grid ai-test-grid">
+                <label>
+                    <span>Discovery method</span>
+                    <select id="omi-mcp-method">
+                        <option value="tools/list" selected>List tools / functions</option>
+                        <option value="prompts/list">List prompts</option>
+                        <option value="resources/list">List resources</option>
+                        <option value="initialize">Initialize only</option>
+                    </select>
+                </label>
+                <label>
+                    <span>Tool to test</span>
+                    <select id="omi-tool-select">
+                        <option value="">Load tools to populate options</option>
+                    </select>
+                </label>
+                <label class="full-width">
+                    <span>Tool arguments JSON</span>
+                    <textarea id="omi-tool-arguments" rows="6" spellcheck="false">{
+  "query": "morning routine",
+  "limit": 5
+}</textarea>
+                </label>
+            </div>
+
+            <div class="ai-form-actions">
+                <button type="button" id="omi-list-tools" class="focus-ring">List MCP tools / functions</button>
+                <button type="button" id="omi-test-tool" class="secondary-button focus-ring">Test selected tool</button>
+                <button type="button" id="omi-copy-result" class="secondary-button focus-ring">Copy result</button>
+            </div>
+            <div id="omi-test-status" class="status-message" role="status" aria-live="polite"></div>
+
+            <div class="ai-tool-results">
+                <div>
+                    <h4>Available tools / functions</h4>
+                    <div id="omi-tools-list" class="ai-tool-list" tabindex="0">Connect to an MCP server to list tools.</div>
+                </div>
+                <div>
+                    <h4>Test response</h4>
+                    <pre id="omi-test-result" class="result-box ai-code-block" tabindex="0"></pre>
+                </div>
+            </div>
+        </section>
+
     </div>
 </div>
 

--- a/static/ai-features.js
+++ b/static/ai-features.js
@@ -12,6 +12,7 @@
     };
 
     const elements = {};
+    let discoveredTools = [];
 
     function getElement(id) {
         return document.getElementById(id);
@@ -100,6 +101,11 @@
         elements.status.className = `status-message ${type || ''}`.trim();
     }
 
+    function showTestStatus(message, type) {
+        elements.testStatus.textContent = message;
+        elements.testStatus.className = `status-message ${type || ''}`.trim();
+    }
+
     function validateConfig(config) {
         if (!config.url.startsWith('https://')) {
             return 'MCP URL should use HTTPS.';
@@ -149,17 +155,17 @@
         showStatus('Saved Omi MCP settings cleared from this browser.', 'success');
     }
 
-    async function copyText(text, successMessage) {
+    async function copyText(text, successMessage, statusTarget) {
         if (!navigator.clipboard) {
-            showStatus('Clipboard access is not available in this browser.', 'error');
+            (statusTarget || showStatus)('Clipboard access is not available in this browser.', 'error');
             return;
         }
         try {
             await navigator.clipboard.writeText(text);
-            showStatus(successMessage, 'success');
+            (statusTarget || showStatus)(successMessage, 'success');
         } catch (error) {
             console.warn('Unable to copy AI config snippet.', error);
-            showStatus('Unable to copy snippet to the clipboard.', 'error');
+            (statusTarget || showStatus)('Unable to copy snippet to the clipboard.', 'error');
         }
     }
 
@@ -167,6 +173,153 @@
         const showing = elements.token.type === 'text';
         elements.token.type = showing ? 'password' : 'text';
         elements.toggleToken.textContent = showing ? 'Show' : 'Hide';
+    }
+
+    function parseArgumentsJson() {
+        const raw = elements.toolArguments.value.trim();
+        if (!raw) return {};
+        try {
+            const parsed = JSON.parse(raw);
+            if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+                throw new Error('Arguments must be a JSON object.');
+            }
+            return parsed;
+        } catch (error) {
+            throw new Error(`Invalid tool arguments JSON: ${error.message}`);
+        }
+    }
+
+    function extractTools(payload) {
+        const result = payload && payload.result ? payload.result : payload;
+        if (Array.isArray(result)) return result;
+        if (result && Array.isArray(result.tools)) return result.tools;
+        if (payload && payload.result && Array.isArray(payload.result.tools)) return payload.result.tools;
+        return [];
+    }
+
+    function summarizeSchema(schema) {
+        if (!schema || typeof schema !== 'object') return 'No schema provided';
+        const properties = schema.properties || {};
+        const keys = Object.keys(properties);
+        if (!keys.length) return 'No arguments';
+        return keys.map(key => {
+            const property = properties[key] || {};
+            return `${key}${property.type ? ` (${property.type})` : ''}`;
+        }).join(', ');
+    }
+
+    function renderToolList(tools) {
+        discoveredTools = tools;
+        elements.toolSelect.innerHTML = '';
+        elements.toolList.innerHTML = '';
+        elements.toolCount.textContent = `${tools.length} tool${tools.length === 1 ? '' : 's'} loaded`;
+        elements.toolCount.className = tools.length ? 'pill success' : 'pill muted';
+
+        if (!tools.length) {
+            const option = document.createElement('option');
+            option.value = '';
+            option.textContent = 'No tools returned';
+            elements.toolSelect.appendChild(option);
+            elements.toolList.textContent = 'The MCP server response did not include a tools array.';
+            return;
+        }
+
+        tools.forEach(tool => {
+            const option = document.createElement('option');
+            option.value = tool.name || '';
+            option.textContent = tool.name || 'Unnamed tool';
+            elements.toolSelect.appendChild(option);
+
+            const card = document.createElement('article');
+            card.className = 'ai-tool-card';
+            const title = document.createElement('h5');
+            title.textContent = tool.name || 'Unnamed tool';
+            const description = document.createElement('p');
+            description.textContent = tool.description || 'No description provided.';
+            const schema = document.createElement('small');
+            schema.textContent = `Arguments: ${summarizeSchema(tool.inputSchema)}`;
+            card.append(title, description, schema);
+            elements.toolList.appendChild(card);
+        });
+    }
+
+    function applySelectedToolExample() {
+        const selected = discoveredTools.find(tool => tool.name === elements.toolSelect.value);
+        const properties = selected && selected.inputSchema && selected.inputSchema.properties ? selected.inputSchema.properties : null;
+        if (!properties) return;
+        const example = {};
+        Object.entries(properties).forEach(([key, value]) => {
+            if (value && Array.isArray(value.enum) && value.enum.length) example[key] = value.enum[0];
+            else if (value && value.type === 'number') example[key] = 0;
+            else if (value && value.type === 'integer') example[key] = 1;
+            else if (value && value.type === 'boolean') example[key] = false;
+            else if (value && value.type === 'array') example[key] = [];
+            else if (value && value.type === 'object') example[key] = {};
+            else example[key] = '';
+        });
+        elements.toolArguments.value = JSON.stringify(example, null, 2);
+    }
+
+    async function sendMcpTest(method, includeTool) {
+        const config = readFormConfig();
+        const validationError = validateConfig(config);
+        if (validationError) {
+            showTestStatus(validationError, 'error');
+            return null;
+        }
+        const payload = {
+            url: config.url,
+            token: config.token,
+            transport: config.transport,
+            method
+        };
+        if (includeTool) {
+            payload.tool_name = elements.toolSelect.value;
+            if (!payload.tool_name) {
+                showTestStatus('Choose a tool before running a test call.', 'error');
+                return null;
+            }
+            try {
+                payload.arguments = parseArgumentsJson();
+            } catch (error) {
+                showTestStatus(error.message, 'error');
+                return null;
+            }
+        }
+
+        showTestStatus(`Running ${method}...`, 'warning');
+        elements.testResult.textContent = '';
+        try {
+            const response = await fetch('/ai/mcp/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            const data = await response.json().catch(() => ({}));
+            elements.testResult.textContent = JSON.stringify(data, null, 2);
+            if (!response.ok) {
+                showTestStatus(data.detail || `MCP test failed with HTTP ${response.status}.`, 'error');
+                return null;
+            }
+            showTestStatus(`${method} completed.`, 'success');
+            return data;
+        } catch (error) {
+            console.warn('Unable to test MCP server.', error);
+            showTestStatus('Unable to reach the MCP test endpoint from this browser.', 'error');
+            return null;
+        }
+    }
+
+    async function listTools() {
+        const method = elements.mcpMethod.value;
+        const data = await sendMcpTest(method, false);
+        if (data && method === 'tools/list') {
+            renderToolList(extractTools(data.result));
+        }
+    }
+
+    async function testSelectedTool() {
+        await sendMcpTest('tools/call', true);
     }
 
     function bindElements() {
@@ -188,6 +341,16 @@
         elements.copyVsCode = getElement('omi-copy-vscode');
         elements.copyPython = getElement('omi-copy-python');
         elements.toggleToken = getElement('omi-toggle-token');
+        elements.mcpMethod = getElement('omi-mcp-method');
+        elements.toolSelect = getElement('omi-tool-select');
+        elements.toolArguments = getElement('omi-tool-arguments');
+        elements.listTools = getElement('omi-list-tools');
+        elements.testTool = getElement('omi-test-tool');
+        elements.copyResult = getElement('omi-copy-result');
+        elements.testStatus = getElement('omi-test-status');
+        elements.toolList = getElement('omi-tools-list');
+        elements.testResult = getElement('omi-test-result');
+        elements.toolCount = getElement('omi-tool-count');
     }
 
     function bindEvents() {
@@ -196,6 +359,10 @@
         elements.clear.addEventListener('click', clearSavedConfig);
         elements.toggleToken.addEventListener('click', toggleTokenVisibility);
         elements.includeToken.addEventListener('change', renderSnippets);
+        elements.listTools.addEventListener('click', listTools);
+        elements.testTool.addEventListener('click', testSelectedTool);
+        elements.toolSelect.addEventListener('change', applySelectedToolExample);
+        elements.copyResult.addEventListener('click', () => copyText(elements.testResult.textContent, 'MCP test result copied.', showTestStatus));
 
         [
             elements.enabled,

--- a/static/site.css
+++ b/static/site.css
@@ -990,6 +990,18 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
 .ai-reference dd { margin:0; min-width:0; overflow-wrap:anywhere; }
 .ai-reference details { border-top:1px solid var(--rci-border); padding-top:.75rem; }
 .ai-snippet-grid { margin-top:.75rem; }
+.ai-mcp-console { margin-top:1rem; }
+.ai-console-header { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem; margin-bottom:1rem; }
+.ai-console-header h2 { margin:0 0 .25rem; }
+.ai-test-grid { margin-top:.75rem; }
+.ai-tool-results { display:grid; grid-template-columns:minmax(260px, .9fr) minmax(0, 1.1fr); gap:1rem; margin-top:1rem; }
+.ai-tool-results h4 { margin:.1rem 0 .5rem; }
+.ai-tool-list { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface-alt); padding:.75rem; min-height:180px; max-height:360px; overflow:auto; }
+.ai-tool-card { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); padding:.65rem; margin-bottom:.6rem; }
+.ai-tool-card:last-child { margin-bottom:0; }
+.ai-tool-card h5 { margin:0 0 .25rem; font-size:.95rem; }
+.ai-tool-card p { margin:.15rem 0 .4rem; color:var(--rci-text-muted); }
+.ai-tool-card small { color:var(--rci-text-muted); overflow-wrap:anywhere; }
 .ai-code-block { white-space:pre; font-family:monospace; font-size:.85rem; line-height:1.45; max-height:360px; }
 .status-message.success { color:#1b7f3a; }
 .status-message.warning { color:#a86400; }
@@ -1002,5 +1014,7 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
   .ai-form-header { flex-direction:column; align-items:flex-start; }
   .ai-hero-status { justify-content:flex-start; }
   .ai-two-column,
-  .ai-form-grid { grid-template-columns:1fr; }
+  .ai-form-grid,
+  .ai-tool-results { grid-template-columns:1fr; }
+  .ai-console-header { flex-direction:column; }
 }

--- a/tests/core/test_mcp_ai_features.py
+++ b/tests/core/test_mcp_ai_features.py
@@ -1,0 +1,146 @@
+"""Tests for the AI Features MCP test endpoint."""
+
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+
+REQUIRED_VARS = {
+    "AZURE_SQL_SERVER": "stub.server.local",
+    "AZURE_SQL_PORT": "1433",
+    "AZURE_SQL_USER": "test",
+    "AZURE_SQL_PASSWORD": "secret",
+    "AZURE_SQL_DATABASE": "testdb",
+}
+
+for key, value in REQUIRED_VARS.items():
+    os.environ.setdefault(key, value)
+
+
+class FakeUserStore:
+    def __init__(self, main):
+        self.users = {
+            "techno": {"id": 2, "username": "Techno", "role": main.ROLE_ADMIN, "password_hash": None},
+        }
+
+    def get_user_by_username(self, username):
+        user = self.users.get(username.lower())
+        return dict(user) if user else None
+
+    def set_user_password_hash(self, user_id, password_hash):
+        for user in self.users.values():
+            if user["id"] == user_id:
+                user["password_hash"] = password_hash
+
+    def record_user_login(self, user_id):
+        return None
+
+
+class FakeMcpResponse:
+    def __init__(self, payload, headers=None):
+        self._payload = payload
+        self.headers = headers or {"Content-Type": "application/json"}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+def load_main(monkeypatch):
+    main = importlib.import_module("main")
+    monkeypatch.setattr(main, "db_manager", FakeUserStore(main))
+    return main
+
+
+def login_admin(client):
+    response = client.post(
+        "/login",
+        json={"username": "Techno", "password": "", "new_password": "techno-secret"},
+    )
+    assert response.status_code == 204
+
+
+def test_mcp_test_endpoint_requires_admin(monkeypatch):
+    main = load_main(monkeypatch)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/ai/mcp/test",
+        json={"url": "https://api.omi.me/v1/mcp/sse", "method": "tools/list"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_mcp_test_endpoint_lists_tools(monkeypatch):
+    main = load_main(monkeypatch)
+    posted_methods = []
+
+    def fake_post(url, json, headers, timeout):
+        posted_methods.append(json["method"])
+        assert url == "https://api.omi.me/v1/mcp/sse"
+        assert headers["Authorization"] == "Bearer omi_mcp_test"
+        if json["method"] == "initialize":
+            return FakeMcpResponse({"jsonrpc": "2.0", "id": "init", "result": {"capabilities": {}}})
+        return FakeMcpResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": "test",
+                "result": {
+                    "tools": [
+                        {
+                            "name": "search_memories",
+                            "description": "Search memories",
+                            "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                        }
+                    ]
+                },
+            }
+        )
+
+    monkeypatch.setattr(main.requests, "post", fake_post)
+    client = TestClient(main.app)
+    login_admin(client)
+
+    response = client.post(
+        "/ai/mcp/test",
+        json={"url": "https://api.omi.me/v1/mcp/sse", "token": "omi_mcp_test", "method": "tools/list"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["result"]["result"]["tools"][0]["name"] == "search_memories"
+    assert posted_methods == ["initialize", "tools/list"]
+
+
+def test_mcp_test_endpoint_calls_selected_tool(monkeypatch):
+    main = load_main(monkeypatch)
+    captured_call = {}
+
+    def fake_post(url, json, headers, timeout):
+        if json["method"] == "tools/call":
+            captured_call.update(json["params"])
+            return FakeMcpResponse({"jsonrpc": "2.0", "id": "test", "result": {"content": [{"type": "text", "text": "ok"}]}})
+        return FakeMcpResponse({"jsonrpc": "2.0", "id": "init", "result": {"capabilities": {}}})
+
+    monkeypatch.setattr(main.requests, "post", fake_post)
+    client = TestClient(main.app)
+    login_admin(client)
+
+    response = client.post(
+        "/ai/mcp/test",
+        json={
+            "url": "https://api.omi.me/v1/mcp/sse",
+            "method": "tools/call",
+            "tool_name": "search_memories",
+            "arguments": {"query": "road", "limit": 2},
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured_call == {"name": "search_memories", "arguments": {"query": "road", "limit": 2}}
+    assert response.json()["result"]["result"]["content"][0]["text"] == "ok"


### PR DESCRIPTION
### Motivation

- Provide a way to discover and exercise MCP (Model Context Protocol) servers from the AI Features page so operators can inspect available tools/functions and run quick test calls. 
- Keep network calls gated to administrators and avoid exposing bearer tokens or server details accidentally in public pages.

### Description

- Added an admin-only proxy endpoint `POST /ai/mcp/test` with request model `McpToolTestRequest` and helpers `_mcp_json_rpc_payload`, `_post_mcp_json_rpc`, and `_mcp_extract_json_response` to build JSON-RPC payloads, handle SSE/JSON responses, and forward MCP session IDs when available. 
- Extended the AI Features UI (`static/ai-features.html`) with a new MCP console to choose discovery methods, list tools/prompts/resources, select a tool, supply JSON arguments, and display/copy results. 
- Implemented client logic in `static/ai-features.js` to validate/serialize tool arguments, render discovered tools and schemas, populate example arguments from schemas, call the new `/ai/mcp/test` proxy, and show status/results. 
- Added responsive styling for the console and tool cards in `static/site.css` and included unit tests in `tests/core/test_mcp_ai_features.py` covering admin protection, discovery listing, and tool call behavior. 

### Testing

- Ran `pytest tests/core/test_mcp_ai_features.py` and the suite for the new test file passed (`3 passed`).
- Ran `python -m py_compile main.py` to validate syntax and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf8a75a70832091db9d13b693230a)