### PR TITLE
Redesign AI Features workspace

### DIFF
--- a/static/ai-features.html
+++ b/static/ai-features.html
@@ -15,216 +15,281 @@
 
 <section class="rci-card ai-hero" aria-labelledby="ai-features-title">
     <div>
-        <p class="eyebrow">External agents, MCP servers, and assistant workflows</p>
-        <h2 id="ai-features-title">Configure AI integrations from one place</h2>
-        <p class="rci-muted">Use this page to plan AI functionality, manage connection details for external assistants, and prepare MCP server configuration snippets. The first available integration is Omi MCP.</p>
+        <p class="eyebrow">Agent and MCP service workspace</p>
+        <h2 id="ai-features-title">Define, compare, and test AI integrations</h2>
+        <p class="rci-muted">Keep a compact overview of agent profiles and MCP services, expand only the configuration or test section you need, and store reusable setup details in this browser.</p>
     </div>
-    <div class="ai-hero-status" aria-label="Configured AI feature areas">
-        <span>🤖 Agents</span>
-        <span>🔌 MCP Servers</span>
-        <span>⚙️ Functionality</span>
+    <div class="ai-hero-status" aria-label="AI feature summary">
+        <span id="agent-summary-pill">🤖 0 agents</span>
+        <span id="mcp-summary-pill">🔌 0 MCP services</span>
+        <span id="enabled-summary-pill">✅ 0 enabled</span>
     </div>
 </section>
 
-<section class="ai-feature-grid" aria-label="AI feature areas">
-    <article class="rci-card ai-feature-card">
-        <h2>External Agents</h2>
-        <p>Reserve connection profiles for assistants such as desktop IDE agents, hosted copilots, and local workflow runners.</p>
-        <ul>
-            <li>Provider and agent name</li>
-            <li>Allowed tools and scopes</li>
-            <li>Default prompt or handoff notes</li>
-        </ul>
-        <span class="pill muted">Planned</span>
+<section class="ai-overview-grid" aria-label="AI configuration overview">
+    <article class="rci-card ai-overview-card">
+        <span class="ai-overview-icon">🤖</span>
+        <div>
+            <h2>Agents</h2>
+            <p id="agent-overview-text">Create profiles for IDE assistants, local workflow runners, hosted copilots, or custom automations.</p>
+        </div>
     </article>
-    <article class="rci-card ai-feature-card ai-feature-card-active">
-        <h2>MCP Servers</h2>
-        <p>Configure Model Context Protocol servers that agents can use for memories, conversation search, or other context tools.</p>
-        <ul>
-            <li>Server URL and transport</li>
-            <li>Bearer token authorization</li>
-            <li>Client-ready config snippets</li>
-        </ul>
-        <span class="pill success">Omi available</span>
+    <article class="rci-card ai-overview-card">
+        <span class="ai-overview-icon">🔌</span>
+        <div>
+            <h2>MCP services</h2>
+            <p id="mcp-overview-text">Manage service URLs, transports, auth headers, snippets, and live tool tests.</p>
+        </div>
     </article>
-    <article class="rci-card ai-feature-card">
-        <h2>Functionality</h2>
-        <p>Track higher-level AI capabilities you may enable later, such as summarization, road-condition insights, and memo workflows.</p>
-        <ul>
-            <li>Feature toggles</li>
-            <li>Task templates</li>
-            <li>Safety and privacy notes</li>
-        </ul>
-        <span class="pill muted">Planned</span>
+    <article class="rci-card ai-overview-card">
+        <span class="ai-overview-icon">🧪</span>
+        <div>
+            <h2>Test bench</h2>
+            <p>Use collapsible test panels to validate handoff prompts, list MCP tools, and call selected MCP functions.</p>
+        </div>
     </article>
 </section>
 
-<div class="section ai-section">
-    <div class="section-header" onclick="toggleSection('omi-mcp')">
-        <span>🔌 Omi MCP Server</span>
-        <span class="section-toggle" id="omi-mcp-toggle">▶</span>
-    </div>
-    <div class="section-content" id="omi-mcp-content">
-        <div class="ai-two-column">
-            <form id="omi-mcp-form" class="ai-config-form" autocomplete="off">
-                <div class="ai-form-header">
-                    <div>
-                        <h2>Connection settings</h2>
-                        <p class="rci-muted">Store Omi MCP connection details in this browser so you can generate client configuration snippets without retyping them.</p>
-                    </div>
-                    <label class="toggle-row">
-                        <input type="checkbox" id="omi-enabled">
-                        <span>Enabled</span>
-                    </label>
-                </div>
-
-                <div class="ai-form-grid">
-                    <label>
-                        <span>Display name</span>
-                        <input type="text" id="omi-display-name" value="Omi" maxlength="80">
-                    </label>
-                    <label>
-                        <span>Server key</span>
-                        <input type="text" id="omi-server-key" value="omi" maxlength="40" pattern="[a-zA-Z0-9_-]+">
-                    </label>
-                    <label class="full-width">
-                        <span>MCP URL</span>
-                        <input type="url" id="omi-url" value="https://api.omi.me/v1/mcp/sse" required>
-                    </label>
-                    <label>
-                        <span>VS Code server type</span>
-                        <select id="omi-vscode-type">
-                            <option value="sse" selected>SSE</option>
-                            <option value="http">HTTP</option>
-                        </select>
-                    </label>
-                    <label>
-                        <span>SDK transport</span>
-                        <select id="omi-transport">
-                            <option value="streamable_http" selected>Streamable HTTP</option>
-                            <option value="sse">SSE</option>
-                        </select>
-                    </label>
-                    <label class="full-width">
-                        <span>Bearer token</span>
-                        <div class="secret-input-row">
-                            <input type="password" id="omi-token" placeholder="omi_mcp_..." pattern="omi_mcp_.+" aria-describedby="omi-token-help">
-                            <button type="button" id="omi-toggle-token" class="secondary-button">Show</button>
-                        </div>
-                        <small id="omi-token-help">Create the key in the Omi app under Settings → Developer → MCP. Token values remain in browser local storage only.</small>
-                    </label>
-                    <label class="full-width">
-                        <span>Notes</span>
-                        <textarea id="omi-notes" rows="3" placeholder="Usage notes, owner, or scope restrictions"></textarea>
-                    </label>
-                </div>
-
-                <div class="ai-form-actions">
-                    <button type="submit" class="focus-ring">Save Omi MCP settings</button>
-                    <button type="button" id="omi-reset" class="secondary-button focus-ring">Reset defaults</button>
-                    <button type="button" id="omi-clear" class="secondary-button focus-ring">Clear saved settings</button>
-                </div>
-                <div id="omi-status" class="status-message" role="status" aria-live="polite"></div>
-            </form>
-
-            <aside class="ai-reference rci-card" aria-labelledby="omi-reference-title">
-                <h2 id="omi-reference-title">Omi quick reference</h2>
-                <dl>
-                    <dt>Website</dt>
-                    <dd><a href="https://omi.me" target="_blank" rel="noopener">omi.me</a></dd>
-                    <dt>Docs</dt>
-                    <dd><a href="https://docs.omi.me" target="_blank" rel="noopener">docs.omi.me</a></dd>
-                    <dt>Auth</dt>
-                    <dd>Bearer token in the <code>Authorization</code> header</dd>
-                    <dt>Key format</dt>
-                    <dd><code>omi_mcp_...</code></dd>
-                    <dt>Tools</dt>
-                    <dd>Memories and conversations: list, semantic search, create/edit/delete memories, and transcript lookup.</dd>
-                </dl>
-                <details>
-                    <summary>Error codes</summary>
-                    <ul>
-                        <li><code>-32602</code>: invalid parameters</li>
-                        <li><code>-32001</code>: resource not found</li>
-                        <li><code>-32002</code>: locked content</li>
-                        <li><code>-32601</code>: unknown tool name</li>
-                    </ul>
-                </details>
-            </aside>
-        </div>
-
-        <div class="ai-snippet-toolbar">
-            <label><input type="checkbox" id="omi-include-token"> Include saved token in snippets</label>
-            <button type="button" id="omi-copy-vscode" class="secondary-button focus-ring">Copy VS Code config</button>
-            <button type="button" id="omi-copy-python" class="secondary-button focus-ring">Copy Python SDK example</button>
-        </div>
-
-        <div class="compare-grid ai-snippet-grid">
-            <div class="json-col">
-                <h4>VS Code <code>.vscode/mcp.json</code></h4>
-                <pre id="omi-vscode-snippet" class="result-box ai-code-block" tabindex="0"></pre>
+<section class="ai-workspace" aria-label="AI workspace">
+    <aside class="rci-card ai-inventory" aria-labelledby="ai-inventory-title">
+        <div class="ai-panel-title-row">
+            <div>
+                <p class="eyebrow">Overview</p>
+                <h2 id="ai-inventory-title">Saved configurations</h2>
             </div>
-            <div class="json-col">
-                <h4>Python SDK example</h4>
-                <pre id="omi-python-snippet" class="result-box ai-code-block" tabindex="0"></pre>
-            </div>
+            <button type="button" id="ai-reset-all" class="secondary-button focus-ring">Reset all</button>
         </div>
 
-        <section class="rci-card ai-mcp-console" aria-labelledby="omi-mcp-console-title">
-            <div class="ai-console-header">
+        <div class="ai-inventory-group">
+            <div class="ai-inventory-heading">
+                <h3>Agents</h3>
+                <button type="button" id="add-agent" class="focus-ring">Add agent</button>
+            </div>
+            <div id="agent-list" class="ai-config-list" role="listbox" aria-label="Agent configurations"></div>
+        </div>
+
+        <div class="ai-inventory-group">
+            <div class="ai-inventory-heading">
+                <h3>MCP services</h3>
+                <button type="button" id="add-mcp" class="focus-ring">Add MCP</button>
+            </div>
+            <div id="mcp-list" class="ai-config-list" role="listbox" aria-label="MCP service configurations"></div>
+        </div>
+    </aside>
+
+    <main class="ai-editor-stack">
+        <section class="rci-card ai-editor-card" aria-labelledby="agent-editor-title">
+            <div class="ai-editor-header">
                 <div>
-                    <h2 id="omi-mcp-console-title">MCP tools and function tester</h2>
-                    <p class="rci-muted">List the tools exposed by the configured MCP server, inspect their schemas, and run a small test call through the Road Condition Indexer admin proxy.</p>
+                    <p class="eyebrow">Agent configuration</p>
+                    <h2 id="agent-editor-title">Define an agent profile</h2>
+                    <p class="rci-muted">Store provider details, allowed scopes, default instructions, and a reusable test scenario.</p>
                 </div>
-                <span id="omi-tool-count" class="pill muted">No tools loaded</span>
+                <span id="selected-agent-pill" class="pill muted">No agent selected</span>
             </div>
 
-            <div class="ai-form-grid ai-test-grid">
-                <label>
-                    <span>Discovery method</span>
-                    <select id="omi-mcp-method">
-                        <option value="tools/list" selected>List tools / functions</option>
-                        <option value="prompts/list">List prompts</option>
-                        <option value="resources/list">List resources</option>
-                        <option value="initialize">Initialize only</option>
-                    </select>
-                </label>
-                <label>
-                    <span>Tool to test</span>
-                    <select id="omi-tool-select">
-                        <option value="">Load tools to populate options</option>
-                    </select>
-                </label>
-                <label class="full-width">
-                    <span>Tool arguments JSON</span>
-                    <textarea id="omi-tool-arguments" rows="6" spellcheck="false">{
+            <details class="ai-collapse" open>
+                <summary>Configuration</summary>
+                <form id="agent-form" class="ai-config-form" autocomplete="off">
+                    <div class="ai-form-header compact">
+                        <label class="toggle-row"><input type="checkbox" id="agent-enabled"> <span>Enabled</span></label>
+                        <button type="button" id="delete-agent" class="danger-button focus-ring">Remove agent</button>
+                    </div>
+                    <div class="ai-form-grid">
+                        <label>
+                            <span>Display name</span>
+                            <input type="text" id="agent-name" maxlength="80" required>
+                        </label>
+                        <label>
+                            <span>Provider</span>
+                            <input type="text" id="agent-provider" maxlength="80" placeholder="OpenAI, Claude, Cursor, local runner">
+                        </label>
+                        <label>
+                            <span>Agent key</span>
+                            <input type="text" id="agent-key" maxlength="50" pattern="[a-zA-Z0-9_-]+" required>
+                        </label>
+                        <label>
+                            <span>Runtime / model</span>
+                            <input type="text" id="agent-runtime" maxlength="100" placeholder="gpt-4.1, desktop IDE, workflow runner">
+                        </label>
+                        <label class="full-width">
+                            <span>Allowed tools and scopes</span>
+                            <input type="text" id="agent-tools" maxlength="240" placeholder="read logs, query MCP memories, summarize road events">
+                        </label>
+                        <label class="full-width">
+                            <span>Default instructions</span>
+                            <textarea id="agent-instructions" rows="4" placeholder="Describe the agent role, guardrails, and handoff notes."></textarea>
+                        </label>
+                        <label class="full-width">
+                            <span>Notes</span>
+                            <textarea id="agent-notes" rows="3" placeholder="Owner, environment, privacy notes, or rollout status."></textarea>
+                        </label>
+                    </div>
+                    <div class="ai-form-actions">
+                        <button type="submit" class="focus-ring">Save agent</button>
+                        <button type="button" id="new-agent" class="secondary-button focus-ring">New blank agent</button>
+                    </div>
+                    <div id="agent-status" class="status-message" role="status" aria-live="polite"></div>
+                </form>
+            </details>
+
+            <details class="ai-collapse">
+                <summary>Test agent handoff</summary>
+                <div class="ai-test-panel">
+                    <div class="ai-form-grid">
+                        <label class="full-width">
+                            <span>Scenario</span>
+                            <textarea id="agent-test-scenario" rows="4" placeholder="Ask this agent to investigate a road-condition anomaly and summarize next steps."></textarea>
+                        </label>
+                    </div>
+                    <div class="ai-form-actions">
+                        <button type="button" id="run-agent-test" class="focus-ring">Generate handoff test</button>
+                        <button type="button" id="copy-agent-test" class="secondary-button focus-ring">Copy test package</button>
+                    </div>
+                    <div id="agent-test-status" class="status-message" role="status" aria-live="polite"></div>
+                    <pre id="agent-test-result" class="result-box ai-code-block" tabindex="0"></pre>
+                </div>
+            </details>
+        </section>
+
+        <section class="rci-card ai-editor-card" aria-labelledby="mcp-editor-title">
+            <div class="ai-editor-header">
+                <div>
+                    <p class="eyebrow">MCP service configuration</p>
+                    <h2 id="mcp-editor-title">Define an MCP service</h2>
+                    <p class="rci-muted">Save connection settings, generate client snippets, and test service capabilities through the admin proxy.</p>
+                </div>
+                <span id="selected-mcp-pill" class="pill muted">No MCP selected</span>
+            </div>
+
+            <details class="ai-collapse" open>
+                <summary>Configuration</summary>
+                <form id="mcp-form" class="ai-config-form" autocomplete="off">
+                    <div class="ai-form-header compact">
+                        <label class="toggle-row"><input type="checkbox" id="mcp-enabled"> <span>Enabled</span></label>
+                        <button type="button" id="delete-mcp" class="danger-button focus-ring">Remove MCP</button>
+                    </div>
+                    <div class="ai-form-grid">
+                        <label>
+                            <span>Display name</span>
+                            <input type="text" id="mcp-name" maxlength="80" required>
+                        </label>
+                        <label>
+                            <span>Server key</span>
+                            <input type="text" id="mcp-key" maxlength="50" pattern="[a-zA-Z0-9_-]+" required>
+                        </label>
+                        <label class="full-width">
+                            <span>MCP URL</span>
+                            <input type="url" id="mcp-url" required>
+                        </label>
+                        <label>
+                            <span>VS Code server type</span>
+                            <select id="mcp-vscode-type">
+                                <option value="sse">SSE</option>
+                                <option value="http">HTTP</option>
+                            </select>
+                        </label>
+                        <label>
+                            <span>SDK transport</span>
+                            <select id="mcp-transport">
+                                <option value="streamable_http">Streamable HTTP</option>
+                                <option value="sse">SSE</option>
+                            </select>
+                        </label>
+                        <label class="full-width">
+                            <span>Bearer token</span>
+                            <div class="secret-input-row">
+                                <input type="password" id="mcp-token" placeholder="token value stored in this browser only">
+                                <button type="button" id="mcp-toggle-token" class="secondary-button">Show</button>
+                            </div>
+                            <small>Tokens remain in browser local storage. Leave blank for unauthenticated local services.</small>
+                        </label>
+                        <label class="full-width">
+                            <span>Notes</span>
+                            <textarea id="mcp-notes" rows="3" placeholder="Docs link, owner, tool scope, or environment notes."></textarea>
+                        </label>
+                    </div>
+                    <div class="ai-form-actions">
+                        <button type="submit" class="focus-ring">Save MCP service</button>
+                        <button type="button" id="new-mcp" class="secondary-button focus-ring">New blank MCP</button>
+                    </div>
+                    <div id="mcp-status" class="status-message" role="status" aria-live="polite"></div>
+                </form>
+            </details>
+
+            <details class="ai-collapse">
+                <summary>Generated snippets</summary>
+                <div class="ai-test-panel">
+                    <div class="ai-snippet-toolbar">
+                        <label><input type="checkbox" id="mcp-include-token"> Include saved token in snippets</label>
+                        <button type="button" id="copy-vscode" class="secondary-button focus-ring">Copy VS Code config</button>
+                        <button type="button" id="copy-python" class="secondary-button focus-ring">Copy Python SDK example</button>
+                    </div>
+                    <div class="compare-grid ai-snippet-grid">
+                        <div class="json-col">
+                            <h4>VS Code <code>.vscode/mcp.json</code></h4>
+                            <pre id="vscode-snippet" class="result-box ai-code-block" tabindex="0"></pre>
+                        </div>
+                        <div class="json-col">
+                            <h4>Python SDK example</h4>
+                            <pre id="python-snippet" class="result-box ai-code-block" tabindex="0"></pre>
+                        </div>
+                    </div>
+                </div>
+            </details>
+
+            <details class="ai-collapse">
+                <summary>MCP tools and function tester</summary>
+                <div class="ai-test-panel">
+                    <div class="ai-console-header">
+                        <p class="rci-muted">List tools exposed by the selected service, inspect schemas, and run a small test call.</p>
+                        <span id="tool-count" class="pill muted">No tools loaded</span>
+                    </div>
+                    <div class="ai-form-grid ai-test-grid">
+                        <label>
+                            <span>Discovery method</span>
+                            <select id="mcp-method">
+                                <option value="tools/list" selected>List tools / functions</option>
+                                <option value="prompts/list">List prompts</option>
+                                <option value="resources/list">List resources</option>
+                                <option value="initialize">Initialize only</option>
+                            </select>
+                        </label>
+                        <label>
+                            <span>Tool to test</span>
+                            <select id="tool-select">
+                                <option value="">Load tools to populate options</option>
+                            </select>
+                        </label>
+                        <label class="full-width">
+                            <span>Tool arguments JSON</span>
+                            <textarea id="tool-arguments" rows="6" spellcheck="false">{
   "query": "morning routine",
   "limit": 5
 }</textarea>
-                </label>
-            </div>
-
-            <div class="ai-form-actions">
-                <button type="button" id="omi-list-tools" class="focus-ring">List MCP tools / functions</button>
-                <button type="button" id="omi-test-tool" class="secondary-button focus-ring">Test selected tool</button>
-                <button type="button" id="omi-copy-result" class="secondary-button focus-ring">Copy result</button>
-            </div>
-            <div id="omi-test-status" class="status-message" role="status" aria-live="polite"></div>
-
-            <div class="ai-tool-results">
-                <div>
-                    <h4>Available tools / functions</h4>
-                    <div id="omi-tools-list" class="ai-tool-list" tabindex="0">Connect to an MCP server to list tools.</div>
+                        </label>
+                    </div>
+                    <div class="ai-form-actions">
+                        <button type="button" id="list-tools" class="focus-ring">List MCP tools / functions</button>
+                        <button type="button" id="test-tool" class="secondary-button focus-ring">Test selected tool</button>
+                        <button type="button" id="copy-result" class="secondary-button focus-ring">Copy result</button>
+                    </div>
+                    <div id="mcp-test-status" class="status-message" role="status" aria-live="polite"></div>
+                    <div class="ai-tool-results">
+                        <div>
+                            <h4>Available tools / functions</h4>
+                            <div id="tools-list" class="ai-tool-list" tabindex="0">Connect to an MCP server to list tools.</div>
+                        </div>
+                        <div>
+                            <h4>Test response</h4>
+                            <pre id="test-result" class="result-box ai-code-block" tabindex="0"></pre>
+                        </div>
+                    </div>
                 </div>
-                <div>
-                    <h4>Test response</h4>
-                    <pre id="omi-test-result" class="result-box ai-code-block" tabindex="0"></pre>
-                </div>
-            </div>
+            </details>
         </section>
-
-    </div>
-</div>
+    </main>
+</section>
 
 </body>
 </html>

--- a/static/ai-features.js
+++ b/static/ai-features.js
@@ -1,255 +1,548 @@
 (function () {
-    const STORAGE_KEY = 'rci.ai.omiMcpConfig';
-    const DEFAULT_CONFIG = {
-        enabled: false,
-        displayName: 'Omi',
-        serverKey: 'omi',
+    const STORAGE_KEY = 'rci.ai.workspaceConfig.v1';
+    const LEGACY_OMI_KEY = 'rci.ai.omiMcpConfig';
+
+    const DEFAULT_AGENT = {
+        id: 'agent-road-analyst',
+        enabled: true,
+        name: 'Road Analyst Agent',
+        provider: 'OpenAI / local workflow',
+        key: 'road_analyst',
+        runtime: 'Configured in client',
+        tools: 'Read logs, inspect road-condition data, use enabled MCP services',
+        instructions: 'Review the current road-condition context, identify anomalies, and return concise operational next steps.',
+        notes: 'Default starter profile. Update it for the assistant or IDE agent you want to use.',
+        testScenario: 'Investigate today\'s newest road-condition anomaly and summarize likely cause, confidence, and next actions.'
+    };
+
+    const DEFAULT_MCP = {
+        id: 'mcp-omi',
+        enabled: true,
+        name: 'Omi',
+        key: 'omi',
         url: 'https://api.omi.me/v1/mcp/sse',
         vscodeType: 'sse',
         transport: 'streamable_http',
         token: '',
-        notes: ''
+        notes: 'Create a key in the Omi app under Settings → Developer → MCP.'
+    };
+
+    const state = {
+        agents: [],
+        mcps: [],
+        selectedAgentId: '',
+        selectedMcpId: ''
     };
 
     const elements = {};
     let discoveredTools = [];
 
-    function getElement(id) {
+    function $(id) {
         return document.getElementById(id);
     }
 
-    function loadSavedConfig() {
-        let raw = '';
-        try {
-            raw = localStorage.getItem(STORAGE_KEY);
-        } catch (error) {
-            console.warn('Unable to read saved Omi MCP config. Falling back to defaults.', error);
-            return { ...DEFAULT_CONFIG };
-        }
-        if (!raw) return { ...DEFAULT_CONFIG };
-        try {
-            const parsed = JSON.parse(raw);
-            return { ...DEFAULT_CONFIG, ...parsed };
-        } catch (error) {
-            console.warn('Invalid saved Omi MCP config. Falling back to defaults.', error);
-            return { ...DEFAULT_CONFIG };
-        }
+    function clone(value) {
+        return JSON.parse(JSON.stringify(value));
     }
 
-    function readFormConfig() {
+    function slugify(value, fallback) {
+        const slug = String(value || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9_-]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+            .slice(0, 50);
+        return slug || fallback;
+    }
+
+    function uniqueId(prefix) {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return `${prefix}-${window.crypto.randomUUID()}`;
+        }
+        return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+    }
+
+    function defaultWorkspace() {
         return {
-            enabled: elements.enabled.checked,
-            displayName: elements.displayName.value.trim() || DEFAULT_CONFIG.displayName,
-            serverKey: elements.serverKey.value.trim() || DEFAULT_CONFIG.serverKey,
-            url: elements.url.value.trim() || DEFAULT_CONFIG.url,
-            vscodeType: elements.vscodeType.value,
-            transport: elements.transport.value,
-            token: elements.token.value.trim(),
-            notes: elements.notes.value.trim()
+            agents: [clone(DEFAULT_AGENT)],
+            mcps: [clone(DEFAULT_MCP)],
+            selectedAgentId: DEFAULT_AGENT.id,
+            selectedMcpId: DEFAULT_MCP.id
         };
     }
 
-    function applyConfig(config) {
-        elements.enabled.checked = Boolean(config.enabled);
-        elements.displayName.value = config.displayName;
-        elements.serverKey.value = config.serverKey;
-        elements.url.value = config.url;
-        elements.vscodeType.value = config.vscodeType;
-        elements.transport.value = config.transport;
-        elements.token.value = config.token;
-        elements.notes.value = config.notes;
+    function migrateLegacyOmi(workspace) {
+        try {
+            const raw = localStorage.getItem(LEGACY_OMI_KEY);
+            if (!raw || workspace.mcps.length) return workspace;
+            const legacy = JSON.parse(raw);
+            const omi = {
+                ...clone(DEFAULT_MCP),
+                enabled: Boolean(legacy.enabled),
+                name: legacy.displayName || DEFAULT_MCP.name,
+                key: legacy.serverKey || DEFAULT_MCP.key,
+                url: legacy.url || DEFAULT_MCP.url,
+                vscodeType: legacy.vscodeType || DEFAULT_MCP.vscodeType,
+                transport: legacy.transport || DEFAULT_MCP.transport,
+                token: legacy.token || '',
+                notes: legacy.notes || DEFAULT_MCP.notes
+            };
+            workspace.mcps = [omi];
+            workspace.selectedMcpId = omi.id;
+        } catch (error) {
+            console.warn('Unable to migrate legacy Omi MCP config.', error);
+        }
+        return workspace;
+    }
+
+    function normalizeWorkspace(workspace) {
+        const defaults = defaultWorkspace();
+        const normalized = {
+            agents: Array.isArray(workspace.agents) ? workspace.agents : defaults.agents,
+            mcps: Array.isArray(workspace.mcps) ? workspace.mcps : defaults.mcps,
+            selectedAgentId: workspace.selectedAgentId || '',
+            selectedMcpId: workspace.selectedMcpId || ''
+        };
+        if (!normalized.agents.length) normalized.agents = defaults.agents;
+        if (!normalized.mcps.length) normalized.mcps = defaults.mcps;
+        normalized.selectedAgentId = normalized.agents.some(agent => agent.id === normalized.selectedAgentId)
+            ? normalized.selectedAgentId
+            : normalized.agents[0].id;
+        normalized.selectedMcpId = normalized.mcps.some(mcp => mcp.id === normalized.selectedMcpId)
+            ? normalized.selectedMcpId
+            : normalized.mcps[0].id;
+        return normalized;
+    }
+
+    function loadWorkspace() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (!raw) return migrateLegacyOmi(defaultWorkspace());
+            return normalizeWorkspace(JSON.parse(raw));
+        } catch (error) {
+            console.warn('Unable to read saved AI workspace config. Falling back to defaults.', error);
+            return defaultWorkspace();
+        }
+    }
+
+    function saveWorkspace() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({
+                agents: state.agents,
+                mcps: state.mcps,
+                selectedAgentId: state.selectedAgentId,
+                selectedMcpId: state.selectedMcpId
+            }));
+            return true;
+        } catch (error) {
+            console.warn('Unable to save AI workspace config.', error);
+            return false;
+        }
+    }
+
+    function selectedAgent() {
+        return state.agents.find(agent => agent.id === state.selectedAgentId) || state.agents[0];
+    }
+
+    function selectedMcp() {
+        return state.mcps.find(mcp => mcp.id === state.selectedMcpId) || state.mcps[0];
+    }
+
+    function setStatus(element, message, type) {
+        element.textContent = message;
+        element.className = `status-message ${type || ''}`.trim();
+    }
+
+    function renderSummary() {
+        const enabledAgents = state.agents.filter(agent => agent.enabled).length;
+        const enabledMcps = state.mcps.filter(mcp => mcp.enabled).length;
+        elements.agentSummaryPill.textContent = `🤖 ${state.agents.length} agent${state.agents.length === 1 ? '' : 's'}`;
+        elements.mcpSummaryPill.textContent = `🔌 ${state.mcps.length} MCP service${state.mcps.length === 1 ? '' : 's'}`;
+        elements.enabledSummaryPill.textContent = `✅ ${enabledAgents + enabledMcps} enabled`;
+        elements.agentOverviewText.textContent = `${enabledAgents} enabled of ${state.agents.length}. Create profiles for IDE assistants, local workflow runners, hosted copilots, or custom automations.`;
+        elements.mcpOverviewText.textContent = `${enabledMcps} enabled of ${state.mcps.length}. Manage service URLs, transports, auth headers, snippets, and live tool tests.`;
+    }
+
+    function configButton(config, selectedId, type) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = `ai-config-item${config.id === selectedId ? ' selected' : ''}`;
+        button.setAttribute('role', 'option');
+        button.setAttribute('aria-selected', config.id === selectedId ? 'true' : 'false');
+        button.dataset.id = config.id;
+        button.dataset.type = type;
+        button.innerHTML = `
+            <span class="ai-config-item-main">
+                <strong>${escapeHtml(config.name || config.key || 'Untitled')}</strong>
+                <small>${escapeHtml(config.provider || config.url || config.runtime || 'No endpoint')}</small>
+            </span>
+            <span class="pill ${config.enabled ? 'success' : 'muted'}">${config.enabled ? 'Enabled' : 'Disabled'}</span>
+        `;
+        return button;
+    }
+
+    function escapeHtml(value) {
+        return String(value).replace(/[&<>'"]/g, character => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            "'": '&#39;',
+            '"': '&quot;'
+        }[character]));
+    }
+
+    function renderLists() {
+        elements.agentList.innerHTML = '';
+        state.agents.forEach(agent => elements.agentList.appendChild(configButton(agent, state.selectedAgentId, 'agent')));
+        elements.mcpList.innerHTML = '';
+        state.mcps.forEach(mcp => elements.mcpList.appendChild(configButton(mcp, state.selectedMcpId, 'mcp')));
+    }
+
+    function applyAgentToForm() {
+        const agent = selectedAgent();
+        elements.agentEnabled.checked = Boolean(agent.enabled);
+        elements.agentName.value = agent.name || '';
+        elements.agentProvider.value = agent.provider || '';
+        elements.agentKey.value = agent.key || '';
+        elements.agentRuntime.value = agent.runtime || '';
+        elements.agentTools.value = agent.tools || '';
+        elements.agentInstructions.value = agent.instructions || '';
+        elements.agentNotes.value = agent.notes || '';
+        elements.agentTestScenario.value = agent.testScenario || '';
+        elements.selectedAgentPill.textContent = agent.name || 'Agent selected';
+        elements.deleteAgent.disabled = state.agents.length <= 1;
+    }
+
+    function applyMcpToForm() {
+        const mcp = selectedMcp();
+        elements.mcpEnabled.checked = Boolean(mcp.enabled);
+        elements.mcpName.value = mcp.name || '';
+        elements.mcpKey.value = mcp.key || '';
+        elements.mcpUrl.value = mcp.url || '';
+        elements.mcpVsCodeType.value = mcp.vscodeType || DEFAULT_MCP.vscodeType;
+        elements.mcpTransport.value = mcp.transport || DEFAULT_MCP.transport;
+        elements.mcpToken.value = mcp.token || '';
+        elements.mcpNotes.value = mcp.notes || '';
+        elements.selectedMcpPill.textContent = mcp.name || 'MCP selected';
+        elements.deleteMcp.disabled = state.mcps.length <= 1;
+        discoveredTools = [];
+        renderToolList([]);
         renderSnippets();
     }
 
-    function getSnippetToken(config) {
-        if (elements.includeToken.checked && config.token) {
-            return config.token;
+    function renderAll() {
+        renderSummary();
+        renderLists();
+        applyAgentToForm();
+        applyMcpToForm();
+    }
+
+    function readAgentForm() {
+        return {
+            ...selectedAgent(),
+            enabled: elements.agentEnabled.checked,
+            name: elements.agentName.value.trim(),
+            provider: elements.agentProvider.value.trim(),
+            key: slugify(elements.agentKey.value, 'agent'),
+            runtime: elements.agentRuntime.value.trim(),
+            tools: elements.agentTools.value.trim(),
+            instructions: elements.agentInstructions.value.trim(),
+            notes: elements.agentNotes.value.trim(),
+            testScenario: elements.agentTestScenario.value.trim()
+        };
+    }
+
+    function readMcpForm() {
+        return {
+            ...selectedMcp(),
+            enabled: elements.mcpEnabled.checked,
+            name: elements.mcpName.value.trim(),
+            key: slugify(elements.mcpKey.value, 'mcp'),
+            url: elements.mcpUrl.value.trim(),
+            vscodeType: elements.mcpVsCodeType.value,
+            transport: elements.mcpTransport.value,
+            token: elements.mcpToken.value.trim(),
+            notes: elements.mcpNotes.value.trim()
+        };
+    }
+
+    function validateKey(key, label) {
+        if (!/^[a-zA-Z0-9_-]+$/.test(key)) return `${label} key can contain letters, numbers, underscores, and hyphens only.`;
+        return '';
+    }
+
+    function validateMcp(config) {
+        const keyError = validateKey(config.key, 'MCP server');
+        if (keyError) return keyError;
+        if (!config.name) return 'MCP display name is required.';
+        if (!config.url) return 'MCP URL is required.';
+        if (!/^https?:\/\//i.test(config.url)) return 'MCP URL should start with http:// or https://.';
+        return '';
+    }
+
+    function validateAgent(config) {
+        const keyError = validateKey(config.key, 'Agent');
+        if (keyError) return keyError;
+        if (!config.name) return 'Agent display name is required.';
+        return '';
+    }
+
+    function updateSelectedAgent(config) {
+        state.agents = state.agents.map(agent => agent.id === state.selectedAgentId ? config : agent);
+    }
+
+    function updateSelectedMcp(config) {
+        state.mcps = state.mcps.map(mcp => mcp.id === state.selectedMcpId ? config : mcp);
+    }
+
+    function saveAgent(event) {
+        event.preventDefault();
+        const config = readAgentForm();
+        const validationError = validateAgent(config);
+        if (validationError) {
+            setStatus(elements.agentStatus, validationError, 'error');
+            return;
         }
+        updateSelectedAgent(config);
+        if (!saveWorkspace()) {
+            setStatus(elements.agentStatus, 'Unable to save agent settings in this browser.', 'error');
+            return;
+        }
+        renderSummary();
+        renderLists();
+        applyAgentToForm();
+        setStatus(elements.agentStatus, `${config.name} saved.`, 'success');
+    }
+
+    function saveMcp(event) {
+        event.preventDefault();
+        const config = readMcpForm();
+        const validationError = validateMcp(config);
+        if (validationError) {
+            setStatus(elements.mcpStatus, validationError, 'error');
+            return;
+        }
+        updateSelectedMcp(config);
+        if (!saveWorkspace()) {
+            setStatus(elements.mcpStatus, 'Unable to save MCP settings in this browser.', 'error');
+            return;
+        }
+        renderSummary();
+        renderLists();
+        applyMcpToForm();
+        setStatus(elements.mcpStatus, `${config.name} saved.`, 'success');
+    }
+
+    function addAgent() {
+        const id = uniqueId('agent');
+        const agent = {
+            ...clone(DEFAULT_AGENT),
+            id,
+            enabled: false,
+            name: 'New Agent',
+            key: slugify(`agent_${state.agents.length + 1}`, 'agent')
+        };
+        state.agents.push(agent);
+        state.selectedAgentId = id;
+        saveWorkspace();
+        renderAll();
+        setStatus(elements.agentStatus, 'New agent created. Update and save its configuration.', 'warning');
+    }
+
+    function addMcp() {
+        const id = uniqueId('mcp');
+        const mcp = {
+            ...clone(DEFAULT_MCP),
+            id,
+            enabled: false,
+            name: 'New MCP Service',
+            key: slugify(`mcp_${state.mcps.length + 1}`, 'mcp'),
+            url: 'https://example.com/mcp'
+        };
+        state.mcps.push(mcp);
+        state.selectedMcpId = id;
+        saveWorkspace();
+        renderAll();
+        setStatus(elements.mcpStatus, 'New MCP service created. Update and save its configuration.', 'warning');
+    }
+
+    function deleteSelectedAgent() {
+        if (state.agents.length <= 1) return;
+        const removed = selectedAgent();
+        state.agents = state.agents.filter(agent => agent.id !== state.selectedAgentId);
+        state.selectedAgentId = state.agents[0].id;
+        saveWorkspace();
+        renderAll();
+        setStatus(elements.agentStatus, `${removed.name} removed.`, 'success');
+    }
+
+    function deleteSelectedMcp() {
+        if (state.mcps.length <= 1) return;
+        const removed = selectedMcp();
+        state.mcps = state.mcps.filter(mcp => mcp.id !== state.selectedMcpId);
+        state.selectedMcpId = state.mcps[0].id;
+        saveWorkspace();
+        renderAll();
+        setStatus(elements.mcpStatus, `${removed.name} removed.`, 'success');
+    }
+
+    function resetAll() {
+        const fresh = defaultWorkspace();
+        state.agents = fresh.agents;
+        state.mcps = fresh.mcps;
+        state.selectedAgentId = fresh.selectedAgentId;
+        state.selectedMcpId = fresh.selectedMcpId;
+        saveWorkspace();
+        renderAll();
+        setStatus(elements.agentStatus, 'AI workspace reset to defaults.', 'warning');
+        setStatus(elements.mcpStatus, 'AI workspace reset to defaults.', 'warning');
+    }
+
+    function selectConfig(event) {
+        const button = event.target.closest('.ai-config-item');
+        if (!button) return;
+        if (button.dataset.type === 'agent') {
+            state.selectedAgentId = button.dataset.id;
+            applyAgentToForm();
+            renderLists();
+            setStatus(elements.agentStatus, '', '');
+        } else {
+            state.selectedMcpId = button.dataset.id;
+            applyMcpToForm();
+            renderLists();
+            setStatus(elements.mcpStatus, '', '');
+            setStatus(elements.mcpTestStatus, '', '');
+            elements.testResult.textContent = '';
+        }
+        saveWorkspace();
+    }
+
+    function getSnippetToken(config) {
+        if (elements.mcpIncludeToken.checked && config.token) return config.token;
         return '<key>';
     }
 
     function buildVsCodeSnippet(config) {
         const token = getSnippetToken(config);
-        const serverKey = config.serverKey || DEFAULT_CONFIG.serverKey;
-        return JSON.stringify({
-            servers: {
-                [serverKey]: {
-                    type: config.vscodeType,
-                    url: config.url,
-                    headers: {
-                        Authorization: `Bearer ${token}`
-                    }
-                }
-            }
-        }, null, 2);
+        const server = {
+            type: config.vscodeType,
+            url: config.url
+        };
+        if (config.token || elements.mcpIncludeToken.checked) {
+            server.headers = { Authorization: `Bearer ${token}` };
+        }
+        return JSON.stringify({ servers: { [config.key || DEFAULT_MCP.key]: server } }, null, 2);
     }
 
     function buildPythonSnippet(config) {
-        const token = getSnippetToken(config) === '<key>' ? 'omi_mcp_YOUR_KEY' : config.token;
-        const serverKey = config.serverKey || DEFAULT_CONFIG.serverKey;
-        return `from langchain_mcp_adapters.client import MultiServerMCPClient\n\nasync with MultiServerMCPClient({\n    "${serverKey}": {\n        "url": "${config.url}",\n        "transport": "${config.transport}",\n        "headers": {"Authorization": "Bearer ${token}"},\n    }\n}) as client:\n    tools = client.get_tools()\n    result = await client.call_tool("${serverKey}", "search_memories", {\n        "query": "morning routine",\n        "limit": 5,\n    })`;
+        const token = getSnippetToken(config) === '<key>' ? 'YOUR_MCP_TOKEN' : config.token;
+        const headersLine = config.token || elements.mcpIncludeToken.checked
+            ? `,\n        "headers": {"Authorization": "Bearer ${token}"}`
+            : '';
+        return `from langchain_mcp_adapters.client import MultiServerMCPClient\n\nasync with MultiServerMCPClient({\n    "${config.key}": {\n        "url": "${config.url}",\n        "transport": "${config.transport}"${headersLine},\n    }\n}) as client:\n    tools = client.get_tools()\n    # result = await client.call_tool("${config.key}", "tool_name", {"example": "value"})`;
     }
 
     function renderSnippets() {
-        const config = readFormConfig();
+        const config = readMcpForm();
         elements.vscodeSnippet.textContent = buildVsCodeSnippet(config);
         elements.pythonSnippet.textContent = buildPythonSnippet(config);
     }
 
-    function showStatus(message, type) {
-        elements.status.textContent = message;
-        elements.status.className = `status-message ${type || ''}`.trim();
-    }
-
-    function showTestStatus(message, type) {
-        elements.testStatus.textContent = message;
-        elements.testStatus.className = `status-message ${type || ''}`.trim();
-    }
-
-    function validateConfig(config) {
-        if (!config.url.startsWith('https://')) {
-            return 'MCP URL should use HTTPS.';
-        }
-        if (config.token && !config.token.startsWith('omi_mcp_')) {
-            return 'Omi MCP tokens should start with omi_mcp_.';
-        }
-        if (!/^[a-zA-Z0-9_-]+$/.test(config.serverKey)) {
-            return 'Server key can contain letters, numbers, underscores, and hyphens only.';
-        }
-        return '';
-    }
-
-    function saveConfig(event) {
-        event.preventDefault();
-        const config = readFormConfig();
-        const validationError = validateConfig(config);
-        if (validationError) {
-            showStatus(validationError, 'error');
-            return;
-        }
-        try {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
-        } catch (error) {
-            console.warn('Unable to save Omi MCP config.', error);
-            showStatus('Unable to save settings in this browser.', 'error');
-            return;
-        }
-        renderSnippets();
-        showStatus('Omi MCP settings saved in this browser.', 'success');
-    }
-
-    function resetDefaults() {
-        applyConfig({ ...DEFAULT_CONFIG });
-        showStatus('Omi MCP settings reset to defaults. Save to keep these values.', 'warning');
-    }
-
-    function clearSavedConfig() {
-        try {
-            localStorage.removeItem(STORAGE_KEY);
-        } catch (error) {
-            console.warn('Unable to clear saved Omi MCP config.', error);
-            showStatus('Unable to clear saved settings in this browser.', 'error');
-            return;
-        }
-        applyConfig({ ...DEFAULT_CONFIG });
-        showStatus('Saved Omi MCP settings cleared from this browser.', 'success');
-    }
-
     async function copyText(text, successMessage, statusTarget) {
-        if (!navigator.clipboard) {
-            (statusTarget || showStatus)('Clipboard access is not available in this browser.', 'error');
+        if (!text) {
+            statusTarget('Nothing to copy yet.', 'warning');
             return;
         }
         try {
             await navigator.clipboard.writeText(text);
-            (statusTarget || showStatus)(successMessage, 'success');
+            statusTarget(successMessage, 'success');
         } catch (error) {
-            console.warn('Unable to copy AI config snippet.', error);
-            (statusTarget || showStatus)('Unable to copy snippet to the clipboard.', 'error');
+            console.warn('Clipboard copy failed.', error);
+            statusTarget('Copy failed. Select the text manually.', 'error');
         }
     }
 
     function toggleTokenVisibility() {
-        const showing = elements.token.type === 'text';
-        elements.token.type = showing ? 'password' : 'text';
-        elements.toggleToken.textContent = showing ? 'Show' : 'Hide';
+        const isHidden = elements.mcpToken.type === 'password';
+        elements.mcpToken.type = isHidden ? 'text' : 'password';
+        elements.mcpToggleToken.textContent = isHidden ? 'Hide' : 'Show';
     }
 
-    function parseArgumentsJson() {
-        const raw = elements.toolArguments.value.trim();
-        if (!raw) return {};
-        try {
-            const parsed = JSON.parse(raw);
-            if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
-                throw new Error('Arguments must be a JSON object.');
-            }
-            return parsed;
-        } catch (error) {
-            throw new Error(`Invalid tool arguments JSON: ${error.message}`);
+    function generateAgentTest() {
+        const config = readAgentForm();
+        const validationError = validateAgent(config);
+        if (validationError) {
+            setStatus(elements.agentTestStatus, validationError, 'error');
+            return;
         }
+        const enabledMcps = state.mcps.filter(mcp => mcp.enabled).map(mcp => ({ key: mcp.key, name: mcp.name, url: mcp.url, transport: mcp.transport }));
+        const packageJson = {
+            agent: {
+                name: config.name,
+                provider: config.provider,
+                key: config.key,
+                runtime: config.runtime,
+                allowed_tools_and_scopes: config.tools,
+                instructions: config.instructions
+            },
+            scenario: config.testScenario || 'Describe a test scenario before generating the package.',
+            enabled_mcp_services: enabledMcps,
+            expected_response_shape: {
+                summary: 'Short finding',
+                confidence: 'low | medium | high',
+                next_actions: ['action one', 'action two'],
+                data_or_tool_needs: ['optional follow-up']
+            }
+        };
+        elements.agentTestResult.textContent = JSON.stringify(packageJson, null, 2);
+        setStatus(elements.agentTestStatus, 'Agent handoff test package generated.', 'success');
     }
 
-    function extractTools(payload) {
-        const result = payload && payload.result ? payload.result : payload;
+    function extractTools(result) {
+        if (!result) return [];
+        if (Array.isArray(result.tools)) return result.tools;
+        if (result.result && Array.isArray(result.result.tools)) return result.result.tools;
         if (Array.isArray(result)) return result;
-        if (result && Array.isArray(result.tools)) return result.tools;
-        if (payload && payload.result && Array.isArray(payload.result.tools)) return payload.result.tools;
         return [];
     }
 
-    function summarizeSchema(schema) {
-        if (!schema || typeof schema !== 'object') return 'No schema provided';
-        const properties = schema.properties || {};
-        const keys = Object.keys(properties);
-        if (!keys.length) return 'No arguments';
-        return keys.map(key => {
-            const property = properties[key] || {};
-            return `${key}${property.type ? ` (${property.type})` : ''}`;
-        }).join(', ');
-    }
-
     function renderToolList(tools) {
-        discoveredTools = tools;
+        discoveredTools = tools || [];
         elements.toolSelect.innerHTML = '';
-        elements.toolList.innerHTML = '';
-        elements.toolCount.textContent = `${tools.length} tool${tools.length === 1 ? '' : 's'} loaded`;
-        elements.toolCount.className = tools.length ? 'pill success' : 'pill muted';
-
-        if (!tools.length) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'No tools returned';
-            elements.toolSelect.appendChild(option);
-            elements.toolList.textContent = 'The MCP server response did not include a tools array.';
+        if (!discoveredTools.length) {
+            elements.toolsList.textContent = 'Connect to an MCP server to list tools.';
+            elements.toolSelect.innerHTML = '<option value="">Load tools to populate options</option>';
+            elements.toolCount.textContent = 'No tools loaded';
             return;
         }
-
-        tools.forEach(tool => {
+        elements.toolCount.textContent = `${discoveredTools.length} tool${discoveredTools.length === 1 ? '' : 's'} loaded`;
+        elements.toolsList.innerHTML = '';
+        discoveredTools.forEach(tool => {
             const option = document.createElement('option');
             option.value = tool.name || '';
             option.textContent = tool.name || 'Unnamed tool';
             elements.toolSelect.appendChild(option);
 
-            const card = document.createElement('article');
+            const card = document.createElement('div');
             card.className = 'ai-tool-card';
-            const title = document.createElement('h5');
-            title.textContent = tool.name || 'Unnamed tool';
-            const description = document.createElement('p');
-            description.textContent = tool.description || 'No description provided.';
-            const schema = document.createElement('small');
-            schema.textContent = `Arguments: ${summarizeSchema(tool.inputSchema)}`;
-            card.append(title, description, schema);
-            elements.toolList.appendChild(card);
+            const schema = tool.inputSchema || tool.input_schema || {};
+            card.innerHTML = `
+                <h5>${escapeHtml(tool.name || 'Unnamed tool')}</h5>
+                <p>${escapeHtml(tool.description || 'No description provided.')}</p>
+                <small>${escapeHtml(JSON.stringify(schema))}</small>
+            `;
+            elements.toolsList.appendChild(card);
         });
+        applySelectedToolExample();
     }
 
     function applySelectedToolExample() {
-        const selected = discoveredTools.find(tool => tool.name === elements.toolSelect.value);
-        const properties = selected && selected.inputSchema && selected.inputSchema.properties ? selected.inputSchema.properties : null;
+        const tool = discoveredTools.find(item => item.name === elements.toolSelect.value);
+        const schema = tool && (tool.inputSchema || tool.input_schema);
+        const properties = schema && schema.properties ? schema.properties : null;
         if (!properties) return;
         const example = {};
         Object.entries(properties).forEach(([key, value]) => {
-            if (value && Array.isArray(value.enum) && value.enum.length) example[key] = value.enum[0];
+            if (value && value.default !== undefined) example[key] = value.default;
             else if (value && value.type === 'number') example[key] = 0;
             else if (value && value.type === 'integer') example[key] = 1;
             else if (value && value.type === 'boolean') example[key] = false;
@@ -260,11 +553,21 @@
         elements.toolArguments.value = JSON.stringify(example, null, 2);
     }
 
+    function parseArgumentsJson() {
+        const raw = elements.toolArguments.value.trim();
+        if (!raw) return {};
+        try {
+            return JSON.parse(raw);
+        } catch (error) {
+            throw new Error(`Tool arguments must be valid JSON: ${error.message}`);
+        }
+    }
+
     async function sendMcpTest(method, includeTool) {
-        const config = readFormConfig();
-        const validationError = validateConfig(config);
+        const config = readMcpForm();
+        const validationError = validateMcp(config);
         if (validationError) {
-            showTestStatus(validationError, 'error');
+            setStatus(elements.mcpTestStatus, validationError, 'error');
             return null;
         }
         const payload = {
@@ -276,18 +579,18 @@
         if (includeTool) {
             payload.tool_name = elements.toolSelect.value;
             if (!payload.tool_name) {
-                showTestStatus('Choose a tool before running a test call.', 'error');
+                setStatus(elements.mcpTestStatus, 'Choose a tool before running a test call.', 'error');
                 return null;
             }
             try {
                 payload.arguments = parseArgumentsJson();
             } catch (error) {
-                showTestStatus(error.message, 'error');
+                setStatus(elements.mcpTestStatus, error.message, 'error');
                 return null;
             }
         }
 
-        showTestStatus(`Running ${method}...`, 'warning');
+        setStatus(elements.mcpTestStatus, `Running ${method} against ${config.name}...`, 'warning');
         elements.testResult.textContent = '';
         try {
             const response = await fetch('/ai/mcp/test', {
@@ -298,14 +601,14 @@
             const data = await response.json().catch(() => ({}));
             elements.testResult.textContent = JSON.stringify(data, null, 2);
             if (!response.ok) {
-                showTestStatus(data.detail || `MCP test failed with HTTP ${response.status}.`, 'error');
+                setStatus(elements.mcpTestStatus, data.detail || `MCP test failed with HTTP ${response.status}.`, 'error');
                 return null;
             }
-            showTestStatus(`${method} completed.`, 'success');
+            setStatus(elements.mcpTestStatus, `${method} completed for ${config.name}.`, 'success');
             return data;
         } catch (error) {
             console.warn('Unable to test MCP server.', error);
-            showTestStatus('Unable to reach the MCP test endpoint from this browser.', 'error');
+            setStatus(elements.mcpTestStatus, 'Unable to reach the MCP test endpoint from this browser.', 'error');
             return null;
         }
     }
@@ -313,78 +616,115 @@
     async function listTools() {
         const method = elements.mcpMethod.value;
         const data = await sendMcpTest(method, false);
-        if (data && method === 'tools/list') {
-            renderToolList(extractTools(data.result));
-        }
-    }
-
-    async function testSelectedTool() {
-        await sendMcpTest('tools/call', true);
+        if (data && method === 'tools/list') renderToolList(extractTools(data.result));
     }
 
     function bindElements() {
-        elements.form = getElement('omi-mcp-form');
-        elements.enabled = getElement('omi-enabled');
-        elements.displayName = getElement('omi-display-name');
-        elements.serverKey = getElement('omi-server-key');
-        elements.url = getElement('omi-url');
-        elements.vscodeType = getElement('omi-vscode-type');
-        elements.transport = getElement('omi-transport');
-        elements.token = getElement('omi-token');
-        elements.notes = getElement('omi-notes');
-        elements.status = getElement('omi-status');
-        elements.reset = getElement('omi-reset');
-        elements.clear = getElement('omi-clear');
-        elements.includeToken = getElement('omi-include-token');
-        elements.vscodeSnippet = getElement('omi-vscode-snippet');
-        elements.pythonSnippet = getElement('omi-python-snippet');
-        elements.copyVsCode = getElement('omi-copy-vscode');
-        elements.copyPython = getElement('omi-copy-python');
-        elements.toggleToken = getElement('omi-toggle-token');
-        elements.mcpMethod = getElement('omi-mcp-method');
-        elements.toolSelect = getElement('omi-tool-select');
-        elements.toolArguments = getElement('omi-tool-arguments');
-        elements.listTools = getElement('omi-list-tools');
-        elements.testTool = getElement('omi-test-tool');
-        elements.copyResult = getElement('omi-copy-result');
-        elements.testStatus = getElement('omi-test-status');
-        elements.toolList = getElement('omi-tools-list');
-        elements.testResult = getElement('omi-test-result');
-        elements.toolCount = getElement('omi-tool-count');
+        elements.agentSummaryPill = $('agent-summary-pill');
+        elements.mcpSummaryPill = $('mcp-summary-pill');
+        elements.enabledSummaryPill = $('enabled-summary-pill');
+        elements.agentOverviewText = $('agent-overview-text');
+        elements.mcpOverviewText = $('mcp-overview-text');
+        elements.agentList = $('agent-list');
+        elements.mcpList = $('mcp-list');
+        elements.addAgent = $('add-agent');
+        elements.addMcp = $('add-mcp');
+        elements.resetAll = $('ai-reset-all');
+        elements.agentForm = $('agent-form');
+        elements.agentEnabled = $('agent-enabled');
+        elements.agentName = $('agent-name');
+        elements.agentProvider = $('agent-provider');
+        elements.agentKey = $('agent-key');
+        elements.agentRuntime = $('agent-runtime');
+        elements.agentTools = $('agent-tools');
+        elements.agentInstructions = $('agent-instructions');
+        elements.agentNotes = $('agent-notes');
+        elements.agentStatus = $('agent-status');
+        elements.newAgent = $('new-agent');
+        elements.deleteAgent = $('delete-agent');
+        elements.selectedAgentPill = $('selected-agent-pill');
+        elements.agentTestScenario = $('agent-test-scenario');
+        elements.runAgentTest = $('run-agent-test');
+        elements.copyAgentTest = $('copy-agent-test');
+        elements.agentTestStatus = $('agent-test-status');
+        elements.agentTestResult = $('agent-test-result');
+        elements.mcpForm = $('mcp-form');
+        elements.mcpEnabled = $('mcp-enabled');
+        elements.mcpName = $('mcp-name');
+        elements.mcpKey = $('mcp-key');
+        elements.mcpUrl = $('mcp-url');
+        elements.mcpVsCodeType = $('mcp-vscode-type');
+        elements.mcpTransport = $('mcp-transport');
+        elements.mcpToken = $('mcp-token');
+        elements.mcpNotes = $('mcp-notes');
+        elements.mcpStatus = $('mcp-status');
+        elements.newMcp = $('new-mcp');
+        elements.deleteMcp = $('delete-mcp');
+        elements.selectedMcpPill = $('selected-mcp-pill');
+        elements.mcpToggleToken = $('mcp-toggle-token');
+        elements.mcpIncludeToken = $('mcp-include-token');
+        elements.vscodeSnippet = $('vscode-snippet');
+        elements.pythonSnippet = $('python-snippet');
+        elements.copyVsCode = $('copy-vscode');
+        elements.copyPython = $('copy-python');
+        elements.mcpMethod = $('mcp-method');
+        elements.toolSelect = $('tool-select');
+        elements.toolArguments = $('tool-arguments');
+        elements.listTools = $('list-tools');
+        elements.testTool = $('test-tool');
+        elements.copyResult = $('copy-result');
+        elements.mcpTestStatus = $('mcp-test-status');
+        elements.toolsList = $('tools-list');
+        elements.testResult = $('test-result');
+        elements.toolCount = $('tool-count');
     }
 
     function bindEvents() {
-        elements.form.addEventListener('submit', saveConfig);
-        elements.reset.addEventListener('click', resetDefaults);
-        elements.clear.addEventListener('click', clearSavedConfig);
-        elements.toggleToken.addEventListener('click', toggleTokenVisibility);
-        elements.includeToken.addEventListener('change', renderSnippets);
+        elements.agentList.addEventListener('click', selectConfig);
+        elements.mcpList.addEventListener('click', selectConfig);
+        elements.addAgent.addEventListener('click', addAgent);
+        elements.newAgent.addEventListener('click', addAgent);
+        elements.addMcp.addEventListener('click', addMcp);
+        elements.newMcp.addEventListener('click', addMcp);
+        elements.deleteAgent.addEventListener('click', deleteSelectedAgent);
+        elements.deleteMcp.addEventListener('click', deleteSelectedMcp);
+        elements.resetAll.addEventListener('click', resetAll);
+        elements.agentForm.addEventListener('submit', saveAgent);
+        elements.mcpForm.addEventListener('submit', saveMcp);
+        elements.mcpToggleToken.addEventListener('click', toggleTokenVisibility);
+        elements.mcpIncludeToken.addEventListener('change', renderSnippets);
+        elements.runAgentTest.addEventListener('click', generateAgentTest);
+        elements.copyAgentTest.addEventListener('click', () => copyText(elements.agentTestResult.textContent, 'Agent test package copied.', (message, type) => setStatus(elements.agentTestStatus, message, type)));
+        elements.copyVsCode.addEventListener('click', () => copyText(elements.vscodeSnippet.textContent, 'VS Code MCP config copied.', (message, type) => setStatus(elements.mcpStatus, message, type)));
+        elements.copyPython.addEventListener('click', () => copyText(elements.pythonSnippet.textContent, 'Python SDK example copied.', (message, type) => setStatus(elements.mcpStatus, message, type)));
         elements.listTools.addEventListener('click', listTools);
-        elements.testTool.addEventListener('click', testSelectedTool);
+        elements.testTool.addEventListener('click', () => sendMcpTest('tools/call', true));
         elements.toolSelect.addEventListener('change', applySelectedToolExample);
-        elements.copyResult.addEventListener('click', () => copyText(elements.testResult.textContent, 'MCP test result copied.', showTestStatus));
+        elements.copyResult.addEventListener('click', () => copyText(elements.testResult.textContent, 'MCP test result copied.', (message, type) => setStatus(elements.mcpTestStatus, message, type)));
 
         [
-            elements.enabled,
-            elements.displayName,
-            elements.serverKey,
-            elements.url,
-            elements.vscodeType,
-            elements.transport,
-            elements.token,
-            elements.notes
+            elements.mcpName,
+            elements.mcpKey,
+            elements.mcpUrl,
+            elements.mcpVsCodeType,
+            elements.mcpTransport,
+            elements.mcpToken,
+            elements.mcpNotes,
+            elements.mcpEnabled
         ].forEach(element => {
             element.addEventListener('input', renderSnippets);
             element.addEventListener('change', renderSnippets);
         });
-
-        elements.copyVsCode.addEventListener('click', () => copyText(elements.vscodeSnippet.textContent, 'VS Code MCP config copied.'));
-        elements.copyPython.addEventListener('click', () => copyText(elements.pythonSnippet.textContent, 'Python SDK example copied.'));
     }
 
     document.addEventListener('DOMContentLoaded', () => {
         bindElements();
         bindEvents();
-        applyConfig(loadSavedConfig());
+        const workspace = loadWorkspace();
+        state.agents = workspace.agents;
+        state.mcps = workspace.mcps;
+        state.selectedAgentId = workspace.selectedAgentId;
+        state.selectedMcpId = workspace.selectedMcpId;
+        renderAll();
     });
 })();

--- a/static/site.css
+++ b/static/site.css
@@ -951,6 +951,7 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
   gap:1rem;
   align-items:center;
   margin-bottom:1rem;
+  background:linear-gradient(135deg, var(--rci-surface), var(--rci-surface-alt));
 }
 .ai-hero h2 { margin:.2rem 0 .35rem; }
 .eyebrow { margin:0; color:var(--rci-primary); font-size:.75rem; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
@@ -959,25 +960,50 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
 .pill { display:inline-flex; align-items:center; gap:.25rem; border:1px solid var(--rci-border); border-radius:999px; padding:.3rem .65rem; background:var(--rci-surface-alt); font-size:.8rem; font-weight:600; white-space:nowrap; }
 .pill.success { color:#1b7f3a; background:rgba(46, 125, 50, .12); border-color:rgba(46, 125, 50, .35); }
 .pill.muted { color:var(--rci-text-muted); }
-.ai-feature-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr)); gap:1rem; margin-bottom:1rem; }
-.ai-feature-card { display:flex; flex-direction:column; gap:.5rem; }
-.ai-feature-card h2 { margin:0; font-size:1.1rem; }
-.ai-feature-card p { margin:0; color:var(--rci-text-muted); }
-.ai-feature-card ul { margin:.25rem 0; padding-left:1.2rem; }
-.ai-feature-card-active { border-color:var(--rci-primary); }
-.ai-section .section-content { display:block; }
-.ai-two-column { display:grid; grid-template-columns:minmax(0, 1.6fr) minmax(260px, .8fr); gap:1rem; align-items:start; }
-.ai-config-form { border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:1rem; background:var(--rci-surface); box-shadow:var(--rci-shadow); }
+.ai-overview-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr)); gap:1rem; margin-bottom:1rem; }
+.ai-overview-card { display:flex; gap:.85rem; align-items:flex-start; }
+.ai-overview-card h2 { margin:0 0 .25rem; font-size:1.05rem; }
+.ai-overview-card p { margin:0; color:var(--rci-text-muted); }
+.ai-overview-icon { display:grid; place-items:center; flex:0 0 2.5rem; height:2.5rem; border-radius:14px; background:var(--rci-primary-accent); color:#fff; font-size:1.3rem; }
+.ai-workspace { display:grid; grid-template-columns:minmax(260px, 340px) minmax(0, 1fr); gap:1rem; align-items:start; }
+.ai-inventory { position:sticky; top:1rem; }
+.ai-panel-title-row,
+.ai-inventory-heading,
+.ai-editor-header,
+.ai-console-header { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem; }
+.ai-panel-title-row h2,
+.ai-inventory-heading h3,
+.ai-editor-header h2 { margin:.1rem 0 .25rem; }
+.ai-inventory-group { margin-top:1rem; padding-top:1rem; border-top:1px solid var(--rci-border); }
+.ai-config-list { display:flex; flex-direction:column; gap:.5rem; margin-top:.65rem; }
+.ai-config-item { display:flex; justify-content:space-between; align-items:center; gap:.75rem; width:100%; padding:.7rem; text-align:left; border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); color:var(--rci-text); box-shadow:none; }
+.ai-config-item:hover,
+.ai-config-item.selected { border-color:var(--rci-primary); background:var(--rci-surface-alt); color:var(--rci-text); }
+.ai-config-item-main { display:flex; min-width:0; flex-direction:column; gap:.15rem; }
+.ai-config-item-main strong,
+.ai-config-item-main small { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ai-config-item-main small { color:var(--rci-text-muted); font-size:.78rem; }
+.ai-editor-stack { display:flex; flex-direction:column; gap:1rem; min-width:0; }
+.ai-editor-card { min-width:0; }
+.ai-editor-header { margin-bottom:1rem; }
+.ai-editor-header p { margin-bottom:0; }
+.ai-collapse { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); margin-top:.75rem; overflow:hidden; }
+.ai-collapse summary { cursor:pointer; list-style:none; padding:.8rem 1rem; font-weight:700; background:var(--rci-surface-alt); border-bottom:1px solid transparent; }
+.ai-collapse summary::-webkit-details-marker { display:none; }
+.ai-collapse summary::before { content:'▶'; display:inline-block; margin-right:.45rem; transition:transform .2s ease; }
+.ai-collapse[open] summary { border-bottom-color:var(--rci-border); }
+.ai-collapse[open] summary::before { transform:rotate(90deg); }
+.ai-config-form,
+.ai-test-panel { padding:1rem; }
 .ai-form-header { display:flex; justify-content:space-between; gap:1rem; align-items:flex-start; margin-bottom:1rem; }
-.ai-form-header h2,
-.ai-reference h2 { margin:0 0 .25rem; }
+.ai-form-header.compact { margin-bottom:.75rem; }
 .toggle-row { display:flex; align-items:center; gap:.4rem; font-weight:600; white-space:nowrap; }
 .ai-form-grid { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:.75rem; }
 .ai-form-grid label { display:flex; flex-direction:column; gap:.25rem; font-weight:600; }
 .ai-form-grid label span { font-size:.78rem; color:var(--rci-text-muted); letter-spacing:.04em; text-transform:uppercase; }
 .ai-form-grid input,
 .ai-form-grid select,
-.ai-form-grid textarea { width:100%; box-sizing:border-box; padding:.45rem .55rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); color:var(--rci-text); font:inherit; }
+.ai-form-grid textarea { width:100%; box-sizing:border-box; padding:.5rem .6rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); color:var(--rci-text); font:inherit; }
 .ai-form-grid textarea { resize:vertical; }
 .ai-form-grid small { color:var(--rci-text-muted); font-weight:400; }
 .full-width { grid-column:1 / -1; }
@@ -985,36 +1011,38 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
 .secret-input-row input { flex:1; }
 .ai-form-actions,
 .ai-snippet-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; margin-top:1rem; }
-.ai-reference dl { display:grid; grid-template-columns:max-content minmax(0, 1fr); gap:.4rem .75rem; margin:0 0 1rem; }
-.ai-reference dt { font-weight:700; color:var(--rci-text-muted); }
-.ai-reference dd { margin:0; min-width:0; overflow-wrap:anywhere; }
-.ai-reference details { border-top:1px solid var(--rci-border); padding-top:.75rem; }
 .ai-snippet-grid { margin-top:.75rem; }
-.ai-mcp-console { margin-top:1rem; }
-.ai-console-header { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem; margin-bottom:1rem; }
-.ai-console-header h2 { margin:0 0 .25rem; }
 .ai-test-grid { margin-top:.75rem; }
-.ai-tool-results { display:grid; grid-template-columns:minmax(260px, .9fr) minmax(0, 1.1fr); gap:1rem; margin-top:1rem; }
-.ai-tool-results h4 { margin:.1rem 0 .5rem; }
+.ai-tool-results { display:grid; grid-template-columns:minmax(240px, .9fr) minmax(0, 1.1fr); gap:1rem; margin-top:1rem; }
+.ai-tool-results h4,
+.ai-snippet-grid h4 { margin:.1rem 0 .5rem; }
 .ai-tool-list { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface-alt); padding:.75rem; min-height:180px; max-height:360px; overflow:auto; }
 .ai-tool-card { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); padding:.65rem; margin-bottom:.6rem; }
 .ai-tool-card:last-child { margin-bottom:0; }
 .ai-tool-card h5 { margin:0 0 .25rem; font-size:.95rem; }
 .ai-tool-card p { margin:.15rem 0 .4rem; color:var(--rci-text-muted); }
 .ai-tool-card small { color:var(--rci-text-muted); overflow-wrap:anywhere; }
-.ai-code-block { white-space:pre; font-family:monospace; font-size:.85rem; line-height:1.45; max-height:360px; }
+.ai-code-block { white-space:pre; font-family:monospace; font-size:.85rem; line-height:1.45; max-height:360px; overflow:auto; }
+.status-message { min-height:1.25rem; margin-top:.65rem; }
 .status-message.success { color:#1b7f3a; }
 .status-message.warning { color:#a86400; }
 .status-message.error { color:var(--rci-danger, #c0392b); }
 [data-theme="dark"] .pill.success,
 [data-theme="dark"] .status-message.success { color:#78d98b; }
 [data-theme="dark"] .status-message.warning { color:#ffd166; }
+@media (max-width:980px){
+  .ai-workspace { grid-template-columns:1fr; }
+  .ai-inventory { position:static; }
+}
 @media (max-width:768px){
   .ai-hero,
-  .ai-form-header { flex-direction:column; align-items:flex-start; }
+  .ai-panel-title-row,
+  .ai-inventory-heading,
+  .ai-editor-header,
+  .ai-form-header,
+  .ai-console-header { flex-direction:column; align-items:flex-start; }
   .ai-hero-status { justify-content:flex-start; }
-  .ai-two-column,
   .ai-form-grid,
   .ai-tool-results { grid-template-columns:1fr; }
-  .ai-console-header { flex-direction:column; }
+  .secret-input-row { flex-direction:column; }
 }


### PR DESCRIPTION
### Motivation
- Provide a compact dashboard to define, compare, and test multiple Agent profiles and MCP services from one place. 
- Make it easy to add/update/remove configurations while keeping a streamlined overview with collapsible configuration and test panels. 
- Enable quick developer workflows: generate client snippets, run MCP tool discovery and calls, and generate agent handoff test packages.

### Description
- Reworked the page layout and panels in `static/ai-features.html` to add an inventory sidebar, overview cards, editor stack, and collapsible configuration/test sections for both Agents and MCP services. 
- Replaced the single-configuration script with a workspace model in `static/ai-features.js` that supports multiple agents and MCPs, CRUD flows (add/save/delete/reset), selection, and persistence to localStorage under `rci.ai.workspaceConfig.v1`, including migration from the legacy `rci.ai.omiMcpConfig`. 
- Added MCP client snippet generation, Python example generation, agent handoff test package creation, MCP tool listing and tool-call testing via the existing `/ai/mcp/test` proxy endpoint, and copy-to-clipboard helpers. 
- Refreshed and extended styling in `static/site.css` to support the new dashboard, sticky inventory, collapsible panels, responsive layout, and UI affordances for selected/disabled items.

### Testing
- Ran `node --check static/ai-features.js` to verify the new script syntax and it completed successfully. 
- Verified HTML ID uniqueness with a small parser script (no duplicate `id` attributes found). 
- Executed `pytest tests/core/test_mcp_ai_features.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c2fcd6c883209e08f154092dcf41)