### PR TITLE
Enhance AI Features: agent chat proxy, chat UI, and JSON import

### DIFF
--- a/main.py
+++ b/main.py
@@ -2738,6 +2738,24 @@ class McpToolTestRequest(BaseModel):
     timeout_seconds: int = Field(default=20, ge=1, le=60)
 
 
+class AiAgentChatMessage(BaseModel):
+    role: Literal["user", "assistant", "system"]
+    content: str = Field(..., max_length=20000)
+
+
+class AiAgentChatRequest(BaseModel):
+    name: str = Field(..., max_length=100)
+    provider: Optional[str] = Field(default="", max_length=100)
+    runtime: str = Field(..., max_length=200)
+    instructions: Optional[str] = Field(default="", max_length=12000)
+    api_url: str = Field(..., max_length=2000)
+    api_key: Optional[str] = Field(default=None, max_length=4000)
+    message: str = Field(..., min_length=1, max_length=20000)
+    history: List[AiAgentChatMessage] = Field(default_factory=list, max_length=20)
+    mcp_services: List[Dict[str, Any]] = Field(default_factory=list, max_length=20)
+    timeout_seconds: int = Field(default=40, ge=1, le=120)
+
+
 def _mcp_extract_json_response(response: requests.Response) -> Any:
     """Return a JSON-RPC payload from JSON or SSE-style MCP responses."""
     content_type = response.headers.get("Content-Type", "")
@@ -2857,6 +2875,76 @@ def test_mcp_tool(request: McpToolTestRequest, dep: None = Depends(admin_depende
         "initialize_headers": {"mcp-session-id": _header_value(initialize_headers, "mcp-session-id")},
         "result": result,
         "response_headers": {"content-type": response_headers.get("Content-Type", "")},
+    }
+
+
+def _extract_agent_chat_content(payload: Any) -> str:
+    """Extract assistant text from common OpenAI-compatible chat responses."""
+    if not isinstance(payload, dict):
+        return ""
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0] or {}
+        message = first.get("message") if isinstance(first, dict) else None
+        if isinstance(message, dict) and isinstance(message.get("content"), str):
+            return message["content"]
+        if isinstance(first, dict) and isinstance(first.get("text"), str):
+            return first["text"]
+    if isinstance(payload.get("output_text"), str):
+        return payload["output_text"]
+    return ""
+
+
+@app.post("/ai/agent/chat")
+def chat_with_ai_agent(request: AiAgentChatRequest, dep: None = Depends(admin_dependency)):
+    """Send a chat turn to an OpenAI-compatible agent endpoint from the AI Features console."""
+    parsed_url = urlparse(request.api_url)
+    if parsed_url.scheme != "https" or not parsed_url.netloc:
+        raise HTTPException(status_code=400, detail="Agent chat API URL must be a valid HTTPS URL")
+
+    enabled_services = [
+        {
+            "key": service.get("key"),
+            "name": service.get("name"),
+            "url": service.get("url"),
+            "transport": service.get("transport"),
+        }
+        for service in request.mcp_services
+        if isinstance(service, dict) and service.get("enabled", True)
+    ]
+    system_parts = [
+        request.instructions or f"You are {request.name}, an AI assistant for the Road Condition Indexer.",
+        "When tools are needed, say which MCP service and tool should be used; do not invent tool results.",
+    ]
+    if enabled_services:
+        system_parts.append(f"Available MCP services for this workspace: {json.dumps(enabled_services)}")
+
+    messages: List[Dict[str, str]] = [{"role": "system", "content": "\n\n".join(system_parts)}]
+    messages.extend({"role": item.role, "content": item.content} for item in request.history[-20:])
+    messages.append({"role": "user", "content": request.message})
+
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    if request.api_key:
+        headers["Authorization"] = f"Bearer {request.api_key}"
+
+    payload = {"model": request.runtime, "messages": messages}
+    try:
+        response = requests.post(request.api_url, json=payload, headers=headers, timeout=request.timeout_seconds)
+        response.raise_for_status()
+        response_payload = response.json()
+    except requests.RequestException as exc:
+        detail = str(exc)
+        if getattr(exc, "response", None) is not None and exc.response is not None:
+            detail = f"{detail}: {exc.response.text[:500]}"
+        raise HTTPException(status_code=502, detail=detail) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail="Agent chat endpoint did not return valid JSON") from exc
+
+    return {
+        "status": "ok",
+        "agent": {"name": request.name, "provider": request.provider, "runtime": request.runtime},
+        "message": _extract_agent_chat_content(response_payload),
+        "raw": response_payload,
     }
 
 

--- a/static/ai-features.html
+++ b/static/ai-features.html
@@ -110,7 +110,19 @@
                         </label>
                         <label>
                             <span>Runtime / model</span>
-                            <input type="text" id="agent-runtime" maxlength="100" placeholder="gpt-4.1, desktop IDE, workflow runner">
+                            <input type="text" id="agent-runtime" maxlength="100" placeholder="gpt-4.1-mini, desktop IDE, workflow runner">
+                        </label>
+                        <label class="full-width">
+                            <span>OpenAI-compatible chat API URL</span>
+                            <input type="url" id="agent-api-url" placeholder="https://api.example.com/v1/chat/completions">
+                            <small>Used by the chat console. Leave blank for agents that are documented only.</small>
+                        </label>
+                        <label class="full-width">
+                            <span>Chat API bearer token</span>
+                            <div class="secret-input-row">
+                                <input type="password" id="agent-api-key" placeholder="token value stored in this browser only">
+                                <button type="button" id="agent-toggle-key" class="secondary-button">Show</button>
+                            </div>
                         </label>
                         <label class="full-width">
                             <span>Allowed tools and scopes</span>
@@ -134,6 +146,26 @@
             </details>
 
             <details class="ai-collapse">
+                <summary>Chat with agent</summary>
+                <div class="ai-test-panel">
+                    <div id="agent-chat-log" class="ai-chat-log" aria-live="polite" data-history="[]">
+                        <p class="rci-muted">Configure an HTTPS OpenAI-compatible chat endpoint above, then send a message to the selected agent. Enabled MCP services are included as context so the agent can request tools deliberately.</p>
+                    </div>
+                    <div class="ai-form-grid">
+                        <label class="full-width">
+                            <span>Message</span>
+                            <textarea id="agent-chat-message" rows="4" placeholder="Ask the selected agent to inspect road-condition context, request MCP tools, or summarize next steps."></textarea>
+                        </label>
+                    </div>
+                    <div class="ai-form-actions">
+                        <button type="button" id="send-agent-chat" class="focus-ring">Send chat message</button>
+                        <button type="button" id="clear-agent-chat" class="secondary-button focus-ring">Clear chat</button>
+                    </div>
+                    <div id="agent-chat-status" class="status-message" role="status" aria-live="polite"></div>
+                </div>
+            </details>
+
+            <details class="ai-collapse">
                 <summary>Test agent handoff</summary>
                 <div class="ai-test-panel">
                     <div class="ai-form-grid">
@@ -148,6 +180,34 @@
                     </div>
                     <div id="agent-test-status" class="status-message" role="status" aria-live="polite"></div>
                     <pre id="agent-test-result" class="result-box ai-code-block" tabindex="0"></pre>
+                </div>
+            </details>
+        </section>
+
+        <section class="rci-card ai-editor-card" aria-labelledby="json-provider-title">
+            <div class="ai-editor-header">
+                <div>
+                    <p class="eyebrow">JSON provider</p>
+                    <h2 id="json-provider-title">Add agents or MCP services from JSON</h2>
+                    <p class="rci-muted">Paste a generated JSON object with complete agent and MCP service definitions, or copy the technical contract below into your AI JSON provider.</p>
+                </div>
+            </div>
+            <details class="ai-collapse" open>
+                <summary>Import JSON</summary>
+                <div class="ai-test-panel">
+                    <div class="ai-form-grid">
+                        <label class="full-width">
+                            <span>Agent / MCP JSON</span>
+                            <textarea id="json-provider-input" rows="10" spellcheck="false" placeholder='{ "agents": [{ "name": "Operations Analyst", "key": "operations_analyst" }], "mcps": [{ "name": "Road Tools", "key": "road_tools", "url": "https://mcp.example.com/sse" }] }'></textarea>
+                        </label>
+                    </div>
+                    <div class="ai-form-actions">
+                        <button type="button" id="import-json-config" class="focus-ring">Import JSON configuration</button>
+                        <button type="button" id="copy-json-requirements" class="secondary-button focus-ring">Copy JSON requirements</button>
+                    </div>
+                    <div id="json-provider-status" class="status-message" role="status" aria-live="polite"></div>
+                    <h4>Technical JSON requirements for AI providers</h4>
+                    <pre id="json-requirements" class="result-box ai-code-block" tabindex="0"></pre>
                 </div>
             </details>
         </section>

--- a/static/ai-features.js
+++ b/static/ai-features.js
@@ -8,7 +8,9 @@
         name: 'Road Analyst Agent',
         provider: 'OpenAI / local workflow',
         key: 'road_analyst',
-        runtime: 'Configured in client',
+        runtime: 'gpt-4.1-mini',
+        apiUrl: '',
+        apiKey: '',
         tools: 'Read logs, inspect road-condition data, use enabled MCP services',
         instructions: 'Review the current road-condition context, identify anomalies, and return concise operational next steps.',
         notes: 'Default starter profile. Update it for the assistant or IDE agent you want to use.',
@@ -204,6 +206,8 @@
         elements.agentProvider.value = agent.provider || '';
         elements.agentKey.value = agent.key || '';
         elements.agentRuntime.value = agent.runtime || '';
+        elements.agentApiUrl.value = agent.apiUrl || '';
+        elements.agentApiKey.value = agent.apiKey || '';
         elements.agentTools.value = agent.tools || '';
         elements.agentInstructions.value = agent.instructions || '';
         elements.agentNotes.value = agent.notes || '';
@@ -244,6 +248,8 @@
             provider: elements.agentProvider.value.trim(),
             key: slugify(elements.agentKey.value, 'agent'),
             runtime: elements.agentRuntime.value.trim(),
+            apiUrl: elements.agentApiUrl.value.trim(),
+            apiKey: elements.agentApiKey.value.trim(),
             tools: elements.agentTools.value.trim(),
             instructions: elements.agentInstructions.value.trim(),
             notes: elements.agentNotes.value.trim(),
@@ -275,7 +281,7 @@
         if (keyError) return keyError;
         if (!config.name) return 'MCP display name is required.';
         if (!config.url) return 'MCP URL is required.';
-        if (!/^https?:\/\//i.test(config.url)) return 'MCP URL should start with http:// or https://.';
+        if (!/^https:\/\//i.test(config.url)) return 'MCP URL should start with https://.';
         return '';
     }
 
@@ -283,6 +289,7 @@
         const keyError = validateKey(config.key, 'Agent');
         if (keyError) return keyError;
         if (!config.name) return 'Agent display name is required.';
+        if (config.apiUrl && !/^https:\/\//i.test(config.apiUrl)) return 'Agent chat API URL must start with https://.';
         return '';
     }
 
@@ -467,6 +474,89 @@
         elements.mcpToggleToken.textContent = isHidden ? 'Hide' : 'Show';
     }
 
+    function toggleAgentKeyVisibility() {
+        const isHidden = elements.agentApiKey.type === 'password';
+        elements.agentApiKey.type = isHidden ? 'text' : 'password';
+        elements.agentToggleKey.textContent = isHidden ? 'Hide' : 'Show';
+    }
+
+    function appendChatMessage(role, content) {
+        const item = document.createElement('div');
+        item.className = `ai-chat-message ${role}`;
+        item.innerHTML = `<strong>${role === 'user' ? 'You' : 'Agent'}</strong><p>${escapeHtml(content)}</p>`;
+        elements.agentChatLog.appendChild(item);
+        elements.agentChatLog.scrollTop = elements.agentChatLog.scrollHeight;
+    }
+
+    function readChatHistory() {
+        try {
+            return JSON.parse(elements.agentChatLog.dataset.history || '[]');
+        } catch (error) {
+            return [];
+        }
+    }
+
+    function writeChatHistory(history) {
+        elements.agentChatLog.dataset.history = JSON.stringify(history.slice(-20));
+    }
+
+    async function sendAgentChat() {
+        const config = readAgentForm();
+        const validationError = validateAgent(config);
+        if (validationError) {
+            setStatus(elements.agentChatStatus, validationError, 'error');
+            return;
+        }
+        if (!config.apiUrl) {
+            setStatus(elements.agentChatStatus, 'Add an HTTPS OpenAI-compatible chat API URL before chatting with this agent.', 'error');
+            return;
+        }
+        const message = elements.agentChatMessage.value.trim();
+        if (!message) {
+            setStatus(elements.agentChatStatus, 'Type a message before sending.', 'error');
+            return;
+        }
+        const history = readChatHistory();
+        appendChatMessage('user', message);
+        elements.agentChatMessage.value = '';
+        setStatus(elements.agentChatStatus, `Sending message to ${config.name}...`, 'warning');
+        try {
+            const response = await fetch('/ai/agent/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: config.name,
+                    provider: config.provider,
+                    runtime: config.runtime,
+                    instructions: config.instructions,
+                    api_url: config.apiUrl,
+                    api_key: config.apiKey,
+                    message,
+                    history,
+                    mcp_services: state.mcps.filter(mcp => mcp.enabled)
+                })
+            });
+            const data = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                setStatus(elements.agentChatStatus, data.detail || `Agent chat failed with HTTP ${response.status}.`, 'error');
+                return;
+            }
+            const reply = data.message || JSON.stringify(data.raw || data, null, 2);
+            appendChatMessage('assistant', reply);
+            writeChatHistory([...history, { role: 'user', content: message }, { role: 'assistant', content: reply }]);
+            setStatus(elements.agentChatStatus, `${config.name} replied.`, 'success');
+        } catch (error) {
+            console.warn('Unable to chat with agent.', error);
+            setStatus(elements.agentChatStatus, 'Unable to reach the agent chat proxy from this browser.', 'error');
+        }
+    }
+
+    function clearAgentChat() {
+        elements.agentChatLog.innerHTML = '';
+        writeChatHistory([]);
+        setStatus(elements.agentChatStatus, 'Chat cleared.', 'warning');
+    }
+
     function generateAgentTest() {
         const config = readAgentForm();
         const validationError = validateAgent(config);
@@ -619,6 +709,107 @@
         if (data && method === 'tools/list') renderToolList(extractTools(data.result));
     }
 
+    function requiredJsonDescription() {
+        return `AI Features JSON provider contract
+
+Return one JSON object. It may include an "agents" array, an "mcps" array, or one object with "type": "agent" or "type": "mcp". Do not wrap the JSON in Markdown.
+
+Agent object required fields:
+- type: "agent" when importing a single object
+- name: display name, string, max 80 characters
+- key: unique slug using letters, numbers, underscores, or hyphens, max 50 characters
+
+Agent object optional fields:
+- enabled: boolean
+- provider: provider or platform label
+- runtime: model or runtime name used as the chat model
+- apiUrl: HTTPS OpenAI-compatible chat completions endpoint such as https://api.example.com/v1/chat/completions
+- apiKey: bearer token for that endpoint; omit when not needed
+- tools: comma-separated allowed tools/scopes
+- instructions: system instructions for chat
+- notes: owner, privacy, rollout, or environment notes
+- testScenario: reusable handoff test scenario
+
+MCP service object required fields:
+- type: "mcp" when importing a single object
+- name: display name, string, max 80 characters
+- key: unique slug using letters, numbers, underscores, or hyphens, max 50 characters
+- url: HTTPS MCP JSON-RPC/SSE endpoint
+
+MCP service object optional fields:
+- enabled: boolean
+- vscodeType: "sse" or "http"
+- transport: "streamable_http", "sse", or "http"
+- token: bearer token; omit when not needed
+- notes: docs link, owner, tool scope, or environment notes
+
+Example:
+{
+  "agents": [{
+    "name": "Operations Analyst",
+    "key": "operations_analyst",
+    "runtime": "gpt-4.1-mini",
+    "apiUrl": "https://api.example.com/v1/chat/completions",
+    "instructions": "Answer with concise road-operation next steps."
+  }],
+  "mcps": [{
+    "name": "Road Tools",
+    "key": "road_tools",
+    "url": "https://mcp.example.com/sse",
+    "transport": "streamable_http"
+  }]
+}`;
+    }
+
+    function normalizeImportedAgent(input) {
+        const agent = { ...clone(DEFAULT_AGENT), ...input, id: input.id || uniqueId('agent') };
+        if (!agent.apiUrl && input.api_url) agent.apiUrl = input.api_url;
+        if (!agent.apiKey && input.api_key) agent.apiKey = input.api_key;
+        agent.key = slugify(agent.key || agent.name, 'agent');
+        agent.enabled = Boolean(agent.enabled);
+        delete agent.type;
+        const validationError = validateAgent(agent);
+        if (validationError) throw new Error(`Agent ${agent.name || agent.key}: ${validationError}`);
+        return agent;
+    }
+
+    function normalizeImportedMcp(input) {
+        const mcp = { ...clone(DEFAULT_MCP), ...input, id: input.id || uniqueId('mcp') };
+        if (!mcp.vscodeType && input.vscode_type) mcp.vscodeType = input.vscode_type;
+        mcp.key = slugify(mcp.key || mcp.name, 'mcp');
+        mcp.enabled = Boolean(mcp.enabled);
+        delete mcp.type;
+        const validationError = validateMcp(mcp);
+        if (validationError) throw new Error(`MCP ${mcp.name || mcp.key}: ${validationError}`);
+        return mcp;
+    }
+
+    function importJsonConfig() {
+        let parsed;
+        try {
+            parsed = JSON.parse(elements.jsonProviderInput.value);
+        } catch (error) {
+            setStatus(elements.jsonProviderStatus, `JSON parse error: ${error.message}`, 'error');
+            return;
+        }
+        try {
+            const agents = Array.isArray(parsed.agents) ? parsed.agents : parsed.type === 'agent' ? [parsed] : [];
+            const mcps = Array.isArray(parsed.mcps) ? parsed.mcps : parsed.type === 'mcp' ? [parsed] : [];
+            if (!agents.length && !mcps.length) throw new Error('Provide an agents array, an mcps array, or a single typed object.');
+            const importedAgents = agents.map(normalizeImportedAgent);
+            const importedMcps = mcps.map(normalizeImportedMcp);
+            state.agents.push(...importedAgents);
+            state.mcps.push(...importedMcps);
+            if (importedAgents.length) state.selectedAgentId = importedAgents[0].id;
+            if (importedMcps.length) state.selectedMcpId = importedMcps[0].id;
+            saveWorkspace();
+            renderAll();
+            setStatus(elements.jsonProviderStatus, `Imported ${importedAgents.length} agent(s) and ${importedMcps.length} MCP service(s).`, 'success');
+        } catch (error) {
+            setStatus(elements.jsonProviderStatus, error.message, 'error');
+        }
+    }
+
     function bindElements() {
         elements.agentSummaryPill = $('agent-summary-pill');
         elements.mcpSummaryPill = $('mcp-summary-pill');
@@ -636,6 +827,9 @@
         elements.agentProvider = $('agent-provider');
         elements.agentKey = $('agent-key');
         elements.agentRuntime = $('agent-runtime');
+        elements.agentApiUrl = $('agent-api-url');
+        elements.agentApiKey = $('agent-api-key');
+        elements.agentToggleKey = $('agent-toggle-key');
         elements.agentTools = $('agent-tools');
         elements.agentInstructions = $('agent-instructions');
         elements.agentNotes = $('agent-notes');
@@ -648,6 +842,11 @@
         elements.copyAgentTest = $('copy-agent-test');
         elements.agentTestStatus = $('agent-test-status');
         elements.agentTestResult = $('agent-test-result');
+        elements.agentChatMessage = $('agent-chat-message');
+        elements.agentChatLog = $('agent-chat-log');
+        elements.sendAgentChat = $('send-agent-chat');
+        elements.clearAgentChat = $('clear-agent-chat');
+        elements.agentChatStatus = $('agent-chat-status');
         elements.mcpForm = $('mcp-form');
         elements.mcpEnabled = $('mcp-enabled');
         elements.mcpName = $('mcp-name');
@@ -677,6 +876,11 @@
         elements.toolsList = $('tools-list');
         elements.testResult = $('test-result');
         elements.toolCount = $('tool-count');
+        elements.jsonProviderInput = $('json-provider-input');
+        elements.importJsonConfig = $('import-json-config');
+        elements.copyJsonRequirements = $('copy-json-requirements');
+        elements.jsonProviderStatus = $('json-provider-status');
+        elements.jsonRequirements = $('json-requirements');
     }
 
     function bindEvents() {
@@ -692,8 +896,11 @@
         elements.agentForm.addEventListener('submit', saveAgent);
         elements.mcpForm.addEventListener('submit', saveMcp);
         elements.mcpToggleToken.addEventListener('click', toggleTokenVisibility);
+        elements.agentToggleKey.addEventListener('click', toggleAgentKeyVisibility);
         elements.mcpIncludeToken.addEventListener('change', renderSnippets);
         elements.runAgentTest.addEventListener('click', generateAgentTest);
+        elements.sendAgentChat.addEventListener('click', sendAgentChat);
+        elements.clearAgentChat.addEventListener('click', clearAgentChat);
         elements.copyAgentTest.addEventListener('click', () => copyText(elements.agentTestResult.textContent, 'Agent test package copied.', (message, type) => setStatus(elements.agentTestStatus, message, type)));
         elements.copyVsCode.addEventListener('click', () => copyText(elements.vscodeSnippet.textContent, 'VS Code MCP config copied.', (message, type) => setStatus(elements.mcpStatus, message, type)));
         elements.copyPython.addEventListener('click', () => copyText(elements.pythonSnippet.textContent, 'Python SDK example copied.', (message, type) => setStatus(elements.mcpStatus, message, type)));
@@ -701,6 +908,8 @@
         elements.testTool.addEventListener('click', () => sendMcpTest('tools/call', true));
         elements.toolSelect.addEventListener('change', applySelectedToolExample);
         elements.copyResult.addEventListener('click', () => copyText(elements.testResult.textContent, 'MCP test result copied.', (message, type) => setStatus(elements.mcpTestStatus, message, type)));
+        elements.importJsonConfig.addEventListener('click', importJsonConfig);
+        elements.copyJsonRequirements.addEventListener('click', () => copyText(requiredJsonDescription(), 'JSON provider requirements copied.', (message, type) => setStatus(elements.jsonProviderStatus, message, type)));
 
         [
             elements.mcpName,
@@ -726,5 +935,6 @@
         state.selectedAgentId = workspace.selectedAgentId;
         state.selectedMcpId = workspace.selectedMcpId;
         renderAll();
+        elements.jsonRequirements.textContent = requiredJsonDescription();
     });
 })();

--- a/static/site.css
+++ b/static/site.css
@@ -1046,3 +1046,9 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
   .ai-tool-results { grid-template-columns:1fr; }
   .secret-input-row { flex-direction:column; }
 }
+.ai-chat-log { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface-alt); padding:.75rem; min-height:180px; max-height:360px; overflow:auto; margin-bottom:.75rem; }
+.ai-chat-message { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); padding:.65rem; margin-bottom:.6rem; }
+.ai-chat-message.user { border-left:4px solid var(--rci-primary); }
+.ai-chat-message.assistant { border-left:4px solid #1b7f3a; }
+.ai-chat-message strong { display:block; margin-bottom:.25rem; }
+.ai-chat-message p { margin:0; white-space:pre-wrap; }

--- a/tests/core/test_mcp_ai_features.py
+++ b/tests/core/test_mcp_ai_features.py
@@ -144,3 +144,71 @@ def test_mcp_test_endpoint_calls_selected_tool(monkeypatch):
     assert response.status_code == 200
     assert captured_call == {"name": "search_memories", "arguments": {"query": "road", "limit": 2}}
     assert response.json()["result"]["result"]["content"][0]["text"] == "ok"
+
+
+def test_agent_chat_endpoint_requires_admin(monkeypatch):
+    main = load_main(monkeypatch)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/ai/agent/chat",
+        json={
+            "name": "Road Analyst",
+            "runtime": "test-model",
+            "api_url": "https://api.example.com/v1/chat/completions",
+            "message": "hello",
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_agent_chat_endpoint_posts_openai_compatible_payload(monkeypatch):
+    main = load_main(monkeypatch)
+    captured = {}
+
+    def fake_post(url, json, headers, timeout):
+        captured.update({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        return FakeMcpResponse(
+            {
+                "choices": [
+                    {"message": {"role": "assistant", "content": "Use the road_tools MCP service to inspect anomalies."}}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(main.requests, "post", fake_post)
+    client = TestClient(main.app)
+    login_admin(client)
+
+    response = client.post(
+        "/ai/agent/chat",
+        json={
+            "name": "Road Analyst",
+            "provider": "OpenAI-compatible",
+            "runtime": "test-model",
+            "instructions": "Be concise.",
+            "api_url": "https://api.example.com/v1/chat/completions",
+            "api_key": "agent_secret",
+            "message": "What should I do?",
+            "history": [{"role": "user", "content": "Find a problem."}],
+            "mcp_services": [
+                {
+                    "enabled": True,
+                    "key": "road_tools",
+                    "name": "Road Tools",
+                    "url": "https://mcp.example.com/sse",
+                    "transport": "streamable_http",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["url"] == "https://api.example.com/v1/chat/completions"
+    assert captured["headers"]["Authorization"] == "Bearer agent_secret"
+    assert captured["json"]["model"] == "test-model"
+    assert captured["json"]["messages"][0]["role"] == "system"
+    assert "road_tools" in captured["json"]["messages"][0]["content"]
+    assert captured["json"]["messages"][-1] == {"role": "user", "content": "What should I do?"}
+    assert response.json()["message"] == "Use the road_tools MCP service to inspect anomalies."


### PR DESCRIPTION
### Motivation
- Let admins chat with OpenAI-compatible agent endpoints from the AI Features page and include enabled MCP services as explicit context for tool requests. 
- Provide a concise UI for sending/receiving chat turns and persisting agent connection details in the workspace. 
- Allow AI providers to push new agents or MCP service definitions into the workspace using a simple JSON contract.

### Description
- Add a new admin-protected chat proxy and helpers in `main.py`: `AiAgentChatRequest` / `AiAgentChatMessage` models, `_extract_agent_chat_content()` helper, and the `POST /ai/agent/chat` endpoint which validates HTTPS `api_url`, forwards bearer tokens, builds OpenAI-compatible `messages`, and returns extracted assistant text and raw payload. 
- Extend the AI Features UI: add `agent-api-url` and `agent-api-key` fields, a "Chat with agent" panel, and front-end chat handling functions (`sendAgentChat`, `appendChatMessage`, `readChatHistory`, `clearAgentChat`, `toggleAgentKeyVisibility`) in `static/ai-features.js` to post to the new proxy and render replies. 
- Add JSON provider/import support in the UI: `Import JSON` panel, `requiredJsonDescription()` text with the technical contract, `importJsonConfig()`, and normalization functions `normalizeImportedAgent()` / `normalizeImportedMcp()` to validate and import `agents` and `mcps` arrays into the browser workspace. 
- Add chat styles to `static/site.css` and update `static/ai-features.html` to include the chat panel and the JSON provider panel. 
- Add tests in `tests/core/test_mcp_ai_features.py` to cover admin protection and correct OpenAI-compatible payload formatting for the new chat proxy.

### Testing
- Ran JavaScript syntax check with `node --check static/ai-features.js` which succeeded. 
- Verified Python compile of the server with `python -m py_compile main.py` which succeeded. 
- Executed the new and existing API tests with `pytest tests/core/test_mcp_ai_features.py -q`, all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ea32a900832089f8e466268dc71a)