### PR TITLE
Add 'Pinky' remote AI agent page

### DIFF
--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -32,6 +32,7 @@
             <a href="tools.html">Tools</a>
             <a href="monitor.html">Monitor</a>
             <a href="ai-features.html">AI Features</a>
+            <a href="pinky.html">Pinky</a>
         </article>
         <article class="maintenance-hub-group">
             <h3>Memos/Shared</h3>

--- a/static/pinky.html
+++ b/static/pinky.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pinky</title>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <link rel="stylesheet" href="/static/site.css">
+    <script src="/static/utils.js"></script>
+    <script src="/static/pinky.js" defer></script>
+</head>
+<body>
+<nav id="page-links" class="page-links mb-1" data-rci-navigation aria-label="Primary navigation"></nav>
+<h1><img src="/static/logo.png" alt="Road Condition Indexer Logo" class="rci-logo">Pinky</h1>
+
+<section class="rci-card pinky-hero" aria-labelledby="pinky-title">
+    <div>
+        <p class="eyebrow">Remote AI agent</p>
+        <h2 id="pinky-title">Pinky Remote Access</h2>
+        <p class="rci-muted">Connect to the self-hosted Pinky HTTP JSON agent, review health and available tools, then send natural-language commands.</p>
+    </div>
+    <div class="pinky-status-pills" aria-label="Pinky remote summary">
+        <span id="pinky-health-pill" class="pill muted">Health unknown</span>
+        <span id="pinky-tool-count-pill" class="pill muted">29 tools expected</span>
+        <span class="pill muted">homey + google_workspace</span>
+    </div>
+</section>
+
+<main class="pinky-layout" aria-labelledby="pinky-title">
+    <section class="rci-card pinky-connection" aria-labelledby="pinky-connection-title">
+        <div class="pinky-panel-header">
+            <div>
+                <p class="eyebrow">Connection</p>
+                <h2 id="pinky-connection-title">Remote endpoint</h2>
+            </div>
+            <button type="button" id="pinky-health-check" class="secondary-button focus-ring">Check health</button>
+        </div>
+
+        <dl class="pinky-endpoint-list">
+            <div>
+                <dt>Base URL</dt>
+                <dd><a href="http://drifter.ddns.net:5000" target="_blank" rel="noopener">http://drifter.ddns.net:5000</a></dd>
+            </div>
+            <div>
+                <dt>Transport</dt>
+                <dd>http-json</dd>
+            </div>
+            <div>
+                <dt>Status</dt>
+                <dd>Validated ok on 2026-05-11</dd>
+            </div>
+            <div>
+                <dt>OpenAPI</dt>
+                <dd><a href="http://drifter.ddns.net:5000/openapi.json" target="_blank" rel="noopener">openapi.json</a></dd>
+            </div>
+            <div>
+                <dt>OMI manifest</dt>
+                <dd><a href="http://drifter.ddns.net:5000/.well-known/omi-tools.json" target="_blank" rel="noopener">omi-tools.json</a></dd>
+            </div>
+        </dl>
+
+        <form id="pinky-auth-form" class="pinky-form" autocomplete="off">
+            <label for="pinky-api-key">Bearer API key</label>
+            <div class="pinky-secret-row">
+                <input type="password" id="pinky-api-key" value="UB$6cv2#p9@YM34%" aria-describedby="pinky-api-key-help">
+                <button type="button" id="pinky-toggle-key" class="secondary-button focus-ring" aria-pressed="false">Show</button>
+            </div>
+            <small id="pinky-api-key-help" class="rci-muted">Used only in browser requests to protected /api/* endpoints. The public health check does not require authentication.</small>
+            <label class="toggle-row pinky-remember-row"><input type="checkbox" id="pinky-remember-key"> <span>Remember this key in this browser</span></label>
+        </form>
+
+        <div id="pinky-status-message" class="status-message" role="status" aria-live="polite"></div>
+    </section>
+
+    <section class="rci-card pinky-command" aria-labelledby="pinky-command-title">
+        <div class="pinky-panel-header">
+            <div>
+                <p class="eyebrow">Command</p>
+                <h2 id="pinky-command-title">Ask Pinky</h2>
+            </div>
+            <button type="button" id="pinky-clear-command" class="secondary-button focus-ring">Clear</button>
+        </div>
+        <form id="pinky-command-form" class="pinky-form">
+            <label for="pinky-command-input">Command</label>
+            <textarea id="pinky-command-input" rows="5" required>List my next 5 calendar events</textarea>
+            <div class="pinky-actions">
+                <button type="submit" id="pinky-send-command" class="focus-ring">Send command</button>
+                <button type="button" id="pinky-load-status" class="secondary-button focus-ring">Load status</button>
+                <button type="button" id="pinky-load-tools" class="secondary-button focus-ring">Load tools</button>
+            </div>
+        </form>
+    </section>
+
+    <section class="rci-card pinky-tools" aria-labelledby="pinky-tools-title">
+        <div class="pinky-panel-header">
+            <div>
+                <p class="eyebrow">Tools</p>
+                <h2 id="pinky-tools-title">Available tool list</h2>
+            </div>
+            <span id="pinky-tools-summary" class="pill muted">Not loaded</span>
+        </div>
+        <div id="pinky-tools-list" class="pinky-tools-list" aria-live="polite">Load tools to see Pinky's capabilities.</div>
+    </section>
+
+    <section class="rci-card pinky-response" aria-labelledby="pinky-response-title">
+        <div class="pinky-panel-header">
+            <div>
+                <p class="eyebrow">Response</p>
+                <h2 id="pinky-response-title">Latest result</h2>
+            </div>
+            <button type="button" id="pinky-copy-response" class="secondary-button focus-ring">Copy JSON</button>
+        </div>
+        <pre id="pinky-response-output" class="ai-code-block pinky-output" aria-live="polite">No response yet.</pre>
+    </section>
+
+    <section class="rci-card pinky-confirm" aria-labelledby="pinky-confirm-title">
+        <div class="pinky-panel-header">
+            <div>
+                <p class="eyebrow">Confirmations</p>
+                <h2 id="pinky-confirm-title">Confirm a pending action</h2>
+            </div>
+        </div>
+        <form id="pinky-confirm-form" class="pinky-form">
+            <label for="pinky-confirm-token">Confirmation token</label>
+            <input type="text" id="pinky-confirm-token" placeholder="Paste token from Pinky's response">
+            <div class="pinky-actions">
+                <button type="submit" class="secondary-button focus-ring">Confirm token</button>
+            </div>
+        </form>
+    </section>
+</main>
+</body>
+</html>

--- a/static/pinky.js
+++ b/static/pinky.js
@@ -1,0 +1,266 @@
+const PINKY_CONFIG = {
+    baseUrl: 'http://drifter.ddns.net:5000',
+    endpoints: {
+        health: 'http://drifter.ddns.net:5000/api/health',
+        tools: 'http://drifter.ddns.net:5000/api/tools',
+        command: 'http://drifter.ddns.net:5000/api/command',
+        status: 'http://drifter.ddns.net:5000/api/status',
+        confirm: token => `http://drifter.ddns.net:5000/api/confirm/${encodeURIComponent(token)}`
+    },
+    recommendedApiKey: 'UB$6cv2#p9@YM34%',
+    expectedToolCount: 29,
+    storageKey: 'rci-pinky-api-key'
+};
+
+const pinkyState = {
+    latestResponse: null
+};
+
+function pinkyElement(id) {
+    return document.getElementById(id);
+}
+
+function setPinkyMessage(message, type = 'success') {
+    const status = pinkyElement('pinky-status-message');
+    status.textContent = message;
+    status.className = `status-message ${type}`;
+    status.style.display = 'block';
+}
+
+function getPinkyApiKey() {
+    return pinkyElement('pinky-api-key').value.trim();
+}
+
+function getPinkyHeaders(includeJson = false) {
+    const apiKey = getPinkyApiKey();
+    const headers = {};
+    if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
+    }
+    if (includeJson) {
+        headers['Content-Type'] = 'application/json';
+    }
+    return headers;
+}
+
+function prettyJson(value) {
+    return JSON.stringify(value, null, 2);
+}
+
+function setPinkyResponse(value) {
+    pinkyState.latestResponse = value;
+    pinkyElement('pinky-response-output').textContent = typeof value === 'string' ? value : prettyJson(value);
+}
+
+function describeFetchError(error) {
+    if (window.location.protocol === 'https:' && PINKY_CONFIG.baseUrl.startsWith('http://')) {
+        return `${error.message}. This page is using HTTPS while Pinky is exposed over HTTP, so the browser may block mixed-content requests.`;
+    }
+    return `${error.message}. Check that Pinky is reachable and allows browser CORS requests from this site.`;
+}
+
+async function pinkyFetch(url, options = {}) {
+    const response = await fetch(url, options);
+    const contentType = response.headers.get('content-type') || '';
+    const payload = contentType.includes('application/json') ? await response.json() : await response.text();
+    if (!response.ok) {
+        const message = typeof payload === 'string' ? payload : (payload.detail || payload.message || prettyJson(payload));
+        throw new Error(`HTTP ${response.status}: ${message}`);
+    }
+    return payload;
+}
+
+async function checkPinkyHealth() {
+    try {
+        setPinkyMessage('Checking Pinky health...', 'warning');
+        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.health);
+        setPinkyResponse(payload);
+        const healthStatus = payload.status || payload.health_status || 'ok';
+        pinkyElement('pinky-health-pill').textContent = `Health ${healthStatus}`;
+        pinkyElement('pinky-health-pill').className = 'pill success';
+        setPinkyMessage('Pinky health check completed.', 'success');
+    } catch (error) {
+        pinkyElement('pinky-health-pill').textContent = 'Health unavailable';
+        pinkyElement('pinky-health-pill').className = 'pill muted';
+        setPinkyResponse({ error: describeFetchError(error) });
+        setPinkyMessage(describeFetchError(error), 'error');
+    }
+}
+
+function normalizePinkyTools(payload) {
+    if (Array.isArray(payload)) return payload;
+    if (payload && Array.isArray(payload.tools)) return payload.tools;
+    if (payload && payload.data && Array.isArray(payload.data.tools)) return payload.data.tools;
+    return [];
+}
+
+function renderPinkyTools(tools) {
+    const container = pinkyElement('pinky-tools-list');
+    container.innerHTML = '';
+    if (!tools.length) {
+        container.textContent = 'No tools were returned by Pinky.';
+        pinkyElement('pinky-tools-summary').textContent = '0 tools';
+        return;
+    }
+
+    tools.forEach(tool => {
+        const card = document.createElement('article');
+        card.className = 'ai-tool-card';
+        const title = document.createElement('h5');
+        title.textContent = tool.name || tool.id || 'Unnamed tool';
+        const description = document.createElement('p');
+        description.textContent = tool.description || tool.summary || 'No description provided.';
+        const metadata = document.createElement('small');
+        metadata.textContent = tool.server || tool.category || tool.input_schema ? prettyJson(tool.input_schema || tool.parameters || tool) : '';
+        card.append(title, description);
+        if (metadata.textContent) card.appendChild(metadata);
+        container.appendChild(card);
+    });
+
+    pinkyElement('pinky-tools-summary').textContent = `${tools.length} tools loaded`;
+    pinkyElement('pinky-tool-count-pill').textContent = `${tools.length} tools available`;
+}
+
+async function loadPinkyTools() {
+    try {
+        setPinkyMessage('Loading Pinky tools...', 'warning');
+        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.tools, {
+            headers: getPinkyHeaders()
+        });
+        const tools = normalizePinkyTools(payload);
+        renderPinkyTools(tools);
+        setPinkyResponse(payload);
+        setPinkyMessage('Pinky tools loaded.', 'success');
+    } catch (error) {
+        setPinkyResponse({ error: describeFetchError(error) });
+        setPinkyMessage(describeFetchError(error), 'error');
+    }
+}
+
+async function loadPinkyStatus() {
+    try {
+        setPinkyMessage('Loading Pinky status...', 'warning');
+        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.status, {
+            headers: getPinkyHeaders()
+        });
+        setPinkyResponse(payload);
+        setPinkyMessage('Pinky status loaded.', 'success');
+    } catch (error) {
+        setPinkyResponse({ error: describeFetchError(error) });
+        setPinkyMessage(describeFetchError(error), 'error');
+    }
+}
+
+async function sendPinkyCommand(event) {
+    event.preventDefault();
+    const commandInput = pinkyElement('pinky-command-input');
+    const command = commandInput.value.trim();
+    if (!command) {
+        setPinkyMessage('Enter a command before sending it to Pinky.', 'error');
+        commandInput.focus();
+        return;
+    }
+
+    try {
+        pinkyElement('pinky-send-command').disabled = true;
+        setPinkyMessage('Sending command to Pinky...', 'warning');
+        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.command, {
+            method: 'POST',
+            headers: getPinkyHeaders(true),
+            body: JSON.stringify({ command })
+        });
+        setPinkyResponse(payload);
+        setPinkyMessage('Pinky command completed.', 'success');
+    } catch (error) {
+        setPinkyResponse({ error: describeFetchError(error) });
+        setPinkyMessage(describeFetchError(error), 'error');
+    } finally {
+        pinkyElement('pinky-send-command').disabled = false;
+    }
+}
+
+async function confirmPinkyToken(event) {
+    event.preventDefault();
+    const tokenInput = pinkyElement('pinky-confirm-token');
+    const token = tokenInput.value.trim();
+    if (!token) {
+        setPinkyMessage('Paste a confirmation token before confirming.', 'error');
+        tokenInput.focus();
+        return;
+    }
+
+    try {
+        setPinkyMessage('Confirming Pinky token...', 'warning');
+        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.confirm(token), {
+            method: 'POST',
+            headers: getPinkyHeaders()
+        });
+        setPinkyResponse(payload);
+        setPinkyMessage('Pinky confirmation completed.', 'success');
+    } catch (error) {
+        setPinkyResponse({ error: describeFetchError(error) });
+        setPinkyMessage(describeFetchError(error), 'error');
+    }
+}
+
+function restorePinkyKey() {
+    const rememberedKey = localStorage.getItem(PINKY_CONFIG.storageKey);
+    if (rememberedKey) {
+        pinkyElement('pinky-api-key').value = rememberedKey;
+        pinkyElement('pinky-remember-key').checked = true;
+    }
+}
+
+function persistPinkyKeyPreference() {
+    if (pinkyElement('pinky-remember-key').checked) {
+        localStorage.setItem(PINKY_CONFIG.storageKey, getPinkyApiKey());
+    } else {
+        localStorage.removeItem(PINKY_CONFIG.storageKey);
+    }
+}
+
+function togglePinkyKeyVisibility() {
+    const input = pinkyElement('pinky-api-key');
+    const button = pinkyElement('pinky-toggle-key');
+    const showing = input.type === 'text';
+    input.type = showing ? 'password' : 'text';
+    button.textContent = showing ? 'Show' : 'Hide';
+    button.setAttribute('aria-pressed', String(!showing));
+}
+
+async function copyPinkyResponse() {
+    const content = pinkyElement('pinky-response-output').textContent;
+    try {
+        await navigator.clipboard.writeText(content);
+        setPinkyMessage('Copied the latest Pinky response to the clipboard.', 'success');
+    } catch (error) {
+        setPinkyMessage(`Could not copy response: ${error.message}`, 'error');
+    }
+}
+
+function initializePinkyPage() {
+    restorePinkyKey();
+    pinkyElement('pinky-health-check').addEventListener('click', checkPinkyHealth);
+    pinkyElement('pinky-load-tools').addEventListener('click', loadPinkyTools);
+    pinkyElement('pinky-load-status').addEventListener('click', loadPinkyStatus);
+    pinkyElement('pinky-command-form').addEventListener('submit', sendPinkyCommand);
+    pinkyElement('pinky-confirm-form').addEventListener('submit', confirmPinkyToken);
+    pinkyElement('pinky-toggle-key').addEventListener('click', togglePinkyKeyVisibility);
+    pinkyElement('pinky-remember-key').addEventListener('change', persistPinkyKeyPreference);
+    pinkyElement('pinky-api-key').addEventListener('input', persistPinkyKeyPreference);
+    pinkyElement('pinky-copy-response').addEventListener('click', copyPinkyResponse);
+    pinkyElement('pinky-clear-command').addEventListener('click', () => {
+        pinkyElement('pinky-command-input').value = '';
+        pinkyElement('pinky-command-input').focus();
+    });
+
+    setPinkyResponse({
+        name: 'Pinky Remote Access',
+        transport: 'http-json',
+        base_url: PINKY_CONFIG.baseUrl,
+        expected_tool_count: PINKY_CONFIG.expectedToolCount,
+        protected_endpoints_use: 'Authorization: Bearer <api key>'
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initializePinkyPage);

--- a/static/site.css
+++ b/static/site.css
@@ -1052,3 +1052,53 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
 .ai-chat-message.assistant { border-left:4px solid #1b7f3a; }
 .ai-chat-message strong { display:block; margin-bottom:.25rem; }
 .ai-chat-message p { margin:0; white-space:pre-wrap; }
+
+/* Pinky remote agent page */
+.pinky-hero {
+  display:flex;
+  justify-content:space-between;
+  gap:1rem;
+  align-items:center;
+  margin-bottom:1rem;
+  background:linear-gradient(135deg, var(--rci-surface), var(--rci-surface-alt));
+}
+.pinky-hero h2 { margin:.2rem 0 .35rem; }
+.pinky-status-pills,
+.pinky-actions { display:flex; flex-wrap:wrap; gap:.5rem; align-items:center; }
+.pinky-layout { display:grid; grid-template-columns:minmax(280px, 380px) minmax(0, 1fr); gap:1rem; align-items:start; }
+.pinky-panel-header { display:flex; justify-content:space-between; gap:1rem; align-items:flex-start; margin-bottom:1rem; }
+.pinky-panel-header h2 { margin:.1rem 0 .25rem; }
+.pinky-connection,
+.pinky-tools { min-width:0; }
+.pinky-command,
+.pinky-response,
+.pinky-confirm { min-width:0; }
+.pinky-endpoint-list { display:grid; gap:.65rem; margin:0 0 1rem; }
+.pinky-endpoint-list div { display:grid; grid-template-columns:110px minmax(0, 1fr); gap:.75rem; align-items:start; }
+.pinky-endpoint-list dt { color:var(--rci-text-muted); font-size:.78rem; font-weight:700; letter-spacing:.04em; text-transform:uppercase; }
+.pinky-endpoint-list dd { margin:0; overflow-wrap:anywhere; }
+.pinky-form { display:flex; flex-direction:column; gap:.55rem; }
+.pinky-form label:not(.toggle-row) { color:var(--rci-text-muted); font-size:.78rem; font-weight:700; letter-spacing:.04em; text-transform:uppercase; }
+.pinky-form input[type="text"],
+.pinky-form input[type="password"],
+.pinky-form textarea { width:100%; box-sizing:border-box; padding:.65rem .75rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); color:var(--rci-text); font:inherit; }
+.pinky-form input:focus,
+.pinky-form textarea:focus { outline:none; border-color:var(--rci-primary); box-shadow:var(--rci-focus-ring); }
+.pinky-form textarea { resize:vertical; min-height:140px; }
+.pinky-secret-row { display:flex; gap:.5rem; align-items:stretch; }
+.pinky-secret-row input { flex:1; }
+.pinky-remember-row { margin-top:.25rem; }
+.pinky-tools-list { border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface-alt); padding:.75rem; min-height:220px; max-height:520px; overflow:auto; }
+.pinky-output { min-height:260px; margin:0; background:var(--rci-surface-alt); border:1px solid var(--rci-border); border-radius:var(--rci-radius); padding:1rem; }
+@media (min-width:981px){
+  .pinky-connection { grid-row:span 3; }
+}
+@media (max-width:980px){
+  .pinky-layout { grid-template-columns:1fr; }
+}
+@media (max-width:700px){
+  .pinky-hero,
+  .pinky-panel-header { flex-direction:column; align-items:flex-start; }
+  .pinky-endpoint-list div { grid-template-columns:1fr; gap:.25rem; }
+  .pinky-secret-row { flex-direction:column; }
+}

--- a/static/utils.js
+++ b/static/utils.js
@@ -689,7 +689,8 @@ const RCI_NAV_GROUPS = [
             { label: 'Audio & Video', href: '/static/av-tools.html', paths: ['/static/av-tools.html'] },
             { label: 'Shared Objects', href: '/static/shared.html', paths: ['/static/shared.html'] },
             { label: 'Monitor', href: '/static/monitor.html', paths: ['/static/monitor.html'] },
-            { label: 'AI Features', href: '/static/ai-features.html', paths: ['/static/ai-features.html'] }
+            { label: 'AI Features', href: '/static/ai-features.html', paths: ['/static/ai-features.html'] },
+            { label: 'Pinky', href: '/static/pinky.html', paths: ['/static/pinky.html'] }
         ]
     },
     {


### PR DESCRIPTION
### Motivation
- Provide a new UI to interact with a self-hosted HTTP/JSON AI agent named Pinky using the supplied endpoints and bearer auth details.
- Make it easy to inspect health, list tools, send commands, confirm pending actions, and view raw responses from the browser.

### Description
- Added a new static page `static/pinky.html` that exposes panels for connection details, health check, tools list, command input, response viewer, and confirmation token workflow.
- Implemented client-side integration in `static/pinky.js` including `PINKY_CONFIG`, fetch helpers, `checkPinkyHealth`, `loadPinkyTools`, `loadPinkyStatus`, `sendPinkyCommand`, `confirmPinkyToken`, localStorage opt-in for the API key, response rendering, and copy-to-clipboard support.
- Added Pinky to the primary Tools navigation (`static/utils.js`) and linked it from the Maintenance Hub (`static/maintenance.html`).
- Added responsive styling for the new page in `static/site.css` and included UX-friendly error messaging for mixed-content/CORS scenarios.

### Testing
- Ran `node --check static/pinky.js` and it completed without syntax errors.
- Ran `python -m pytest tests/core/test_imports.py` and the suite passed (`3 passed`).
- Ran `git diff --check` to verify there are no outstanding whitespace/diff issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ef79be10832093d0a160bc4e6100)