### PR TITLE
Make Pinky settings configurable and persist them in-browser

### DIFF
--- a/static/pinky.html
+++ b/static/pinky.html
@@ -39,25 +39,61 @@
         <dl class="pinky-endpoint-list">
             <div>
                 <dt>Base URL</dt>
-                <dd><a href="http://drifter.ddns.net:5000" target="_blank" rel="noopener">http://drifter.ddns.net:5000</a></dd>
+                <dd><a id="pinky-base-url-link" href="http://drifter.ddns.net:5000" target="_blank" rel="noopener">http://drifter.ddns.net:5000</a></dd>
             </div>
             <div>
                 <dt>Transport</dt>
-                <dd>http-json</dd>
+                <dd id="pinky-transport-label">http-json</dd>
             </div>
             <div>
                 <dt>Status</dt>
-                <dd>Validated ok on 2026-05-11</dd>
+                <dd id="pinky-validation-label">Validated ok on 2026-05-11</dd>
             </div>
             <div>
                 <dt>OpenAPI</dt>
-                <dd><a href="http://drifter.ddns.net:5000/openapi.json" target="_blank" rel="noopener">openapi.json</a></dd>
+                <dd><a id="pinky-openapi-link" href="http://drifter.ddns.net:5000/openapi.json" target="_blank" rel="noopener">openapi.json</a></dd>
             </div>
             <div>
                 <dt>OMI manifest</dt>
-                <dd><a href="http://drifter.ddns.net:5000/.well-known/omi-tools.json" target="_blank" rel="noopener">omi-tools.json</a></dd>
+                <dd><a id="pinky-manifest-link" href="http://drifter.ddns.net:5000/.well-known/omi-tools.json" target="_blank" rel="noopener">omi-tools.json</a></dd>
             </div>
         </dl>
+
+        <form id="pinky-settings-form" class="pinky-form pinky-settings-form" autocomplete="off">
+            <label for="pinky-base-url">Base URL</label>
+            <input type="url" id="pinky-base-url" value="http://drifter.ddns.net:5000" required>
+            <div class="pinky-settings-grid">
+                <div>
+                    <label for="pinky-health-path">Health path</label>
+                    <input type="text" id="pinky-health-path" value="/api/health" required>
+                </div>
+                <div>
+                    <label for="pinky-tools-path">Tools path</label>
+                    <input type="text" id="pinky-tools-path" value="/api/tools" required>
+                </div>
+                <div>
+                    <label for="pinky-command-path">Command path</label>
+                    <input type="text" id="pinky-command-path" value="/api/command" required>
+                </div>
+                <div>
+                    <label for="pinky-status-path">Status path</label>
+                    <input type="text" id="pinky-status-path" value="/api/status" required>
+                </div>
+                <div>
+                    <label for="pinky-confirm-path">Confirm path</label>
+                    <input type="text" id="pinky-confirm-path" value="/api/confirm/{token}" required>
+                </div>
+                <div>
+                    <label for="pinky-expected-tools">Expected tools</label>
+                    <input type="number" id="pinky-expected-tools" value="29" min="0" step="1" required>
+                </div>
+            </div>
+            <div class="pinky-actions">
+                <button type="button" id="pinky-save-settings" class="secondary-button focus-ring">Save settings</button>
+                <button type="button" id="pinky-reset-settings" class="secondary-button focus-ring">Reset defaults</button>
+            </div>
+            <small class="rci-muted">Save settings to remember them in this browser and use them to build Pinky's request URLs. Use {token} in the confirmation path where the token should be inserted.</small>
+        </form>
 
         <form id="pinky-auth-form" class="pinky-form" autocomplete="off">
             <label for="pinky-api-key">Bearer API key</label>

--- a/static/pinky.js
+++ b/static/pinky.js
@@ -1,19 +1,24 @@
-const PINKY_CONFIG = {
+const DEFAULT_PINKY_SETTINGS = {
     baseUrl: 'http://drifter.ddns.net:5000',
-    endpoints: {
-        health: 'http://drifter.ddns.net:5000/api/health',
-        tools: 'http://drifter.ddns.net:5000/api/tools',
-        command: 'http://drifter.ddns.net:5000/api/command',
-        status: 'http://drifter.ddns.net:5000/api/status',
-        confirm: token => `http://drifter.ddns.net:5000/api/confirm/${encodeURIComponent(token)}`
-    },
-    recommendedApiKey: 'UB$6cv2#p9@YM34%',
+    healthPath: '/api/health',
+    toolsPath: '/api/tools',
+    commandPath: '/api/command',
+    statusPath: '/api/status',
+    confirmPath: '/api/confirm/{token}',
     expectedToolCount: 29,
-    storageKey: 'rci-pinky-api-key'
+    transport: 'http-json',
+    validationStatus: 'Validated ok on 2026-05-11'
+};
+
+const PINKY_CONFIG = {
+    recommendedApiKey: 'UB$6cv2#p9@YM34%',
+    apiKeyStorageKey: 'rci-pinky-api-key',
+    settingsStorageKey: 'rci-pinky-settings'
 };
 
 const pinkyState = {
-    latestResponse: null
+    latestResponse: null,
+    settings: { ...DEFAULT_PINKY_SETTINGS }
 };
 
 function pinkyElement(id) {
@@ -25,6 +30,61 @@ function setPinkyMessage(message, type = 'success') {
     status.textContent = message;
     status.className = `status-message ${type}`;
     status.style.display = 'block';
+}
+
+function normalizePinkyBaseUrl(baseUrl) {
+    const trimmed = String(baseUrl || '').trim().replace(/\/+$/, '');
+    if (!trimmed) return DEFAULT_PINKY_SETTINGS.baseUrl;
+    const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+    try {
+        return new URL(candidate).origin;
+    } catch (error) {
+        return DEFAULT_PINKY_SETTINGS.baseUrl;
+    }
+}
+
+function normalizePinkyPath(path, fallback) {
+    const trimmed = String(path || '').trim();
+    if (!trimmed) return fallback;
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function normalizePinkySettings(settings = {}) {
+    const expectedToolCount = Number.parseInt(settings.expectedToolCount, 10);
+    return {
+        ...DEFAULT_PINKY_SETTINGS,
+        ...settings,
+        baseUrl: normalizePinkyBaseUrl(settings.baseUrl || DEFAULT_PINKY_SETTINGS.baseUrl),
+        healthPath: normalizePinkyPath(settings.healthPath, DEFAULT_PINKY_SETTINGS.healthPath),
+        toolsPath: normalizePinkyPath(settings.toolsPath, DEFAULT_PINKY_SETTINGS.toolsPath),
+        commandPath: normalizePinkyPath(settings.commandPath, DEFAULT_PINKY_SETTINGS.commandPath),
+        statusPath: normalizePinkyPath(settings.statusPath, DEFAULT_PINKY_SETTINGS.statusPath),
+        confirmPath: normalizePinkyPath(settings.confirmPath, DEFAULT_PINKY_SETTINGS.confirmPath),
+        expectedToolCount: Number.isFinite(expectedToolCount) && expectedToolCount >= 0 ? expectedToolCount : DEFAULT_PINKY_SETTINGS.expectedToolCount
+    };
+}
+
+function buildPinkyUrl(path) {
+    const settings = pinkyState.settings;
+    if (/^https?:\/\//i.test(path)) return path;
+    const baseUrl = settings.baseUrl.endsWith('/') ? settings.baseUrl : `${settings.baseUrl}/`;
+    try {
+        return new URL(path.replace(/^\/+/, ''), baseUrl).toString();
+    } catch (error) {
+        return new URL(path.replace(/^\/+/, ''), `${DEFAULT_PINKY_SETTINGS.baseUrl}/`).toString();
+    }
+}
+
+function getPinkyEndpoints() {
+    const settings = pinkyState.settings;
+    return {
+        health: buildPinkyUrl(settings.healthPath),
+        tools: buildPinkyUrl(settings.toolsPath),
+        command: buildPinkyUrl(settings.commandPath),
+        status: buildPinkyUrl(settings.statusPath),
+        confirm: token => buildPinkyUrl(settings.confirmPath.replace('{token}', encodeURIComponent(token)))
+    };
 }
 
 function getPinkyApiKey() {
@@ -53,7 +113,7 @@ function setPinkyResponse(value) {
 }
 
 function describeFetchError(error) {
-    if (window.location.protocol === 'https:' && PINKY_CONFIG.baseUrl.startsWith('http://')) {
+    if (window.location.protocol === 'https:' && pinkyState.settings.baseUrl.startsWith('http://')) {
         return `${error.message}. This page is using HTTPS while Pinky is exposed over HTTP, so the browser may block mixed-content requests.`;
     }
     return `${error.message}. Check that Pinky is reachable and allows browser CORS requests from this site.`;
@@ -73,7 +133,7 @@ async function pinkyFetch(url, options = {}) {
 async function checkPinkyHealth() {
     try {
         setPinkyMessage('Checking Pinky health...', 'warning');
-        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.health);
+        const payload = await pinkyFetch(getPinkyEndpoints().health);
         setPinkyResponse(payload);
         const healthStatus = payload.status || payload.health_status || 'ok';
         pinkyElement('pinky-health-pill').textContent = `Health ${healthStatus}`;
@@ -124,7 +184,7 @@ function renderPinkyTools(tools) {
 async function loadPinkyTools() {
     try {
         setPinkyMessage('Loading Pinky tools...', 'warning');
-        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.tools, {
+        const payload = await pinkyFetch(getPinkyEndpoints().tools, {
             headers: getPinkyHeaders()
         });
         const tools = normalizePinkyTools(payload);
@@ -140,7 +200,7 @@ async function loadPinkyTools() {
 async function loadPinkyStatus() {
     try {
         setPinkyMessage('Loading Pinky status...', 'warning');
-        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.status, {
+        const payload = await pinkyFetch(getPinkyEndpoints().status, {
             headers: getPinkyHeaders()
         });
         setPinkyResponse(payload);
@@ -164,7 +224,7 @@ async function sendPinkyCommand(event) {
     try {
         pinkyElement('pinky-send-command').disabled = true;
         setPinkyMessage('Sending command to Pinky...', 'warning');
-        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.command, {
+        const payload = await pinkyFetch(getPinkyEndpoints().command, {
             method: 'POST',
             headers: getPinkyHeaders(true),
             body: JSON.stringify({ command })
@@ -191,7 +251,7 @@ async function confirmPinkyToken(event) {
 
     try {
         setPinkyMessage('Confirming Pinky token...', 'warning');
-        const payload = await pinkyFetch(PINKY_CONFIG.endpoints.confirm(token), {
+        const payload = await pinkyFetch(getPinkyEndpoints().confirm(token), {
             method: 'POST',
             headers: getPinkyHeaders()
         });
@@ -204,7 +264,7 @@ async function confirmPinkyToken(event) {
 }
 
 function restorePinkyKey() {
-    const rememberedKey = localStorage.getItem(PINKY_CONFIG.storageKey);
+    const rememberedKey = localStorage.getItem(PINKY_CONFIG.apiKeyStorageKey);
     if (rememberedKey) {
         pinkyElement('pinky-api-key').value = rememberedKey;
         pinkyElement('pinky-remember-key').checked = true;
@@ -213,10 +273,85 @@ function restorePinkyKey() {
 
 function persistPinkyKeyPreference() {
     if (pinkyElement('pinky-remember-key').checked) {
-        localStorage.setItem(PINKY_CONFIG.storageKey, getPinkyApiKey());
+        localStorage.setItem(PINKY_CONFIG.apiKeyStorageKey, getPinkyApiKey());
     } else {
-        localStorage.removeItem(PINKY_CONFIG.storageKey);
+        localStorage.removeItem(PINKY_CONFIG.apiKeyStorageKey);
     }
+}
+
+function getPinkySettingsFromForm() {
+    return normalizePinkySettings({
+        baseUrl: pinkyElement('pinky-base-url').value,
+        healthPath: pinkyElement('pinky-health-path').value,
+        toolsPath: pinkyElement('pinky-tools-path').value,
+        commandPath: pinkyElement('pinky-command-path').value,
+        statusPath: pinkyElement('pinky-status-path').value,
+        confirmPath: pinkyElement('pinky-confirm-path').value,
+        expectedToolCount: pinkyElement('pinky-expected-tools').value
+    });
+}
+
+function applyPinkySettings(settings) {
+    pinkyState.settings = normalizePinkySettings(settings);
+    pinkyElement('pinky-base-url').value = pinkyState.settings.baseUrl;
+    pinkyElement('pinky-health-path').value = pinkyState.settings.healthPath;
+    pinkyElement('pinky-tools-path').value = pinkyState.settings.toolsPath;
+    pinkyElement('pinky-command-path').value = pinkyState.settings.commandPath;
+    pinkyElement('pinky-status-path').value = pinkyState.settings.statusPath;
+    pinkyElement('pinky-confirm-path').value = pinkyState.settings.confirmPath;
+    pinkyElement('pinky-expected-tools').value = pinkyState.settings.expectedToolCount;
+    updatePinkyEndpointSummary();
+}
+
+function persistPinkySettings(showMessage = true) {
+    const settings = getPinkySettingsFromForm();
+    applyPinkySettings(settings);
+    localStorage.setItem(PINKY_CONFIG.settingsStorageKey, JSON.stringify(pinkyState.settings));
+    if (showMessage) {
+        setPinkyMessage('Pinky settings saved in this browser.', 'success');
+    }
+}
+
+function restorePinkySettings() {
+    const rememberedSettings = localStorage.getItem(PINKY_CONFIG.settingsStorageKey);
+    if (!rememberedSettings) {
+        applyPinkySettings(DEFAULT_PINKY_SETTINGS);
+        return;
+    }
+
+    try {
+        applyPinkySettings(JSON.parse(rememberedSettings));
+    } catch (error) {
+        applyPinkySettings(DEFAULT_PINKY_SETTINGS);
+        localStorage.removeItem(PINKY_CONFIG.settingsStorageKey);
+        setPinkyMessage(`Saved Pinky settings could not be loaded: ${error.message}`, 'error');
+    }
+}
+
+function resetPinkySettings() {
+    localStorage.removeItem(PINKY_CONFIG.settingsStorageKey);
+    applyPinkySettings(DEFAULT_PINKY_SETTINGS);
+    setPinkyMessage('Pinky settings reset to defaults.', 'success');
+}
+
+function updatePinkyEndpointSummary() {
+    const endpoints = getPinkyEndpoints();
+    const baseUrlLink = pinkyElement('pinky-base-url-link');
+    baseUrlLink.href = pinkyState.settings.baseUrl;
+    baseUrlLink.textContent = pinkyState.settings.baseUrl;
+    pinkyElement('pinky-transport-label').textContent = pinkyState.settings.transport;
+    pinkyElement('pinky-validation-label').textContent = pinkyState.settings.validationStatus;
+    pinkyElement('pinky-openapi-link').href = buildPinkyUrl('/openapi.json');
+    pinkyElement('pinky-manifest-link').href = buildPinkyUrl('/.well-known/omi-tools.json');
+    pinkyElement('pinky-tool-count-pill').textContent = `${pinkyState.settings.expectedToolCount} tools expected`;
+    setPinkyResponse({
+        name: 'Pinky Remote Access',
+        transport: pinkyState.settings.transport,
+        base_url: pinkyState.settings.baseUrl,
+        endpoints,
+        expected_tool_count: pinkyState.settings.expectedToolCount,
+        protected_endpoints_use: 'Authorization: Bearer <api key>'
+    });
 }
 
 function togglePinkyKeyVisibility() {
@@ -239,6 +374,7 @@ async function copyPinkyResponse() {
 }
 
 function initializePinkyPage() {
+    restorePinkySettings();
     restorePinkyKey();
     pinkyElement('pinky-health-check').addEventListener('click', checkPinkyHealth);
     pinkyElement('pinky-load-tools').addEventListener('click', loadPinkyTools);
@@ -248,18 +384,19 @@ function initializePinkyPage() {
     pinkyElement('pinky-toggle-key').addEventListener('click', togglePinkyKeyVisibility);
     pinkyElement('pinky-remember-key').addEventListener('change', persistPinkyKeyPreference);
     pinkyElement('pinky-api-key').addEventListener('input', persistPinkyKeyPreference);
+    pinkyElement('pinky-save-settings').addEventListener('click', () => persistPinkySettings());
+    pinkyElement('pinky-reset-settings').addEventListener('click', resetPinkySettings);
+    pinkyElement('pinky-settings-form').addEventListener('input', () => {
+        applyPinkySettings(getPinkySettingsFromForm());
+    });
+    pinkyElement('pinky-settings-form').addEventListener('submit', event => {
+        event.preventDefault();
+        persistPinkySettings();
+    });
     pinkyElement('pinky-copy-response').addEventListener('click', copyPinkyResponse);
     pinkyElement('pinky-clear-command').addEventListener('click', () => {
         pinkyElement('pinky-command-input').value = '';
         pinkyElement('pinky-command-input').focus();
-    });
-
-    setPinkyResponse({
-        name: 'Pinky Remote Access',
-        transport: 'http-json',
-        base_url: PINKY_CONFIG.baseUrl,
-        expected_tool_count: PINKY_CONFIG.expectedToolCount,
-        protected_endpoints_use: 'Authorization: Bearer <api key>'
     });
 }
 

--- a/static/site.css
+++ b/static/site.css
@@ -1081,10 +1081,15 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
 .pinky-form label:not(.toggle-row) { color:var(--rci-text-muted); font-size:.78rem; font-weight:700; letter-spacing:.04em; text-transform:uppercase; }
 .pinky-form input[type="text"],
 .pinky-form input[type="password"],
+.pinky-form input[type="url"],
+.pinky-form input[type="number"],
 .pinky-form textarea { width:100%; box-sizing:border-box; padding:.65rem .75rem; border:1px solid var(--rci-border); border-radius:var(--rci-radius); background:var(--rci-surface); color:var(--rci-text); font:inherit; }
 .pinky-form input:focus,
 .pinky-form textarea:focus { outline:none; border-color:var(--rci-primary); box-shadow:var(--rci-focus-ring); }
 .pinky-form textarea { resize:vertical; min-height:140px; }
+.pinky-settings-form { margin-bottom:1rem; padding-bottom:1rem; border-bottom:1px solid var(--rci-border); }
+.pinky-settings-grid { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:.65rem; }
+.pinky-settings-grid > div { min-width:0; }
 .pinky-secret-row { display:flex; gap:.5rem; align-items:stretch; }
 .pinky-secret-row input { flex:1; }
 .pinky-remember-row { margin-top:.25rem; }
@@ -1100,5 +1105,6 @@ option.selected-default { background-color:var(--rci-primary-accent) !important;
   .pinky-hero,
   .pinky-panel-header { flex-direction:column; align-items:flex-start; }
   .pinky-endpoint-list div { grid-template-columns:1fr; gap:.25rem; }
+  .pinky-settings-grid { grid-template-columns:1fr; }
   .pinky-secret-row { flex-direction:column; }
 }


### PR DESCRIPTION
### Motivation
- Provide a UI to configure Pinky connection details (base URL and endpoint paths) so the page can target different Pinky instances without editing source files.
- Persist those settings in the browser so preferences are remembered across visits and used to construct request URLs.
- Replace hard-coded endpoint construction with a normalized builder to avoid malformed URLs and to support custom confirmation token placement.

### Description
- Added a settings form to `static/pinky.html` exposing `baseUrl`, per-endpoint paths, the confirmation path template, and `expectedToolCount`, plus `Save` and `Reset` controls.
- Reworked `static/pinky.js` to introduce `DEFAULT_PINKY_SETTINGS`, `normalizePinkySettings`, `normalizePinkyBaseUrl`, `buildPinkyUrl`, and `getPinkyEndpoints`, and to persist/restore/reset settings in `localStorage` under `rci-pinky-settings`.
- Updated all Pinky requests to use the dynamic endpoints from `getPinkyEndpoints()` and adjusted API key storage to `rci-pinky-api-key` with corresponding UI handlers and visibility toggle.
- Added responsive form styling and input type support in `static/site.css` (URL/number inputs and a two-column settings grid) to match the existing layout.

### Testing
- Ran `node --check static/pinky.js` to validate the JavaScript syntax and it succeeded.
- Executed a Node VM smoke test that exercises `getPinkyEndpoints()` and expected-tool-count normalization and it passed.
- Ran `python -m pytest tests/core/test_imports.py` and the tests completed successfully (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fb76120083209ec8ed62a3a3506f)